### PR TITLE
Run all tests in same workspace (issue #43)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: julia
 sudo: required
-dist: precise
+dist: trusty
 os:
   - linux
 julia:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   # delete old test coverage results
   - find $HOME/.julia -name '*.jl.*cov' -delete
   # filter out "method definition overwritten" warnings
-  - julia --check-bounds=yes --color=yes -e 'Pkg.test(\"NonlinearEigenproblems\", coverage=true)'
+  - julia --check-bounds=yes --color=yes -e 'Pkg.test("NonlinearEigenproblems", coverage=true)'
 before_cache:
   # add Coverage package to cache, so that we don't have to install it on each run
   - julia -e 'Pkg.add("Coverage");'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: julia
+sudo: required
+dist: precise
 os:
   - linux
 julia:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   # delete old test coverage results
   - find $HOME/.julia -name '*.jl.*cov' -delete
   # filter out "method definition overwritten" warnings
-  - "julia --check-bounds=yes --color=yes -e 'Pkg.test(\"NonlinearEigenproblems\", coverage=true)' 2> >(grep -v \"WARNING: Method definition.\\+overwritten in module [Compat|SpecialFunctions|Polynomials|Missings|IterativeSolvers]\")"
+  - julia --check-bounds=yes --color=yes -e 'Pkg.test(\"NonlinearEigenproblems\", coverage=true)'
 before_cache:
   # add Coverage package to cache, so that we don't have to install it on each run
   - julia -e 'Pkg.add("Coverage");'

--- a/test/beyn.jl
+++ b/test/beyn.jl
@@ -1,19 +1,21 @@
 # Run tests on Beyns contour integral method
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+end
 
 @testset "Beyn contour" begin
     nep=nep_gallery("dep0")

--- a/test/beyn.jl
+++ b/test/beyn.jl
@@ -5,8 +5,6 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
     using NEPCore
     using NEPTypes

--- a/test/beyn.jl
+++ b/test/beyn.jl
@@ -1,7 +1,7 @@
 # Run tests on Beyns contour integral method
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/beyn_parallel.jl
+++ b/test/beyn_parallel.jl
@@ -6,6 +6,7 @@
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
 workspace()
+
 push!(LOAD_PATH, string(@__DIR__, "/../src"))
 push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
 push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
@@ -18,7 +19,6 @@ using Gallery
 using IterativeSolvers
 using Base.Test
 using BenchmarkTools
-
 
 nep=nep_gallery("dep0",500)
 

--- a/test/beyn_parallel.jl
+++ b/test/beyn_parallel.jl
@@ -5,20 +5,19 @@
 # julia -p 20
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
+if !isdefined(:global_modules_loaded)
+    workspace()
 
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
-using BenchmarkTools
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+end
 
 nep=nep_gallery("dep0",500)
 

--- a/test/bigfloats.jl
+++ b/test/bigfloats.jl
@@ -1,6 +1,6 @@
 # Unit  tests for bigfloats. Type stability of methods.
 
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/bigfloats.jl
+++ b/test/bigfloats.jl
@@ -1,18 +1,20 @@
 # Unit  tests for bigfloats. Type stability of methods.
 
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
 
-using Base.Test
+    using Base.Test
+end
 
 
 println("Test NEP-test with BigFloat")

--- a/test/bigfloats.jl
+++ b/test/bigfloats.jl
@@ -4,8 +4,6 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
     using NEPCore
     using NEPTypes

--- a/test/blocknewton.jl
+++ b/test/blocknewton.jl
@@ -1,7 +1,7 @@
 # Run tests on block Newton
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/blocknewton.jl
+++ b/test/blocknewton.jl
@@ -1,15 +1,19 @@
 # Run tests on block Newton
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
+
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+end
 
 @testset "blocknewton" begin
     nep=nep_gallery("dep0",4);

--- a/test/compan.jl
+++ b/test/compan.jl
@@ -1,14 +1,17 @@
 # Test of companion linearization
 
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using Base.Test
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using Base.Test
+end
 
 
 comaniontest = @testset "Companion Linearization" begin

--- a/test/compan.jl
+++ b/test/compan.jl
@@ -1,6 +1,6 @@
 # Test of companion linearization
 
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/compute_eigvec_from_eigval_lopcg.jl
+++ b/test/compute_eigvec_from_eigval_lopcg.jl
@@ -1,4 +1,4 @@
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/compute_eigvec_from_eigval_lopcg.jl
+++ b/test/compute_eigvec_from_eigval_lopcg.jl
@@ -1,16 +1,18 @@
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+end
 
 # explicit import needed for overloading functions from packages
 import NEPCore.compute_Mlincomb

--- a/test/compute_eigvec_from_eigval_lopcg.jl
+++ b/test/compute_eigvec_from_eigval_lopcg.jl
@@ -2,8 +2,6 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
     using NEPCore
     using NEPTypes

--- a/test/compute_eigvec_from_eigval_lu.jl
+++ b/test/compute_eigvec_from_eigval_lu.jl
@@ -1,4 +1,4 @@
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/compute_eigvec_from_eigval_lu.jl
+++ b/test/compute_eigvec_from_eigval_lu.jl
@@ -1,16 +1,18 @@
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+end
 
 # explicit import needed for overloading functions from packages
 import NEPCore.compute_Mlincomb

--- a/test/compute_eigvec_from_eigval_lu.jl
+++ b/test/compute_eigvec_from_eigval_lu.jl
@@ -2,8 +2,6 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
     using NEPCore
     using NEPTypes

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,18 +1,19 @@
 # Tests for core functionality
 
-
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+end
 
 
 struct TestNEP <: NEP

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,7 +1,7 @@
 # Tests for core functionality
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/deflation.jl
+++ b/test/deflation.jl
@@ -1,6 +1,6 @@
 # Run tests for the deflation
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/deflation.jl
+++ b/test/deflation.jl
@@ -1,17 +1,20 @@
 # Run tests for the deflation
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+end
 
 nep=nep_gallery("dep0");
 nep.tauv=[0,0.8];

--- a/test/deflation.jl
+++ b/test/deflation.jl
@@ -4,8 +4,6 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
     using NEPCore
     using NEPTypes

--- a/test/dep_distributed.jl
+++ b/test/dep_distributed.jl
@@ -1,7 +1,7 @@
 # Run tests for the dep_distributed example
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/dep_distributed.jl
+++ b/test/dep_distributed.jl
@@ -1,19 +1,21 @@
 # Run tests for the dep_distributed example
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+end
 
 
 dep=nep_gallery("dep_distributed");

--- a/test/dep_distributed.jl
+++ b/test/dep_distributed.jl
@@ -5,8 +5,6 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
     using NEPCore
     using NEPTypes

--- a/test/fiber.jl
+++ b/test/fiber.jl
@@ -1,20 +1,23 @@
 # Run tests on the fiber problem in NLEVP (bessel function nonlinearity)
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
+if !isdefined(:global_modules_loaded)
+    workspace()
 
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
-using GalleryNLEVP
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+    using GalleryNLEVP
+end
+
+# Always run this, since it's not loaded by load_modules_for_tests.jl
 using LinSolversMATLAB
 
 

--- a/test/fiber.jl
+++ b/test/fiber.jl
@@ -1,7 +1,10 @@
 # Run tests on the fiber problem in NLEVP (bessel function nonlinearity)
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
+end
+
 push!(LOAD_PATH, string(@__DIR__, "/../src"))
 push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
 push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))

--- a/test/fiber.jl
+++ b/test/fiber.jl
@@ -1,9 +1,7 @@
 # Run tests on the fiber problem in NLEVP (bessel function nonlinearity)
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
-    workspace()
-end
+workspace()
 
 push!(LOAD_PATH, string(@__DIR__, "/../src"))
 push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))

--- a/test/gun.jl
+++ b/test/gun.jl
@@ -1,20 +1,24 @@
 # Run tests on Beyns contour integral method
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
+if !isdefined(:global_modules_loaded)
+    workspace()
 
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
-using GalleryNLEVP
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+    using GalleryNLEVP
+    using LinSolversMATLAB
+end
+
+# Always run this, since it's not loaded by load_modules_for_tests.jl
 using LinSolversMATLAB
 
 

--- a/test/gun.jl
+++ b/test/gun.jl
@@ -1,9 +1,7 @@
 # Run tests on Beyns contour integral method
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
-    workspace()
-end
+workspace()
 
 push!(LOAD_PATH, string(@__DIR__, "/../src"))
 push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))

--- a/test/gun.jl
+++ b/test/gun.jl
@@ -1,7 +1,10 @@
 # Run tests on Beyns contour integral method
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
+end
+
 push!(LOAD_PATH, string(@__DIR__, "/../src"))
 push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
 push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
@@ -77,7 +80,7 @@ guntest=@testset "GUN (NLEVP interface)" begin
         z=ones(n); λ=150^2;
         @test norm(compute_Mlincomb(nep2,λ,z)-compute_Mlincomb(nep1,λ,z))
     end
-    
+
 end
 Base.Test.print_test_results(guntest)
 

--- a/test/gun_native.jl
+++ b/test/gun_native.jl
@@ -1,5 +1,5 @@
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/gun_native.jl
+++ b/test/gun_native.jl
@@ -1,13 +1,16 @@
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using Base.Test
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using Base.Test
+end
 
 @testset "GUN (native)" begin
     nep = nep_gallery("nlevp_native_gun")

--- a/test/iar.jl
+++ b/test/iar.jl
@@ -1,5 +1,5 @@
 #Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/iar.jl
+++ b/test/iar.jl
@@ -1,16 +1,19 @@
 #Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+end
 
 #import NEPSolver.iar;
 #include("../src/method_iar.jl");

--- a/test/iar.jl
+++ b/test/iar.jl
@@ -3,8 +3,6 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
     using NEPCore
     using NEPTypes

--- a/test/iar_chebyshev.jl
+++ b/test/iar_chebyshev.jl
@@ -1,16 +1,19 @@
 # #Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+end
 
 #import NEPSolver.iar_chebyshev;
 #include("../src/method_iar_chebyshev.jl");

--- a/test/iar_chebyshev.jl
+++ b/test/iar_chebyshev.jl
@@ -1,5 +1,5 @@
 # #Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/iar_chebyshev.jl
+++ b/test/iar_chebyshev.jl
@@ -3,8 +3,6 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
     using NEPCore
     using NEPTypes

--- a/test/infbilanczos.jl
+++ b/test/infbilanczos.jl
@@ -1,6 +1,6 @@
 # Test for infinite Bi-Lanczos
 
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/infbilanczos.jl
+++ b/test/infbilanczos.jl
@@ -1,14 +1,18 @@
 # Test for infinite Bi-Lanczos
 
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
+
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+end
 
 
 nep=nep_gallery("qdep0");

--- a/test/inner_solves.jl
+++ b/test/inner_solves.jl
@@ -1,6 +1,6 @@
 # Run tests for the inner solves
 
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     using NonlinearEigenproblems: NEPCore, NEPTypes, NEPSolver, Gallery

--- a/test/inner_solves.jl
+++ b/test/inner_solves.jl
@@ -1,8 +1,11 @@
 # Run tests for the inner solves
 
-workspace()
-using NonlinearEigenproblems: NEPCore, NEPTypes, NEPSolver, Gallery
-using Base.Test
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
+
+    using NonlinearEigenproblems: NEPCore, NEPTypes, NEPSolver, Gallery
+    using Base.Test
+end
 
 #import NEPSolver.inner_solve;
 #include("../src/inner_solver.jl");
@@ -33,5 +36,5 @@ n=size(dep,1);
     λv,V=inner_solve(NEPSolver.ContourBeynInnerSolver,pnep,λv=[0,1]+0.0im,Neig=3);
     nn=minimum(svdvals(compute_Mder(pnep,λv[1])))
     @test nn < eps()*100
-    
+
 end

--- a/test/jd.jl
+++ b/test/jd.jl
@@ -1,4 +1,4 @@
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/jd.jl
+++ b/test/jd.jl
@@ -62,6 +62,7 @@ nep = SPMF_NEP(get_Av(nep), get_fv(nep))
 TOL = 1e-10;
 # Also test that a warning is issued
 @test_warn "maxit = 60 is larger than size of NEP = 4. Setting maxit = size(nep,1)" λ,u=jd(Float64, nep, tol=TOL, maxit=60, displaylevel = 1, projtype = :Galerkin, inner_solver_method = NEPSolver.SGIterInnerSolver, v0=ones(size(nep,1)))
+λ,u=jd(Float64, nep, tol=TOL, maxit=4, displaylevel = 1, projtype = :Galerkin, inner_solver_method = NEPSolver.SGIterInnerSolver, v0=ones(size(nep,1)))
 λ = λ[1]
 u = vec(u)
 println(" Resnorm of computed solution: ",compute_resnorm(nep,λ,u))

--- a/test/jd.jl
+++ b/test/jd.jl
@@ -39,23 +39,6 @@ println(" 6 smallest eigenvalues according to the absolute values: \n ", Dc[c[1:
 
 
 
-println("\nTesting in only Complex64 precision (32 bit in real and 32 bit in imaginary)")
-nep = nep_gallery("pep0",30)
-TOL = 1e-4;
-λ,u = jd(Complex64, nep, tol=TOL, maxit=25, Neig = 2, displaylevel = 1, v0=ones(size(nep,1)))
-println(" Resnorm of computed solution: ",compute_resnorm(nep,λ[1],u[:,1]))
-println(" Smallest eigevalue found: \n λ: ",λ)
-Dc,Vc = polyeig(Complex64,nep,DefaultEigSolver)
-c = sortperm(abs.(Dc))
-println(" 4 smallest eigenvalues according to the absolute values: \n ", Dc[c[1:4]])
-
-@test norm(compute_Mlincomb(nep,λ[1],u[:,1])) < TOL
-@test norm(compute_Mlincomb(nep,λ[2],u[:,2])) < TOL
-@test  abs(Dc[c[1]]-λ[1])/abs(Dc[c[1]]) < TOL*50
-@test (abs(Dc[c[2]]-λ[2])/abs(Dc[c[2]]) < TOL*50) || (abs(Dc[c[3]]-λ[2])/abs(Dc[c[3]]) < TOL*50) #Complex conjugate eigenvalues
-
-
-
 println("\nTesting SG as inner solver")
 nep = nep_gallery("real_quadratic")
 nep = SPMF_NEP(get_Av(nep), get_fv(nep))

--- a/test/jd.jl
+++ b/test/jd.jl
@@ -1,13 +1,16 @@
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+end
 
 
 @testset "Jacobi–Davidson" begin

--- a/test/load_modules_for_tests.jl
+++ b/test/load_modules_for_tests.jl
@@ -1,6 +1,6 @@
 push!(LOAD_PATH, string(@__DIR__, "/../src"))
+push!(LOAD_PATH, string(@__DIR__, "/../src/utils"))
 push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
 using NEPCore
 using NEPTypes

--- a/test/load_modules_for_tests.jl
+++ b/test/load_modules_for_tests.jl
@@ -1,0 +1,16 @@
+push!(LOAD_PATH, string(@__DIR__, "/../src"))
+push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+
+using NEPCore
+using NEPTypes
+using LinSolvers
+using NEPSolver
+using Gallery
+using IterativeSolvers
+using LinearMaps
+using GalleryPeriodicDDE
+using GalleryWaveguide
+using Serialization
+
+global global_modules_loaded = true

--- a/test/matlablinsolvers.jl
+++ b/test/matlablinsolvers.jl
@@ -1,12 +1,16 @@
 #  Tests for the Linear solvers
-workspace()
+if !isdefined(:global_modules_loaded)
+    workspace()
 
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
 
-using NEPCore
-using LinSolvers
+    using NEPCore
+    using LinSolvers
+    using Base.Test
+end
+
+# Always run this, since it's not loaded by load_modules_for_tests.jl
 using LinSolversMATLAB
-using Base.Test
 
 @testset "LinSolvers" begin
     A=sparse(randn(5,5));

--- a/test/matlablinsolvers.jl
+++ b/test/matlablinsolvers.jl
@@ -1,5 +1,8 @@
 #  Tests for the Linear solvers
-workspace()
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
+end
+
 push!(LOAD_PATH, string(@__DIR__, "/../src"))
 
 using NEPCore

--- a/test/matlablinsolvers.jl
+++ b/test/matlablinsolvers.jl
@@ -1,7 +1,5 @@
 #  Tests for the Linear solvers
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
-    workspace()
-end
+workspace()
 
 push!(LOAD_PATH, string(@__DIR__, "/../src"))
 

--- a/test/mslp.jl
+++ b/test/mslp.jl
@@ -1,5 +1,5 @@
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/mslp.jl
+++ b/test/mslp.jl
@@ -3,18 +3,16 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
     using NEPCore
     using LinSolvers
     using IterativeSolvers
     using Base.Test
-    using LinearMaps;
+    using LinearMaps
     using NEPTypes
-    using Gallery;
-    using NEPSolver;
-    using NEPCore;
+    using Gallery
+    using NEPSolver
+    using NEPCore
 end
 
 

--- a/test/mslp.jl
+++ b/test/mslp.jl
@@ -1,18 +1,21 @@
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using NEPCore
-using LinSolvers
-using IterativeSolvers
-using Base.Test
-using LinearMaps;
-using NEPTypes
-using Gallery;
-using NEPSolver;
-using NEPCore;
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+
+    using NEPCore
+    using LinSolvers
+    using IterativeSolvers
+    using Base.Test
+    using LinearMaps;
+    using NEPTypes
+    using Gallery;
+    using NEPSolver;
+    using NEPCore;
+end
 
 
 A=sprandn(100,100,0.1);

--- a/test/newton_test.jl
+++ b/test/newton_test.jl
@@ -1,16 +1,18 @@
 # Run tests on Newton methods & rfi methods
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using Base.Test
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
 
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using Base.Test
+end
 
 
 nep=nep_gallery("dep0")

--- a/test/newton_test.jl
+++ b/test/newton_test.jl
@@ -1,7 +1,7 @@
 # Run tests on Newton methods & rfi methods
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/periodicdde.jl
+++ b/test/periodicdde.jl
@@ -1,17 +1,21 @@
 # Run tests on Periodic DDE
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using GalleryPeriodicDDE
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
 
-using Base.Test
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using GalleryPeriodicDDE
+
+    using Base.Test
+end
+
 @testset "PeriodicDDE" begin
     nep=nep_gallery(PeriodicDDE_NEP,name="mathieu")
     (λ,v)=quasinewton(Complex128,nep,λ=-0.2,v=[1;1])

--- a/test/periodicdde.jl
+++ b/test/periodicdde.jl
@@ -1,7 +1,7 @@
 # Run tests on Periodic DDE
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/proj.jl
+++ b/test/proj.jl
@@ -1,15 +1,18 @@
 #  Tests for the projected NEPs
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
 #using Winston # For plotting
 
-using Base.Test
+    using Base.Test
+end
 
 projtest=@testset "Projected problems" begin
 

--- a/test/proj.jl
+++ b/test/proj.jl
@@ -1,5 +1,5 @@
 #  Tests for the projected NEPs
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ include("load_modules_for_tests.jl")
 @testset "All tests" begin
     base_path = string(@__DIR__)
     file_list = readdir(base_path)
-    tests_to_run = filter(f -> is_test_script(f) && !in(uppercase(f), tests_not_to_run), file_list)
+    tests_to_run = filter(f -> is_test_script(joinpath(base_path, f)) && !in(uppercase(f), tests_not_to_run), file_list)
 
     to = TimerOutput()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,22 +19,7 @@ tests_not_to_run = to_uppercase_set([
     "matlablinsolvers.jl", # needs MATLAB
     ])
 
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
-
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using LinearMaps
-using GalleryPeriodicDDE
-using GalleryWaveguide
-using Serialization
-
-global global_modules_loaded = true
+include("load_modules_for_tests.jl")
 
 @testset "All tests" begin
     base_path = string(@__DIR__)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,11 +8,14 @@ function to_uppercase_set(array)
     return Set{String}(map(uppercase, array))
 end
 
+function is_test_script(file)
+    # only include .jl files containing the string '@test'
+    ismatch(r"(?i)\.jl$", file) && contains(open(readstring, file), "@test")
+end
+
 # Add tests below if you wish that they are not run together with all tests
 tests_not_to_run = to_uppercase_set([
     "runtests.jl", # this file
-    "submit_test_coverage.jl", # run by CI tool
-    "utils.jl", # test utilities
     "Beyn_parallel.jl", # currently disabled
     "fiber.jl", # needs MATLAB
     "gun.jl", # needs MATLAB
@@ -24,17 +27,15 @@ include("load_modules_for_tests.jl")
 @testset "All tests" begin
     base_path = string(@__DIR__)
     file_list = readdir(base_path)
-    tests_to_run = filter(f -> ismatch(r"(?i)\.jl$", f) && !in(uppercase(f), tests_not_to_run), file_list)
+    tests_to_run = filter(f -> is_test_script(f) && !in(uppercase(f), tests_not_to_run), file_list)
 
     to = TimerOutput()
 
     for i = 1:length(tests_to_run)
         file = tests_to_run[i]
         test_name = replace(file, r"(?i)\.jl$", "")
-        #if test_name == "tiar" || test_name == "spmf" || test_name == "transf"
-            @printf("Running test %s (%d / %d)\n", test_name, i, length(tests_to_run))
-            @timeit to test_name include(base_path * "/" * file)
-        #end
+        @printf("Running test %s (%d / %d)\n", test_name, i, length(tests_to_run))
+        @timeit to test_name include(base_path * "/" * file)
     end
 
     show(to; title = "Test Performance", compact = true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,8 +19,6 @@ tests_not_to_run = to_uppercase_set([
     "matlablinsolvers.jl", # needs MATLAB
     ])
 
-global global_running_all_tests = true
-
 push!(LOAD_PATH, string(@__DIR__, "/../src"))
 push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
 push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
@@ -36,26 +34,24 @@ using GalleryPeriodicDDE
 using GalleryWaveguide
 using Serialization
 
-try
-    @testset "All tests" begin
-        base_path = string(@__DIR__)
-        file_list = readdir(base_path)
-        tests_to_run = filter(f -> ismatch(r"(?i)\.jl$", f) && !in(uppercase(f), tests_not_to_run), file_list)
+global global_modules_loaded = true
 
-        to = TimerOutput()
+@testset "All tests" begin
+    base_path = string(@__DIR__)
+    file_list = readdir(base_path)
+    tests_to_run = filter(f -> ismatch(r"(?i)\.jl$", f) && !in(uppercase(f), tests_not_to_run), file_list)
 
-        for i = 1:length(tests_to_run)
-            file = tests_to_run[i]
-            test_name = replace(file, r"(?i)\.jl$", "")
-            #if test_name == "tiar" || test_name == "spmf" || test_name == "transf"
-                @printf("Running test %s (%d / %d)\n", test_name, i, length(tests_to_run))
-                @timeit to test_name include(base_path * "/" * file)
-            #end
-        end
+    to = TimerOutput()
 
-        show(to; title = "Test Performance", compact = true)
-        println()
+    for i = 1:length(tests_to_run)
+        file = tests_to_run[i]
+        test_name = replace(file, r"(?i)\.jl$", "")
+        #if test_name == "tiar" || test_name == "spmf" || test_name == "transf"
+            @printf("Running test %s (%d / %d)\n", test_name, i, length(tests_to_run))
+            @timeit to test_name include(base_path * "/" * file)
+        #end
     end
-finally
-    global_running_all_tests = false
+
+    show(to; title = "Test Performance", compact = true)
+    println()
 end

--- a/test/serialization.jl
+++ b/test/serialization.jl
@@ -1,8 +1,11 @@
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src/utils"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using Base.Test
-using Serialization
+    push!(LOAD_PATH, string(@__DIR__, "/../src/utils"))
+
+    using Base.Test
+    using Serialization
+end
 
 @testset "Serialization" begin
     file = "sparse_matrix.txt"

--- a/test/serialization.jl
+++ b/test/serialization.jl
@@ -1,4 +1,4 @@
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src/utils"))

--- a/test/sgiter.jl
+++ b/test/sgiter.jl
@@ -1,7 +1,7 @@
 # Run tests on block Newton
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/sgiter.jl
+++ b/test/sgiter.jl
@@ -1,14 +1,18 @@
 # Run tests on block Newton
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using Base.Test
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
+
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using Base.Test
+end
 
 @testset "sgiter" begin
 

--- a/test/spmf.jl
+++ b/test/spmf.jl
@@ -3,7 +3,7 @@
 
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/spmf.jl
+++ b/test/spmf.jl
@@ -3,15 +3,19 @@
 
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-#push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
 
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
 
-using NonlinearEigenproblems: NEPCore, NEPTypes, LinSolvers,NEPSolver,Gallery
-
-using Base.Test
-
+    using Base.Test
+end
 
 @testset "SPMF" begin
     # Create an SPMF

--- a/test/tiar.jl
+++ b/test/tiar.jl
@@ -1,7 +1,7 @@
 # Run tests for the dep_distributed example
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/tiar.jl
+++ b/test/tiar.jl
@@ -1,19 +1,21 @@
 # Run tests for the dep_distributed example
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using IterativeSolvers
-using Base.Test
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using IterativeSolvers
+    using Base.Test
+end
 
 
 # The user can create his own orthogonalization function to use in IAR
@@ -74,7 +76,7 @@ TIAR=@testset "TIAR" begin
     end
     @testset "Solve by projection" begin
         n=1000;
-        
+
         dep=nep_gallery("dep0",n);
         nn=norm(compute_Mder(dep,0));
         errmeasure= (λ,v) -> norm(compute_Mlincomb(dep,λ,v))/nn;

--- a/test/tiar.jl
+++ b/test/tiar.jl
@@ -5,8 +5,6 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
     using NEPCore
     using NEPTypes

--- a/test/transf.jl
+++ b/test/transf.jl
@@ -1,18 +1,20 @@
 # Run tests for the NEP transformations
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using Base.Test
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using Base.Test
+end
 
 @testset "transformations" begin
 

--- a/test/transf.jl
+++ b/test/transf.jl
@@ -1,7 +1,7 @@
 # Run tests for the NEP transformations
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))

--- a/test/transf.jl
+++ b/test/transf.jl
@@ -5,8 +5,6 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
-    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra/waveguide"))
 
     using NEPCore
     using NEPTypes

--- a/test/wep_small.jl
+++ b/test/wep_small.jl
@@ -1,18 +1,22 @@
 # Run tests for the waveguide eigenvalue problem
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-workspace()
-push!(LOAD_PATH, string(@__DIR__, "/../src"))
-#push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+    workspace()
 
-using NEPCore
-using NEPTypes
-using LinSolvers
-using NEPSolver
-using Gallery
-using GalleryWaveguide
+    push!(LOAD_PATH, string(@__DIR__, "/../src"))
+    #push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
 
-using Base.Test
+    using NEPCore
+    using NEPTypes
+    using LinSolvers
+    using NEPSolver
+    using Gallery
+    using GalleryWaveguide
+
+    using Base.Test
+end
+
 import NEPCore.compute_Mder;
 
 

--- a/test/wep_small.jl
+++ b/test/wep_small.jl
@@ -5,7 +5,7 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))
-    #push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+    push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
 
     using NEPCore
     using NEPTypes

--- a/test/wep_small.jl
+++ b/test/wep_small.jl
@@ -1,7 +1,7 @@
 # Run tests for the waveguide eigenvalue problem
 
 # Intended to be run from nep-pack/ directory or nep-pack/test directory
-if !isdefined(:global_running_all_tests) || global_running_all_tests != true
+if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../src"))


### PR DESCRIPTION
A script called [load_modules_for_tests.jl](https://github.com/nep-pack/NonlinearEigenproblems.jl/blob/issue-43-run-tests-in-same-workspace/test/load_modules_for_tests.jl) has been added, which loads all the modules needed for the tests, and sets a global flag `global_modules_loaded`. All tests check whether this flag exists, and if so, do not create a new workspace or load modules. This script is used by the runtests script, but can also be run manually in the REPL to speed up running tests and avoid the "Method definition overwritten" warnings (it only has to be run once per session).

It's quite hacky, but I fear that a cleaner fix would require a lot more work, which will have to be rethought anyway as we migrate to Julia 0.7 (for example, `workspace()` has been removed in 0.7).

With this change, plus changing the Travis build environment to one with more memory, the full build [takes ~7 minutes](https://travis-ci.org/nep-pack/NonlinearEigenproblems.jl/builds/408020028) (of which 4.5 minutes are spent on actual unit tests), compared to [~40 minutes in master](https://travis-ci.org/nep-pack/NonlinearEigenproblems.jl/builds/407945663) (of which 36 minutes are spent on unit tests).