### PR TITLE
DEP parametric type

### DIFF
--- a/src/NEPCore.jl
+++ b/src/NEPCore.jl
@@ -118,7 +118,7 @@ julia> norm(compute_Mder(nep,λ,1)*v-compute_Mlincomb(nep,λ,hcat(v,v),a=[0,1]))
         elseif (@method_concretely_defined(compute_Mder,nep))
             return compute_Mlincomb_from_Mder(nep,λ,V,a)
         else
-            error("No procedure to compute Mlincomb")
+            error("No procedure to compute Mlincomb λ::",typeof(λ), " V::",typeof(V))
         end
     end
 

--- a/src/NEPCore.jl
+++ b/src/NEPCore.jl
@@ -260,7 +260,7 @@ julia> x'*compute_Mlincomb(nep,s,x)
         while (abs(Δλ)>TOL) & (count<max_iter)
             count = count+1
             z1 = compute_Mlincomb(nep, λ_iter, reshape(x,size(nep,1),1))
-            z2 = compute_Mlincomb(nep, λ_iter, reshape(x,size(nep,1),1),[1],1)
+            z2 = compute_Mlincomb(nep, λ_iter, reshape(x,size(nep,1),1),[T(1)],1)
 
             Δλ =- dot(y,z1)/dot(y,z2);
             λ_iter += Δλ

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -254,12 +254,12 @@ matrices A_i, and tauv is a vector of the values tau_i
 """
     type DEP{T<:AbstractMatrix} <: AbstractSPMF
         n::Int
-        A::Array{T}     # An array of matrices (full or sparse matrices)
+        A::Array{T,1}     # An array of matrices (full or sparse matrices)
         tauv::Array{Float64,1} # the delays
     end
     function DEP(AA::Array{T,1},tauv=[0,1.0]) where {T<:AbstractMatrix}
         n=size(AA[1],1)
-        this=DEP{T}(n,AA,tauv);   # allow for 1xn matrices
+        this=DEP{T}(n,AA,tauv);  
         return this;
     end
 

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -835,4 +835,8 @@ Returns true/false if the NEP is sparse (if compute_Mder() returns sparse)
         return compute_Mlincomb(nep,complex(λ),V;a=a)
     end
 
+    function compute_Mlincomb(nep::DEP,λ::Number,V::Array{T,1};a=ones(T,size(V,2))) where T<:Number
+        return compute_Mlincomb(nep,complex(λ),reshape(V,size(V,1),1);a=a)
+    end
+
 end

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -822,11 +822,13 @@ Returns true/false if the NEP is sparse (if compute_Mder() returns sparse)
     include("nep_transformations.jl")
 
     # structure exploitation for DEP (TODO: document this)
-    function compute_Mlincomb(nep::DEP,λ::T,V::Array{T,2};a=ones(T,size(V,2))) where {T<:Number}
+    function compute_Mlincomb(nep::DEP,λ::T,V::Matrix{T};
+                              a::Vector{T}=ones(T,size(V,2))) where {T<:Number}
         n=size(V,1); k=1
         try k=size(V,2) end
         Av=get_Av(nep)
-        V=broadcast(*,V,a.');
+        D=Diagonal(a);
+        V=V*D;
         z=zeros(T,n)
         for j=1:length(nep.tauv)
             w=Array{T,1}(exp(-λ*nep.tauv[j])*(-nep.tauv[j]).^(0:k-1))
@@ -837,11 +839,11 @@ Returns true/false if the NEP is sparse (if compute_Mder() returns sparse)
         return z
     end
     # Automatically promote to complex if λ is real 
-    function compute_Mlincomb(nep::DEP,λ::T,V::Array{Complex{T},2};a=ones(Complex{T},size(V,2))) where T<:Real
+    function compute_Mlincomb(nep::DEP,λ::T,V::Array{Complex{T},2};a::Vector{Complex{T}}=ones(Complex{T},size(V,2))) where T<:Real
         return compute_Mlincomb(nep,complex(λ),V;a=a)
     end
-
-    function compute_Mlincomb(nep::DEP,λ::Number,V::Array{T,1};a=ones(T,size(V,2))) where T<:Number
+    # Allow vector-valued V
+    function compute_Mlincomb(nep::DEP,λ::Number,V::Vector{T};a::Vector{T}=ones(T,1)) where T<:Number
         return compute_Mlincomb(nep,complex(λ),reshape(V,size(V,1),1);a=a)
     end
 

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -252,15 +252,15 @@ Constructor: DEP(AA,tauv) where AA is an array of the
 ```
 matrices A_i, and tauv is a vector of the values tau_i
 """
-    type DEP <: AbstractSPMF
+    type DEP{T<:AbstractMatrix} <: AbstractSPMF
         n::Int
-        A::Array{<:AbstractMatrix}     # An array of matrices (full or sparse matrices)
+        A::Array{T}     # An array of matrices (full or sparse matrices)
         tauv::Array{Float64,1} # the delays
-        function DEP(AA,tauv=[0,1.0])
-            n=size(AA[1],1)
-            this=new(n,reshape(AA,size(AA,1)),tauv);   # allow for 1xn matrices
-            return this;
-        end
+    end
+    function DEP(AA::Array{T,1},tauv=[0,1.0]) where {T<:AbstractMatrix}
+        n=size(AA[1],1)
+        this=DEP{T}(n,AA,tauv);   # allow for 1xn matrices
+        return this;
     end
 
 # Compute the ith derivative of a DEP
@@ -829,6 +829,10 @@ Returns true/false if the NEP is sparse (if compute_Mder() returns sparse)
         if k>1 z[:]-=view(V,:,2:2) end
         z[:]-=λ*view(V,:,1:1);
         return z
+    end
+    # Automatically promote to complex if λ is real 
+    function compute_Mlincomb(nep::DEP,λ::T,V::Array{Complex{T},2};a=ones(Complex{T},size(V,2))) where T<:Real
+        return compute_Mlincomb(nep,complex(λ),V;a=a)
     end
 
 end

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -266,12 +266,18 @@ matrices A_i, and tauv is a vector of the values tau_i
 # Compute the ith derivative of a DEP
     function compute_Mder(nep::DEP,λ::Number,i::Integer=0)
         local M,I;
-        if issparse(nep)
-            M=spzeros(nep.n,nep.n)
-            I=speye(nep.n,nep.n)
+        # T can be determined compile time, since DEP parametric type
+        T=eltype(nep.A[1]); 
+        if (isa(λ,Complex)) 
+            T=complex(T)
+        end
+        
+        if (issparse(nep.A[1])) # Can be determined compiled time since DEP parametric type
+            M=spzeros(T,nep.n,nep.n)
+            I=speye(T,nep.n,nep.n)
         else
-            M=zeros(nep.n,nep.n)
-            I=eye(nep.n,nep.n)
+            M=zeros(T,nep.n,nep.n)
+            I=eye(T,nep.n,nep.n)
         end
         if i==0; M=-λ*I;  end
         if i==1; M=-I; end
@@ -280,6 +286,7 @@ matrices A_i, and tauv is a vector of the values tau_i
         end
         return M
     end
+
 
 
 

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -266,11 +266,9 @@ matrices A_i, and tauv is a vector of the values tau_i
 # Compute the ith derivative of a DEP
     function compute_Mder(nep::DEP,λ::Number,i::Integer=0)
         local M,I;
+        # T is eltype(nep.A[1]) unless λ complex, then T is complex(eltype(nep.A[1]))
         # T can be determined compile time, since DEP parametric type
-        T=eltype(nep.A[1]); 
-        if (isa(λ,Complex)) 
-            T=complex(T)
-        end
+        T=isa(λ,Complex)?complex(eltype(nep.A[1])) : eltype(nep.A[1]);
         
         if (issparse(nep.A[1])) # Can be determined compiled time since DEP parametric type
             M=spzeros(T,nep.n,nep.n)
@@ -282,7 +280,8 @@ matrices A_i, and tauv is a vector of the values tau_i
         if i==0; M=-λ*I;  end
         if i==1; M=-I; end
         for j=1:size(nep.A,1)
-            M+=nep.A[j]*(exp(-nep.tauv[j]*λ)*(-nep.tauv[j])^i)
+            a=exp(-nep.tauv[j]*λ)*(-nep.tauv[j])^i;
+            M += nep.A[j]*a
         end
         return M
     end

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -816,12 +816,11 @@ Returns true/false if the NEP is sparse (if compute_Mder() returns sparse)
     include("nep_transformations.jl")
 
     # structure exploitation for DEP (TODO: document this)
-    function compute_Mlincomb(nep::DEP,λ::Number,V;a=ones(size(V,2)))
+    function compute_Mlincomb(nep::DEP,λ::T,V::Array{T,2};a=ones(T,size(V,2))) where {T<:Number}
         n=size(V,1); k=1
         try k=size(V,2) end
         Av=get_Av(nep)
         V=broadcast(*,V,a.');
-        T=eltype(V)
         z=zeros(T,n)
         for j=1:length(nep.tauv)
             w=Array{T,1}(exp(-λ*nep.tauv[j])*(-nep.tauv[j]).^(0:k-1))

--- a/src/inner_solver.jl
+++ b/src/inner_solver.jl
@@ -48,12 +48,9 @@ function inner_solve(TT::Type{DefaultInnerSolver},T_arit::DataType,nep::NEPTypes
 end
 
 
-function inner_solve(TT::Type{NewtonInnerSolver},T_arit::DataType,nep::NEPTypes.Proj_NEP;kwargs...)
+function inner_solve(TT::Type{NewtonInnerSolver},T_arit::DataType,nep::NEPTypes.Proj_NEP;
+                     V=eye(T_arit,size(nep,1),size(λv,1)),λv=zeros(T_arit,1),tol=sqrt(eps()),kwargs...)
 
-    kvargsdict = Dict(kwargs);
-    λv = kvargsdict[:λv];
-    V = kvargsdict[:V];
-    tol = kvargsdict[:tol];
     for k=1:size(λv,1)
         try
             v0=V[:,k]; # Starting vector for projected problem

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -39,6 +39,10 @@ function iar(
     proj_solve=false,
     inner_solver_method=DefaultInnerSolver)where{T<:Number,T_orth<:IterativeSolvers.OrthogonalizationMethod}
 
+    # Ensure types σ and v are of type T
+    σ=T(σ)
+    v=Array{T,1}(v)
+    
     n = size(nep,1);
     m = maxit;
 

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -50,7 +50,7 @@ function iar(
     V = zeros(T,n*(m+1),m+1);
     H = zeros(T,m+1,m);
     y = zeros(T,n,m+1);
-    α=γ.^(0:m); α[1]=zero(T);
+    α=Vector{T}(γ.^(0:m)); α[1]=zero(T);
     local M0inv::LinSolver = linsolvercreator(nep,σ);
     err = ones(m,m);
     λ=zeros(T,m+1); Q=zeros(T,n,m+1);

--- a/src/method_iar_chebyshev.jl
+++ b/src/method_iar_chebyshev.jl
@@ -99,7 +99,7 @@ function iar_chebyshev(
     V = zeros(T,n*(m+1),m+1);
     H = zeros(T,m+1,m);
     y = zeros(T,n,m+1);
-    α=γ.^(0:m); α[1]=zero(T);
+    α=Vector{T}(γ.^(0:m)); α[1]=zero(T);
     local M0inv::LinSolver = linsolvercreator(nep,σ);
     err = ones(m,m);
     λ=zeros(T,m+1); Q=zeros(T,n,m+1);

--- a/src/method_jd.jl
+++ b/src/method_jd.jl
@@ -120,7 +120,7 @@ function jd(::Type{T},
 
         # solve for basis extension using comment on top of page 367 to avoid
         # matrix access. The orthogonalization to u comes anyway since u in V
-        pk[:] = compute_Mlincomb(nep,λ,u,[1],1)
+        pk[:] = compute_Mlincomb(nep,λ,u,[T(1)],1)
         linsolver = linsolvercreator(nep,λ)
         v[:] = lin_solve(linsolver, pk, tol=tol) # M(λ)\pk
         orthogonalize_and_normalize!(V, v, view(dummy_vector, 1:k), orthmethod)

--- a/src/method_newton.jl
+++ b/src/method_newton.jl
@@ -168,6 +168,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))
         λ::T=T(λ)
         v=Array{T,1}(v)
         c=Array{T,1}(c)
+        n=size(v,1);
 
         local linsolver::LinSolver=linsolvercreator(nep,λ)
 
@@ -209,7 +210,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))
 
 
                 # Compute eigenvector update
-                Δv = -lin_solve(linsolver,compute_Mlincomb(nep,λ1,v)) #M*v);
+                Δv = -lin_solve(linsolver,compute_Mlincomb(nep,λ1,reshape(v,n,1))) #M*v);
 
                 (Δλ,Δv,j,scaling)=armijo_rule(nep,errmeasure,err,
                                               λ,v,Δλ,Δv,real(T(armijo_factor)),armijo_max)
@@ -478,8 +479,12 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
                        linsolvercreator::Function=default_linsolvercreator)
 
 
+        # Ensure types λ and v are of type T
+        λ=T(λ)
+        v=Array{T,1}(v)
+        c=Array{T,1}(c)
+
         n = size(nep,1);
-        v = Array{T,1}(v);
         local err;
 
         en = zeros(n);
@@ -504,7 +509,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
                 end
 
 
-                d = dot(Q[:,n],compute_Mlincomb(nep,λ,v,[T(1)],1));
+                d = dot(Q[:,n],compute_Mlincomb(nep,λ,reshape(v,n,1),[T(1)],1));
                 #d = dot(Q[:,n],compute_Mder(nep,λ,1)*P*[-p;T(1.0)]);
                 λ = λ - R[n,n]/d;
             end

--- a/src/method_rfi.jl
+++ b/src/method_rfi.jl
@@ -56,11 +56,11 @@ function rfi(nep::NEP,
                 local linsolver_t::LinSolver = linsolvercreator(nept,λ)
 
                 #S1: T(λ_k)x_(k+1) = T'(λ_k)u_(k)
-                x = lin_solve(linsolver,compute_Mlincomb(nep,λ,u,[1],1),tol = tol)
+                x = lin_solve(linsolver,compute_Mlincomb(nep,λ,u,[T(1)],1),tol = tol)
                 u = x/norm(x);
 
                 #S2: (T(λ_k)^H)y_(k+1) = (T'(λ_k)^H)v_(k)
-                y = lin_solve(linsolver_t,compute_Mlincomb(nept,λ,v,[1],1),tol = tol)
+                y = lin_solve(linsolver_t,compute_Mlincomb(nept,λ,v,[T(1)],1),tol = tol)
                 v = y/norm(y)
 
                 λ_vec = compute_rf(nep, u, y=v)
@@ -123,18 +123,18 @@ function rfi_b(nep::NEP,
                 end
 
                 #Construct C_k
-                C = [compute_Mder(nep,λ,0) compute_Mlincomb(nep,λ,u,[1],1);v'*compute_Mder(nep,λ,1) T(0.0)]
+                C = [compute_Mder(nep,λ,0) compute_Mlincomb(nep,λ,u,[T(1)],1);v'*compute_Mder(nep,λ,1) T(0.0)]
                 #local linsolver::LinSolver = BackslashLinSolver(C);
 
                 #C[s;μ] = -[T(λ)u;0]
                 #l1 = lin_solve(linsolver,-[compute_Mlincomb(nep,λ,u,[1],0);0],tol = tol);
-                l1 = C\-[compute_Mlincomb(nep,λ,u,[1],0);0]
+                l1 = C\-[compute_Mlincomb(nep,λ,u,[T(1)],0);0]
                 s = l1[1:end-1]
                 u = (u+s)/norm(u+s)
 
                 #C[t;ν] = -[T(λ)'v;0]
                 #l2 = lin_solve(linsolver,-[compute_Mlincomb(nept,λ,v,[1],0);0],tol = tol);
-                l2 = C\-[compute_Mlincomb(nept,λ,v,[1],0);0]
+                l2 = C\-[compute_Mlincomb(nept,λ,v,[T(1)],0);0]
                 t = l2[1:end-1]
                 v = (v+t)/norm(v+t)
 

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -49,6 +49,10 @@ function tiar(
     inner_solver_method=DefaultInnerSolver
     )where{T,T_orth<:IterativeSolvers.OrthogonalizationMethod}
 
+    # Ensure types σ and v are of type T
+    σ=T(σ)
+    v=Array{T,1}(v)
+
     # initialization
     n = size(nep,1); m = maxit;
 

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -72,7 +72,7 @@ function tiar(
     h  = zeros(T,m+1);
     hh = zeros(T,m+1);
     y  = zeros(T,n,m+1);
-    α=γ.^(0:m); α[1]=zero(T);
+    α=Array{T,1}(γ.^(0:m)); α[1]=zero(T);
     local M0inv::LinSolver = linsolvercreator(nep,σ);
     err = ones(m+1,m+1);
     λ=zeros(T,m+1); Q=zeros(T,n,m+1);

--- a/test/core.jl
+++ b/test/core.jl
@@ -28,17 +28,18 @@ n=size(nep,1);
 ## Mlincomb_tests
 V=complex(randn(n,3));
 λ=0.3+1im;
+T=typeof(λ);
 z1=compute_Mlincomb(nep,λ,V)
-z2=compute_Mlincomb(nep,λ,V,a=[1,1,1])
+z2=compute_Mlincomb(nep,λ,V,a=[T(1),T(1),T(1)])
 @test z1==z2
 z3=compute_Mder(nep,λ,0)*V[:,1]+ compute_Mder(nep,λ,1)*V[:,2]+ compute_Mder(nep,λ,2)*V[:,3]
 @test z1 ≈ z3
 
 ## Test Mlincomb starting counting with kth derivative
-z2=compute_Mlincomb(nep,λ,V,a=[0,0,1])
+z2=compute_Mlincomb(nep,λ,V,a=[T(0),T(0),T(1)])
 z3=compute_Mder(nep,λ,2)*V[:,3]
 @test z2≈z3
-z4=compute_Mlincomb(nep,λ,V[:,3],[1], 2);
+z4=compute_Mlincomb(nep,λ,V[:,3],[T(1)], 2);
 @test z3≈z4
 #
 


### PR DESCRIPTION
Here is an attempt to make DEP parametric. By doing this I was able to make `compute_Mder` and `issparse` type stable #44. The DEP is now parametric with respect to the underlying matrices (not with respect to the elements of the matrices). This approach is sufficient since now the type of the matrix gives information about if the problem is sparse (which was needed in `compute_Mder`). 

Good news: There was very little need for code modification and code repetition, e.g., still only one `compute_Mder` necessary. The fact that the type is parametric matters mostly for the type definition.

One downside: I hardcoded the type of the delays to `Float64`. This means, e.g. for `BigFloat` there will be more round-off errors than expected. I could make the DEP also parametric wrt the type of the delay. The rule of thumb for julia is to only make things parametric if needed, and I'm not convinced it is strictly necessary. 


```
julia> using NonlinearEigenproblems: NEPTypes, NEPSolver, NEPCore, Gallery
julia> nep=nep_gallery("dep0")
julia> @code_warntype(issparse(nep))
Variables:
  #self# <optimized out>
  nep::NonlinearEigenproblems.NEPTypes.DEP{Array{Float64,2}}

Body:
  begin 
      (Base.arrayref)((Core.getfield)(nep::NonlinearEigenproblems.NEPTypes.DEP{Array{Float64,2}}, :A)::Array{Array{Float64,2},1}, 1)::Array{Float64,2}
      return false
  end::Bool

julia> @code_warntype(issparse(dep2))
Variables:
  #self# <optimized out>
  nep::NonlinearEigenproblems.NEPTypes.DEP{SparseMatrixCSC{Complex{Float64},Int64}}

Body:
  begin 
      (Base.arrayref)((Core.getfield)(nep::NonlinearEigenproblems.NEPTypes.DEP{SparseMatrixCSC{Complex{Float64},Int64}}, :A)::Array{SparseMatrixCSC{Complex{Float64},Int64},1}, 1)::SparseMatrixCSC{Complex{Float64},Int64}
      return true
  end::Bool
julia> @code_warntype(compute_Mder(dep2,0))
Variables:
  #self#::NonlinearEigenproblems.NEPCore.#compute_Mder
  nep::NonlinearEigenproblems.NEPTypes.DEP{SparseMatrixCSC{Complex{Float64},Int64}}
  λ::Int64

Body:
  begin 
      return $(Expr(:invoke, MethodInstance for compute_Mder(::NonlinearEigenproblems.NEPTypes.DEP{SparseMatrixCSC{Complex{Float64},Int64}}, ::Int64, ::Int64), :(#self#), :(nep), :(λ), 0))
  end::SparseMatrixCSC{Complex{Float64},Int64}
julia> @code_warntype(compute_Mder(nep,0))
Variables:
  #self#::NonlinearEigenproblems.NEPCore.#compute_Mder
  nep::NonlinearEigenproblems.NEPTypes.DEP{Array{Float64,2}}
  λ::Int64

Body:
  begin 
      return $(Expr(:invoke, MethodInstance for compute_Mder(::NonlinearEigenproblems.NEPTypes.DEP{Array{Float64,2}}, ::Int64, ::Int64), :(#self#), :(nep), :(λ), 0))
  end::Array{Float64,2}

julia> @code_warntype(compute_Mder(nep,0+1im))  # comp Mder for a "real DEP" with complex lambda  is type-stable.
Variables:
  #self#::NonlinearEigenproblems.NEPCore.#compute_Mder
  nep::NonlinearEigenproblems.NEPTypes.DEP{Array{Float64,2}}
  λ::Complex{Int64}

Body:
  begin 
      return $(Expr(:invoke, MethodInstance for compute_Mder(::NonlinearEigenproblems.NEPTypes.DEP{Array{Float64,2}}, ::Complex{Int64}, ::Int64), :(#self#), :(nep), :(λ), 0))
  end::Array{Complex{Float64},2}
```