### PR TITLE
SUMNEP type #51

### DIFF
--- a/src/Gallery.jl
+++ b/src/Gallery.jl
@@ -387,8 +387,8 @@ module Gallery
           nep = nep_gallery("nlevp_native_gun")
           K, M = get_Av(nep.nep1);
           W1, W2 = get_Av(nep.nep2);
-          c1 = LowRankMatrixAndFunction(W1, nep.fi[3])
-          c2 = LowRankMatrixAndFunction(W2, nep.fi[4])
+          c1 = LowRankMatrixAndFunction(W1, get_fv(nep.nep2)[1])
+          c2 = LowRankMatrixAndFunction(W2, get_fv(nep.nep2)[2])
           return SumNEP(PEP([K, M]), LowRankFactorizedNEP([c1, c2]))
       else
           error("The name $name is not supported in NEP-Gallery.")

--- a/src/Gallery.jl
+++ b/src/Gallery.jl
@@ -376,19 +376,22 @@ module Gallery
           M=read_sparse_matrix(gunbase * "M.txt")
           W1=read_sparse_matrix(gunbase * "W1.txt")
           W2=read_sparse_matrix(gunbase * "W2.txt")
-          minusop= S-> -S
+          minusop= S-> S
           oneop= S -> eye(size(S,1),size(S,2))
           sqrt1op= S -> 1im*sqrtm(Matrix(S))
           sqrt2op= S -> 1im*sqrtm(Matrix(S)-108.8774^2*eye(S))
-          AA=[K,M,W1,W2];
-          nep=SPMF_NEP(AA,[oneop,minusop,sqrt1op,sqrt2op])
+          AA=[K,-M,W1,W2];
+          pep=PEP([K,-M]);
+          sqrtnep=SPMF_NEP([W1,W2],[sqrt1op,sqrt2op]);
+          nep=SumNEP(pep,sqrtnep);
           return nep;
       elseif name == "nlevp_gun_low_rank_nep"
           nep = nep_gallery("nlevp_native_gun")
-          K, M, W1, W2 = nep.A
+          K, M = get_Av(nep.nep1);
+          W1, W2 = get_Av(nep.nep2);
           c1 = LowRankMatrixAndFunction(W1, nep.fi[3])
           c2 = LowRankMatrixAndFunction(W2, nep.fi[4])
-          return SumNEP(PEP([K, -M]), LowRankFactorizedNEP([c1, c2]))
+          return SumNEP(PEP([K, M]), LowRankFactorizedNEP([c1, c2]))
       else
           error("The name $name is not supported in NEP-Gallery.")
       end

--- a/src/Gallery.jl
+++ b/src/Gallery.jl
@@ -383,13 +383,6 @@ module Gallery
           sqrtnep=SPMF_NEP([W1,W2],[sqrt1op,sqrt2op]);
           nep=SumNEP(pep,sqrtnep);
           return nep;
-      elseif name == "nlevp_gun_low_rank_nep"
-          nep = nep_gallery("nlevp_native_gun")
-          K, M = get_Av(nep.nep1);
-          W1, W2 = get_Av(nep.nep2);
-          c1 = LowRankMatrixAndFunction(W1, get_fv(nep.nep2)[1])
-          c2 = LowRankMatrixAndFunction(W2, get_fv(nep.nep2)[2])
-          return SumNEP(PEP([K, M]), LowRankFactorizedNEP([c1, c2]))
       else
           error("The name $name is not supported in NEP-Gallery.")
       end

--- a/src/Gallery.jl
+++ b/src/Gallery.jl
@@ -376,12 +376,10 @@ module Gallery
           M=read_sparse_matrix(gunbase * "M.txt")
           W1=read_sparse_matrix(gunbase * "W1.txt")
           W2=read_sparse_matrix(gunbase * "W2.txt")
-          minusop= S-> S
-          oneop= S -> eye(size(S,1),size(S,2))
+          # The gun problem is a sum of a PEP and a problem containing square roots.
+          pep=PEP([K,-M]);
           sqrt1op= S -> 1im*sqrtm(Matrix(S))
           sqrt2op= S -> 1im*sqrtm(Matrix(S)-108.8774^2*eye(S))
-          AA=[K,-M,W1,W2];
-          pep=PEP([K,-M]);
           sqrtnep=SPMF_NEP([W1,W2],[sqrt1op,sqrt2op]);
           nep=SumNEP(pep,sqrtnep);
           return nep;

--- a/src/Gallery.jl
+++ b/src/Gallery.jl
@@ -383,12 +383,12 @@ module Gallery
           AA=[K,M,W1,W2];
           nep=SPMF_NEP(AA,[oneop,minusop,sqrt1op,sqrt2op])
           return nep;
-      elseif name == "nlevp_gun_pnep"
+      elseif name == "nlevp_gun_low_rank_nep"
           nep = nep_gallery("nlevp_native_gun")
           K, M, W1, W2 = nep.A
           c1 = LowRankMatrixAndFunction(W1, nep.fi[3])
           c2 = LowRankMatrixAndFunction(W2, nep.fi[4])
-          return PNEP([K, -M], [c1, c2])
+          return SumNEP(PEP([K, -M]), LowRankFactorizedNEP([c1, c2]))
       else
           error("The name $name is not supported in NEP-Gallery.")
       end

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -144,6 +144,9 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
 """
      function SPMF_NEP(AA::Vector{<:AbstractMatrix}, fii::Vector{<:Function}, Schur_fact = false)
 
+         if (size(AA,1)==0)
+             return SPMF_NEP(0); # Create empty SPMF_NEP. 
+         end
          n=size(AA[1],1);
 
          if     (size(AA,1) != 1) && (size(AA,2) == 1) # Stored as column vector - do nothing
@@ -948,8 +951,13 @@ SPMF with low rank LU factors for each matrix.
                 end
             end
         end
-
         return LowRankFactorizedNEP(SPMF_NEP(A, f), r, L, U)
+    end
+ 
+    function LowRankFactorizedNEP(n) # Create an empty LowRankFactorizedNEP
+        #LowRankFactorizedNEP(SPMF_NEP(n),0,Vector{Matrix{Float64}}(0),Vector{Matrix{Float64}}(0))
+        nep=LowRankFactorizedNEP(Vector{MatrixAndFunction{Matrix{Float64}}}(0)) # 
+        return nep
     end
 
     # forward function calls to SPMF

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -7,7 +7,7 @@ module NEPTypes
     export REP
     export SPMF_NEP
     export AbstractSPMF
-    export SUMNEP
+    export SumNEP
 
     export MatrixAndFunction
     export LowRankMatrixAndFunction
@@ -790,9 +790,9 @@ julia> compute_Mder(nep,λ)[1:2,1:2]
     end
 
     """
-        type SUMNEP{nep1::NEP,nep2::NEP} <: NEP
+        type SumNEP{nep1::NEP,nep2::NEP} <: NEP
 
-SUMNEP corresponds to a sum of two NEPs, i.e., if nep is a SUMNEP it
+SumNEP corresponds to a sum of two NEPs, i.e., if nep is a SumNEP it
 is defined by
 ```math
 M(λ)=M_1(λ)+M_2(λ)
@@ -803,7 +803,7 @@ where M_1 and M_2 are defined by `nep1` and `nep2`.
 ```julia-repl
 julia> nep1=DEP([ones(3,3),randn(3,3)])
 julia> nep2=PEP([ones(3,3),randn(3,3),randn(3,3)])
-julia> sumnep=SUMNEP(nep1,nep2);
+julia> sumnep=SumNEP(nep1,nep2);
 julia> s=3.0;
 julia> M=compute_Mder(sumnep,s);
 3×3 Array{Float64,2}:
@@ -819,19 +819,19 @@ julia> M1+M2  # Same as M
   6.03155    -7.26726  -6.42828 
 ```
 """
-    struct SUMNEP{NEP1<:NEP,NEP2<:NEP}  <: NEP 
+    struct SumNEP{NEP1<:NEP,NEP2<:NEP}  <: NEP 
         nep1::NEP1
         nep2::NEP2
     end
 
     # Delegate all interface functions
-    size(snep::SUMNEP)=size(snep.nep1)
-    size(snep::SUMNEP,d)=size(snep.nep1,d)
-    compute_Mlincomb(nep::SUMNEP, λ::Number, V;a=ones(eltype(λ),size(V,2))) =
+    size(snep::SumNEP)=size(snep.nep1)
+    size(snep::SumNEP,d)=size(snep.nep1,d)
+    compute_Mlincomb(nep::SumNEP, λ::Number, V;a=ones(eltype(λ),size(V,2))) =
         (compute_Mlincomb(nep.nep1, λ, V,a=a)+compute_Mlincomb(nep.nep2,λ,V,a=a))
-    compute_Mder(nep::SUMNEP, λ::Number,i::Int = 0) =
+    compute_Mder(nep::SumNEP, λ::Number,i::Int = 0) =
         (compute_Mder(nep.nep1,λ,i)+compute_Mder(nep.nep2,λ,i))
-    compute_MM(nep::SUMNEP, S::Matrix,V::Matrix) =
+    compute_MM(nep::SumNEP, S::Matrix,V::Matrix) =
         (compute_MM(nep.nep1,S,V)+compute_M(nep.nep2,S,V))
 
 

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -142,7 +142,8 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
  0.0  0.0
 ```
 """
-     function SPMF_NEP(AA::Array{<:AbstractMatrix,1}, fii::Array{Function,1}, Schur_fact = false)
+     function SPMF_NEP(AA::Vector{<:AbstractMatrix}, fii::Vector{<:Function}, Schur_fact = false)
+
          n=size(AA[1],1);
 
          if     (size(AA,1) != 1) && (size(AA,2) == 1) # Stored as column vector - do nothing
@@ -179,7 +180,10 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
          this=SPMF_NEP(n,AA,fii,Schur_fact,Zero);
          return this
     end
-
+    function SPMF_NEP(n) # Create an empty NEP of size n x n
+         Z=zeros(n,n)
+         return SPMF_NEP(n,Vector{Matrix}(),Vector{Function}(),false,Z);
+    end
     function compute_MM(nep::SPMF_NEP,S,V)
         if (issparse(V))
             if (size(V)==size(nep))

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -7,6 +7,7 @@ module NEPTypes
     export REP
     export SPMF_NEP
     export AbstractSPMF
+    export SUMNEP
 
     export MatrixAndFunction
     export LowRankMatrixAndFunction
@@ -788,7 +789,53 @@ julia> compute_Mder(nep,λ)[1:2,1:2]
         return false; # A projected NEP is (essentially) never sparse
     end
 
+    """
+        type SUMNEP{nep1::NEP,nep2::NEP} <: NEP
 
+SUMNEP corresponds to a sum of two NEPs, i.e., if nep is a SUMNEP it
+is defined by
+```math
+M(λ)=M_1(λ)+M_2(λ)
+```
+where M_1 and M_2 are defined by `nep1` and `nep2`.
+
+# Example:
+```julia-repl
+julia> nep1=DEP([ones(3,3),randn(3,3)])
+julia> nep2=PEP([ones(3,3),randn(3,3),randn(3,3)])
+julia> sumnep=SUMNEP(nep1,nep2);
+julia> s=3.0;
+julia> M=compute_Mder(sumnep,s);
+3×3 Array{Float64,2}:
+  8.54014     6.71897   7.12007 
+ -0.943908  -13.0795   -0.621659
+  6.03155    -7.26726  -6.42828 
+julia> M1=compute_Mder(nep1,s);
+julia> M2=compute_Mder(nep2,s);
+julia> M1+M2  # Same as M
+3×3 Array{Float64,2}:
+  8.54014     6.71897   7.12007 
+ -0.943908  -13.0795   -0.621659
+  6.03155    -7.26726  -6.42828 
+```
+"""
+    struct SUMNEP{NEP1<:NEP,NEP2<:NEP}  <: NEP 
+        nep1::NEP1
+        nep2::NEP2
+    end
+
+    # Delegate all interface functions
+    size(snep::SUMNEP)=size(snep.nep1)
+    size(snep::SUMNEP,d)=size(snep.nep1,d)
+    compute_Mlincomb(nep::SUMNEP, λ::Number, V;a=ones(eltype(λ),size(V,2))) =
+        (compute_Mlincomb(nep.nep1, λ, V,a=a)+compute_Mlincomb(nep.nep2,λ,V,a=a))
+    compute_Mder(nep::SUMNEP, λ::Number,i::Int = 0) =
+        (compute_Mder(nep.nep1,λ,i)+compute_Mder(nep.nep2,λ,i))
+    compute_MM(nep::SUMNEP, S::Matrix,V::Matrix) =
+        (compute_MM(nep.nep1,S,V)+compute_M(nep.nep2,S,V))
+
+
+    
     ############################################################################
     # PNEP (Polynomial plus Nonlinear Eigenvalue Problem)
     ############################################################################

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -371,7 +371,6 @@ julia> compute_Mder(pep,3)-(A0+A1*3+A2*9)
         return PEP(n,AA)
     end
 
-
 # Computes the sum ``Σ_i M_i V f_i(S)`` for a PEP
     function compute_MM(nep::PEP,S,V)
         if (issparse(nep))

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -7,7 +7,7 @@ module NEPTypes
     export REP
     export SPMF_NEP
     export AbstractSPMF
-    export SumNEP
+    export SumNEP, SPMFSumNEP, GenericSumNEP
 
     export MatrixAndFunction
     export LowRankMatrixAndFunction
@@ -819,21 +819,38 @@ julia> M1+M2  # Same as M
   6.03155    -7.26726  -6.42828
 ```
 """
-    struct SumNEP{NEP1<:NEP,NEP2<:NEP}  <: NEP
+    struct GenericSumNEP{NEP1<:NEP,NEP2<:NEP}  <: NEP
         nep1::NEP1
         nep2::NEP2
     end
 
+    struct SPMFSumNEP{NEP1<:AbstractSPMF,NEP2<:AbstractSPMF}  <: AbstractSPMF
+        nep1::NEP1
+        nep2::NEP2
+    end
+
+    AnySumNEP=Union{GenericSumNEP,SPMFSumNEP};
+    # Creator functions for SumNEP
+    function SumNEP(nep1::AbstractSPMF,nep2::AbstractSPMF)
+        return SPMFSumNEP(nep1,nep2);
+    end
+    function SumNEP(nep1::NEP,nep2::NEP)
+        return GenericSumNEP(nep1,nep2);
+    end
+
     # Delegate all interface functions
-    size(snep::SumNEP)=size(snep.nep1)
-    size(snep::SumNEP,d)=size(snep.nep1,d)
-    compute_Mlincomb(nep::SumNEP, λ::Number, V;a=ones(eltype(λ),size(V,2))) =
+    size(snep::AnySumNEP)=size(snep.nep1)
+    size(snep::AnySumNEP,d)=size(snep.nep1,d)
+    compute_Mlincomb(nep::AnySumNEP, λ::Number, V;a=ones(eltype(λ),size(V,2))) =
         (compute_Mlincomb(nep.nep1, λ, V,a=a)+compute_Mlincomb(nep.nep2,λ,V,a=a))
-    compute_Mder(nep::SumNEP, λ::Number,i::Int = 0) =
+    compute_Mder(nep::AnySumNEP, λ::Number,i::Int = 0) =
         (compute_Mder(nep.nep1,λ,i)+compute_Mder(nep.nep2,λ,i))
-    compute_MM(nep::SumNEP, S::Matrix,V::Matrix) =
+    compute_MM(nep::AnySumNEP, S::Matrix,V::Matrix) =
         (compute_MM(nep.nep1,S,V)+compute_M(nep.nep2,S,V))
 
+    # For SPMFSumNEP, also delegate the get_Av() and get_fv()
+    get_Av(nep::SPMFSumNEP)=[get_Av(nep.nep1),get_Av(nep.nep2)];
+    get_fv(nep::SPMFSumNEP)=[get_fv(nep.nep1),get_fv(nep.nep2)];
 
 
     ############################################################################

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -9,10 +9,6 @@ module NEPTypes
     export AbstractSPMF
     export SumNEP, SPMFSumNEP, GenericSumNEP
 
-    export MatrixAndFunction
-    export LowRankMatrixAndFunction
-    export LowRankFactorizedNEP
-
     export Proj_NEP;
     export Proj_SPMF_NEP;
     export create_proj_NEP;
@@ -860,116 +856,6 @@ julia> M1+M2  # Same as M
     get_fv(nep::SPMFSumNEP)=[get_fv(nep.nep1),get_fv(nep.nep2)];
 
 
-    ############################################################################
-    # PNEP (Polynomial plus Nonlinear Eigenvalue Problem)
-    ############################################################################
-
-    abstract type AbstractMatrixAndFunction{S<:AbstractMatrix{<:Real}} end
-
-    struct MatrixAndFunction{S<:AbstractMatrix{<:Real}} <: AbstractMatrixAndFunction{S}
-        A::S
-        f::Function
-    end
-
-    struct LowRankMatrixAndFunction{S<:AbstractMatrix{<:Real}} <: AbstractMatrixAndFunction{S}
-        A::S
-        L::S        # L factor of LU-factorized A
-        U::S        # U factor of LU-factorized A
-        f::Function
-    end
-
-    "Creates low rank LU factorization of A"
-    function LowRankMatrixAndFunction(A::AbstractMatrix{<:Real}, f::Function)
-        L, U = low_rank_lu_factors(A)
-        LowRankMatrixAndFunction(A, L, U, f)
-    end
-
-    function low_rank_lu_factors(A::SparseMatrixCSC{<:Real,Int64})
-        n = size(A, 1)
-        r, c = findn(A)
-        r = extrema(r)
-        c = extrema(c)
-        B = A[r[1]:r[2], c[1]:c[2]]
-        L, U = lu(full(B))
-        Lc, Uc = compactlu(sparse(L), sparse(U))
-        Lca = spzeros(n, size(Lc, 2))
-        Lca[r[1]:r[2], :] = Lc
-        Uca = spzeros(size(Uc, 1), n)
-        Uca[:, c[1]:c[2]] = Uc
-        return Lca, Uca'
-
-        # TODO use this; however we then need to support permutation and scaling
-        #F = lufact(B)
-        #Lcf,Ucf = compactlu(sparse(F[:L]),sparse(F[:U]))
-        #Lcaf = spzeros(n, size(Lcf, 2))
-        #Lcaf[r[1]:r[2], :] = Lcf
-        #Ucaf = spzeros(size(Ucf, 1), n)
-        #Ucaf[:, c[1]:c[2]] = Ucf
-        #Ucaf = Ucaf'
-    end
-
-    function compactlu(L, U)
-        n = size(L, 1)
-        select = map(i -> nnz(L[i:n, i]) > 1 || nnz(U[i, i:n]) > 0, 1:n)
-        return L[:,select], U[select,:]
-    end
-
-"""
-SPMF with low rank LU factors for each matrix.
-"""
-    struct LowRankFactorizedNEP{S<:AbstractMatrix{<:Real}} <: AbstractSPMF
-        spmf::SPMF_NEP
-        r::Int          # Sum of ranks of matrices
-        L::Vector{S}    # Low rank L factors of matrices
-        U::Vector{S}    # Low rank U factors of matrices
-    end
-
-    function LowRankFactorizedNEP(Amf::AbstractVector{<:AbstractMatrixAndFunction{S}}) where {T<:Real, S<:AbstractMatrix{T}}
-        q = length(Amf)
-        r = 0
-        f = Vector{Function}(q)
-        A = Vector{S}(q)
-        # L and U factors of low rank A
-        L = Vector{S}(0)
-        U = Vector{S}(0)
-
-        if q > 0
-            for k = 1:q
-                f[k] = Amf[k].f
-                A[k] = Amf[k].A
-            end
-
-            if isa(Amf[1], LowRankMatrixAndFunction)
-                L = Vector{S}(q)
-                U = Vector{S}(q)
-                for k = 1:q
-                    L[k] = Amf[k].L
-                    U[k] = Amf[k].U
-                    r += size(U[k], 2)
-                    # if A is not specified, create it from LU factors
-                    isempty(A[k]) && (A[k] = L[k] * U[k]')
-                end
-            end
-        end
-        return LowRankFactorizedNEP(SPMF_NEP(A, f), r, L, U)
-    end
-
-    function LowRankFactorizedNEP(n) # Create an empty LowRankFactorizedNEP
-        #LowRankFactorizedNEP(SPMF_NEP(n),0,Vector{Matrix{Float64}}(0),Vector{Matrix{Float64}}(0))
-        nep=LowRankFactorizedNEP(Vector{MatrixAndFunction{Matrix{Float64}}}(0)) #
-        return nep
-    end
-
-    # forward function calls to SPMF
-    compute_Mder(nep::LowRankFactorizedNEP, λ::T, i::Int = 0) where T<:Number =
-        compute_Mder(nep.spmf, λ, i)
-
-    compute_Mlincomb(nep::LowRankFactorizedNEP, λ::T, V::Union{Vector{T}, Matrix{T}}; a = ones(T, size(V, 2))) where T<:Number =
-        compute_Mlincomb(nep.spmf, λ, V, a=a)
-
-    size(nep::LowRankFactorizedNEP) = size(nep.spmf)
-    size(nep::LowRankFactorizedNEP, dim) = size(nep.spmf, dim)
-
    #######################################################
    ### Functions in common for many NEPs in NEPTypes
 
@@ -978,12 +864,12 @@ SPMF with low rank LU factors for each matrix.
     size(nep::NEP,dim=-1)
  Overloads the size functions for NEPs storing size in nep.n
 """
-    function size(nep::Union{DEP,PEP,REP,SPMF_NEP,LowRankFactorizedNEP},dim)
+    function size(nep::Union{DEP,PEP,REP,SPMF_NEP},dim)
         return nep.n
     end
 
 
-    function size(nep::Union{DEP,PEP,REP,SPMF_NEP,LowRankFactorizedNEP})
+    function size(nep::Union{DEP,PEP,REP,SPMF_NEP})
         return (nep.n,nep.n)
     end
 

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -145,7 +145,7 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
      function SPMF_NEP(AA::Vector{<:AbstractMatrix}, fii::Vector{<:Function}, Schur_fact = false)
 
          if (size(AA,1)==0)
-             return SPMF_NEP(0); # Create empty SPMF_NEP. 
+             return SPMF_NEP(0); # Create empty SPMF_NEP.
          end
          n=size(AA[1],1);
 
@@ -953,10 +953,10 @@ SPMF with low rank LU factors for each matrix.
         end
         return LowRankFactorizedNEP(SPMF_NEP(A, f), r, L, U)
     end
- 
+
     function LowRankFactorizedNEP(n) # Create an empty LowRankFactorizedNEP
         #LowRankFactorizedNEP(SPMF_NEP(n),0,Vector{Matrix{Float64}}(0),Vector{Matrix{Float64}}(0))
-        nep=LowRankFactorizedNEP(Vector{MatrixAndFunction{Matrix{Float64}}}(0)) # 
+        nep=LowRankFactorizedNEP(Vector{MatrixAndFunction{Matrix{Float64}}}(0)) #
         return nep
     end
 

--- a/src/nleigs/NleigsTypes.jl
+++ b/src/nleigs/NleigsTypes.jl
@@ -1,0 +1,119 @@
+module NleigsTypes
+
+using NEPTypes
+
+export MatrixAndFunction
+export LowRankMatrixAndFunction
+export LowRankFactorizedNEP
+
+import Base.size
+import NEPCore.compute_Mder
+import NEPCore.compute_Mlincomb
+
+abstract type AbstractMatrixAndFunction{S<:AbstractMatrix{<:Real}} end
+
+struct MatrixAndFunction{S<:AbstractMatrix{<:Real}} <: AbstractMatrixAndFunction{S}
+    A::S
+    f::Function
+end
+
+struct LowRankMatrixAndFunction{S<:AbstractMatrix{<:Real}} <: AbstractMatrixAndFunction{S}
+    A::S
+    L::S        # L factor of LU-factorized A
+    U::S        # U factor of LU-factorized A
+    f::Function
+end
+
+"Creates low rank LU factorization of A"
+function LowRankMatrixAndFunction(A::AbstractMatrix{<:Real}, f::Function)
+    L, U = low_rank_lu_factors(A)
+    LowRankMatrixAndFunction(A, L, U, f)
+end
+
+function low_rank_lu_factors(A::SparseMatrixCSC{<:Real,Int64})
+    n = size(A, 1)
+    r, c = findn(A)
+    r = extrema(r)
+    c = extrema(c)
+    B = A[r[1]:r[2], c[1]:c[2]]
+    L, U = lu(full(B))
+    Lc, Uc = compactlu(sparse(L), sparse(U))
+    Lca = spzeros(n, size(Lc, 2))
+    Lca[r[1]:r[2], :] = Lc
+    Uca = spzeros(size(Uc, 1), n)
+    Uca[:, c[1]:c[2]] = Uc
+    return Lca, Uca'
+
+    # TODO use this; however we then need to support permutation and scaling
+    #F = lufact(B)
+    #Lcf,Ucf = compactlu(sparse(F[:L]),sparse(F[:U]))
+    #Lcaf = spzeros(n, size(Lcf, 2))
+    #Lcaf[r[1]:r[2], :] = Lcf
+    #Ucaf = spzeros(size(Ucf, 1), n)
+    #Ucaf[:, c[1]:c[2]] = Ucf
+    #Ucaf = Ucaf'
+end
+
+function compactlu(L, U)
+    n = size(L, 1)
+    select = map(i -> nnz(L[i:n, i]) > 1 || nnz(U[i, i:n]) > 0, 1:n)
+    return L[:,select], U[select,:]
+end
+
+"""
+SPMF with low rank LU factors for each matrix.
+"""
+struct LowRankFactorizedNEP{S<:AbstractMatrix{<:Real}} <: AbstractSPMF
+    spmf::SPMF_NEP
+    r::Int          # Sum of ranks of matrices
+    L::Vector{S}    # Low rank L factors of matrices
+    U::Vector{S}    # Low rank U factors of matrices
+end
+
+function LowRankFactorizedNEP(Amf::AbstractVector{<:AbstractMatrixAndFunction{S}}) where {T<:Real, S<:AbstractMatrix{T}}
+    q = length(Amf)
+    r = 0
+    f = Vector{Function}(q)
+    A = Vector{S}(q)
+    # L and U factors of low rank A
+    L = Vector{S}(0)
+    U = Vector{S}(0)
+
+    if q > 0
+        for k = 1:q
+            f[k] = Amf[k].f
+            A[k] = Amf[k].A
+        end
+
+        if isa(Amf[1], LowRankMatrixAndFunction)
+            L = Vector{S}(q)
+            U = Vector{S}(q)
+            for k = 1:q
+                L[k] = Amf[k].L
+                U[k] = Amf[k].U
+                r += size(U[k], 2)
+                # if A is not specified, create it from LU factors
+                isempty(A[k]) && (A[k] = L[k] * U[k]')
+            end
+        end
+    end
+    return LowRankFactorizedNEP(SPMF_NEP(A, f), r, L, U)
+end
+
+function LowRankFactorizedNEP(n) # Create an empty LowRankFactorizedNEP
+    #LowRankFactorizedNEP(SPMF_NEP(n),0,Vector{Matrix{Float64}}(0),Vector{Matrix{Float64}}(0))
+    nep=LowRankFactorizedNEP(Vector{MatrixAndFunction{Matrix{Float64}}}(0)) #
+    return nep
+end
+
+# forward function calls to SPMF
+compute_Mder(nep::LowRankFactorizedNEP, λ::T, i::Int = 0) where T<:Number =
+    compute_Mder(nep.spmf, λ, i)
+
+compute_Mlincomb(nep::LowRankFactorizedNEP, λ::T, V::Union{Vector{T}, Matrix{T}}; a = ones(T, size(V, 2))) where T<:Number =
+    compute_Mlincomb(nep.spmf, λ, V, a=a)
+
+size(nep::LowRankFactorizedNEP) = size(nep.spmf)
+size(nep::LowRankFactorizedNEP, dim) = size(nep.spmf, dim)
+
+end

--- a/src/nleigs/NleigsTypes.jl
+++ b/src/nleigs/NleigsTypes.jl
@@ -100,11 +100,9 @@ function LowRankFactorizedNEP(Amf::AbstractVector{<:AbstractMatrixAndFunction{S}
     return LowRankFactorizedNEP(SPMF_NEP(A, f), r, L, U)
 end
 
-function LowRankFactorizedNEP(n) # Create an empty LowRankFactorizedNEP
-    #LowRankFactorizedNEP(SPMF_NEP(n),0,Vector{Matrix{Float64}}(0),Vector{Matrix{Float64}}(0))
-    nep=LowRankFactorizedNEP(Vector{MatrixAndFunction{Matrix{Float64}}}(0)) #
-    return nep
-end
+# Create an empty LowRankFactorizedNEP
+LowRankFactorizedNEP(::Type{T}, n) where T<:Number =
+    LowRankFactorizedNEP(SPMF_NEP(n), 0, Vector{Matrix{T}}(0), Vector{Matrix{T}}(0))
 
 # forward function calls to SPMF
 compute_Mder(nep::LowRankFactorizedNEP, λ::T, i::Int = 0) where T<:Number =

--- a/src/nleigs/method_nleigs.jl
+++ b/src/nleigs/method_nleigs.jl
@@ -140,7 +140,7 @@ function nleigs(
         functions = [monomials(p); nep.nep2.spmf.fi]
         sgdd = scgendivdiffs(sigma[range], xi[range], beta[range], maxdgr, isfunm, functions)
         # Construct first generalized divided difference
-        computeD && push!(D, constructD(0, L, n, p, q, r, nep.nep2.spmf.A, sgdd))
+        computeD && push!(D, constructD(0, L, n, p, q, r, [nep.nep1.A; nep.nep2.spmf.A], sgdd))
         # Norm of first generalized divided difference
         nrmD[1] = maximum(abs.(sgdd[:,1]))
     end
@@ -202,7 +202,7 @@ function nleigs(
 
             # rational divided differences
             if spmf && computeD
-                push!(D, constructD(k, L, n, p, q, r, nep.nep2.spmf.A, sgdd))
+                push!(D, constructD(k, L, n, p, q, r, [nep.nep1.A; nep.nep2.spmf.A], sgdd))
             end
             N += 1
 

--- a/src/nleigs/method_nleigs.jl
+++ b/src/nleigs/method_nleigs.jl
@@ -77,7 +77,7 @@ function nleigs(
     #@code_warntype prepare_inputs(nep, Sigma, Xi)
     #return
     spmf,iL,L,LL,UU,p,q,r,Sigma,Xi,computeD,BBCC = prepare_inputs(nep, Sigma, Xi)
-    n = nep.n
+    n = size(nep, 1)
     n == 1 && (maxdgr = maxit + 1)
     b = blksize
 
@@ -137,9 +137,10 @@ function nleigs(
         sgdd = Matrix{CT}(0, 0)
     else
         # Compute scalar generalized divided differences
-        sgdd = scgendivdiffs(sigma[range], xi[range], beta[range], maxdgr, isfunm, nep.spmf.fi)
+        functions = [monomials(p); nep.nep2.spmf.fi]
+        sgdd = scgendivdiffs(sigma[range], xi[range], beta[range], maxdgr, isfunm, functions)
         # Construct first generalized divided difference
-        computeD && push!(D, constructD(0, L, n, p, q, r, nep.spmf.A, sgdd))
+        computeD && push!(D, constructD(0, L, n, p, q, r, nep.nep2.spmf.A, sgdd))
         # Norm of first generalized divided difference
         nrmD[1] = maximum(abs.(sgdd[:,1]))
     end
@@ -201,7 +202,7 @@ function nleigs(
 
             # rational divided differences
             if spmf && computeD
-                push!(D, constructD(k, L, n, p, q, r, nep.spmf.A, sgdd))
+                push!(D, constructD(k, L, n, p, q, r, nep.nep2.spmf.A, sgdd))
             end
             N += 1
 
@@ -279,6 +280,11 @@ function nleigs(
             w = backslash(wc, nep, spmf, iL, LL, UU, p, q, r, reuselu, computeD, sigma, k, D, beta, N, xi, expand, kconv, BBCC, sgdd)
 
             # orthogonalization
+#            Vview = view(V, 1:kn, 1:l)
+#            H[l+1,l] = orthogonalize_and_normalize!(Vview, w, view(H, 1:l,l), DGKS)
+#            K[1:l,l] .= view(H, 1:l, l) .* sigma[k+1] .+ t
+#            K[l+1,l] = H[l+1,l] * sigma[k+1]
+#            V[1:kn,l+1] = w
             normw = norm(w)
             Vview = view(V, 1:kn, 1:l)
             h = Vview' * w
@@ -431,25 +437,26 @@ function prepare_inputs(nep::NEP, Sigma::AbstractVector{CT}, Xi::AbstractVector{
     p = -1
     q = 0
     r = 0
-    spmf = isa(nep, PNEP)
+    # TODO: support other types of NEPs here, e.g. SumNEP{PEP, SPMF}
+    spmf = isa(nep, SumNEP{PEP,LowRankFactorizedNEP{N}} where N<:Any)
 
     if !spmf
         BBCC = Matrix{T}(0, 0)
         if isa(nep, AbstractSPMF)
             warn("NLEIGS performs better if the problem is split into a ",
                 "polynomial part and a nonlinear part. If possible, create ",
-                "the problem as a $PNEP instead of a $(typeof(nep).name).")
+                "the problem as a $(SumNEP{PEP,LowRankFactorizedNEP}) instead of a $(typeof(nep).name).")
         end
         #BBCC = isempty(nep.B) ? similar(nep.C[1].A, 0, 0) : similar(nep.B[1], 0, 0)
     else
-        p = nep.p
-        q = nep.q
+        p = length(nep.nep1.A) - 1
+        q = length(nep.nep2.spmf.A)
         if q > 0
-            # L and U factors of the low rank nonlinear part C
-            L = nep.L
+            # L and U factors of the low rank nonlinear part
+            L = nep.nep2.L
             if !isempty(L)
-                UU = hcat(nep.U...)::eltype(nep.U)
-                r = nep.r
+                UU = hcat(nep.nep2.U...)::eltype(nep.nep2.U)
+                r = nep.nep2.r
                 iL = zeros(Int, r)
                 c = 0
                 for ii = 1:q
@@ -461,7 +468,7 @@ function prepare_inputs(nep::NEP, Sigma::AbstractVector{CT}, Xi::AbstractVector{
             end
         end
 
-        BBCC = vcat(nep.spmf.A...)::eltype(nep.spmf.A)
+        BBCC = vcat(nep.nep1.A..., nep.nep2.spmf.A...)::eltype(nep.nep1.A)
     end
 
     # process the input Xi
@@ -469,7 +476,7 @@ function prepare_inputs(nep::NEP, Sigma::AbstractVector{CT}, Xi::AbstractVector{
         Xi = [T(Inf)]
     end
 
-    computeD = (nep.n <= 400) # for small problems, explicitly use generalized divided differences
+    computeD = (size(nep, 1) <= 400) # for small problems, explicitly use generalized divided differences
 
     return spmf,iL,L,LL,UU,p,q,r,Sigma,Xi,computeD,BBCC
 end
@@ -511,7 +518,7 @@ end
 # backslash: Backslash or left matrix divide
 #   wc       continuation vector
 function backslash(wc, nep, spmf, iL, LL, UU, p, q, r, reuselu, computeD, sigma, k, D, beta, N, xi, expand, kconv, BBCC, sgdd)
-    n = nep.n
+    n = size(nep, 1)
     shift = sigma[k+1]
 
     # construction of B*wc
@@ -647,3 +654,11 @@ function resize_matrix(A, rows, cols)
     resized[1:size(A, 1), 1:size(A, 2)] = A
     return resized
 end
+
+function monomials(p)
+    f = Vector{Function}(p+1)
+    for k=1:p+1
+        f[k] = x -> x^(k-1)
+    end
+    return f
+ end

--- a/src/nleigs/method_nleigs.jl
+++ b/src/nleigs/method_nleigs.jl
@@ -438,14 +438,14 @@ function prepare_inputs(nep::NEP, Sigma::AbstractVector{CT}, Xi::AbstractVector{
     q = 0
     r = 0
     # TODO: support other types of NEPs here, e.g. SumNEP{PEP, SPMF}
-    spmf = isa(nep, SumNEP{PEP,LowRankFactorizedNEP{N}} where N<:Any)
+    spmf = isa(nep, SPMFSumNEP{PEP,LowRankFactorizedNEP{N}} where N<:Any)
 
     if !spmf
         BBCC = Matrix{T}(0, 0)
         if isa(nep, AbstractSPMF)
             warn("NLEIGS performs better if the problem is split into a ",
                 "polynomial part and a nonlinear part. If possible, create ",
-                "the problem as a $(SumNEP{PEP,LowRankFactorizedNEP}) instead of a $(typeof(nep).name).")
+                "the problem as a $(SPMFSumNEP{PEP,LowRankFactorizedNEP}) instead of a $(typeof(nep).name).")
         end
         #BBCC = isempty(nep.B) ? similar(nep.C[1].A, 0, 0) : similar(nep.B[1], 0, 0)
     else

--- a/src/nleigs/ratnewtoncoeffs.jl
+++ b/src/nleigs/ratnewtoncoeffs.jl
@@ -13,7 +13,7 @@ function ratnewtoncoeffs(fun, sigma::AbstractVector{CT}, xi::AbstractVector{T}, 
     D[1] = fun(as_matrix(sigma[1])) * beta[1]
     n = size(D[1], 1)
     for j = 2:m
-        # evaluate current linearizaion at sigma(j);
+        # evaluate current linearizaion at sigma[j]
         Qj = T(0)
         for k = 1:j-1
             Qj += D[k] * evalrat(sigma[1:k-1], xi[1:k-1], beta[1:k], [sigma[j]])[1]

--- a/test/core.jl
+++ b/test/core.jl
@@ -61,7 +61,7 @@ end
     B1=3*eye(3,3)+ones(3,3);
     nep2=PEP([B0,B1]);
     λ=1+1im;
-    sumnep=SUMNEP(nep1,nep2);
+    sumnep=SumNEP(nep1,nep2);
     M=compute_Mder(sumnep,λ);
     M1=compute_Mder(nep1,λ);
     M2=compute_Mder(nep2,λ);

--- a/test/core.jl
+++ b/test/core.jl
@@ -51,3 +51,19 @@ my_test_NEP = TestNEP([1 2; 3 4])
 @test_throws ErrorException size(my_test_NEP,1)
 
 end
+
+
+@testset "Types (sumnep)" begin
+    A0=ones(3,3);
+    A1=eye(3,3);
+    nep1=DEP([A0,A1])
+    B0=flipdim(eye(3,3),1)
+    B1=3*eye(3,3)+ones(3,3);
+    nep2=PEP([B0,B1]);
+    λ=1+1im;
+    sumnep=SUMNEP(nep1,nep2);
+    M=compute_Mder(sumnep,λ);
+    M1=compute_Mder(nep1,λ);
+    M2=compute_Mder(nep2,λ);
+    @test (M1+M2)≈M
+end

--- a/test/load_modules_for_tests.jl
+++ b/test/load_modules_for_tests.jl
@@ -1,6 +1,7 @@
 push!(LOAD_PATH, string(@__DIR__, "/../src"))
 push!(LOAD_PATH, string(@__DIR__, "/../src/utils"))
 push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
+push!(LOAD_PATH, string(@__DIR__, "/../src/nleigs"))
 
 using NEPCore
 using NEPTypes

--- a/test/load_modules_for_tests.jl
+++ b/test/load_modules_for_tests.jl
@@ -4,6 +4,7 @@ push!(LOAD_PATH, string(@__DIR__, "/../src/gallery_extra"))
 
 using NEPCore
 using NEPTypes
+using NleigsTypes
 using LinSolvers
 using NEPSolver
 using Gallery

--- a/test/nleigs/gun_test_utils.jl
+++ b/test/nleigs/gun_test_utils.jl
@@ -1,5 +1,5 @@
 function gun_init()
-    nep = nep_gallery("nlevp_gun_pnep")
+    nep = nep_gallery("nlevp_gun_low_rank_nep")
 
     gam = 300^2 - 200^2
     mu = 250^2
@@ -21,9 +21,9 @@ function gun_init()
 
     # options
     srand(1)
-    v = randn(nep.n)
+    v = randn(size(nep, 1))
 
-    funres = (λ, v) -> gun_residual(λ, v, nep.spmf.A...)
+    funres = (λ, v) -> gun_residual(λ, v, nep.nep1.A..., nep.nep2.spmf.A...)
 
     return nep, Sigma, Xi, v, nodes, funres
 end

--- a/test/nleigs/gun_test_utils.jl
+++ b/test/nleigs/gun_test_utils.jl
@@ -1,5 +1,5 @@
 function gun_init()
-    nep = nep_gallery("nlevp_gun_low_rank_nep")
+    nep = gun_nep()
 
     gam = 300^2 - 200^2
     mu = 250^2
@@ -26,6 +26,15 @@ function gun_init()
     funres = (λ, v) -> gun_residual(λ, v, nep.nep1.A..., nep.nep2.spmf.A...)
 
     return nep, Sigma, Xi, v, nodes, funres
+end
+
+function gun_nep()
+    nep = nep_gallery("nlevp_native_gun")
+    K, M = get_Av(nep.nep1);
+    W1, W2 = get_Av(nep.nep2);
+    c1 = LowRankMatrixAndFunction(W1, get_fv(nep.nep2)[1])
+    c2 = LowRankMatrixAndFunction(W2, get_fv(nep.nep2)[2])
+    return SumNEP(PEP([K, M]), LowRankFactorizedNEP([c1, c2]))
 end
 
 function gun_residual(λ, v, K, M, W1, W2)

--- a/test/nleigs/nleigs_basic.jl
+++ b/test/nleigs/nleigs_basic.jl
@@ -5,9 +5,11 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../../src/nleigs"))
 
     using NEPCore
     using NEPTypes
+    using NleigsTypes
     using Gallery
     using IterativeSolvers
     using Base.Test

--- a/test/nleigs/nleigs_basic.jl
+++ b/test/nleigs/nleigs_basic.jl
@@ -18,8 +18,7 @@ include("../../src/nleigs/method_nleigs.jl")
 n = 2
 B = Vector{Matrix{Float64}}([[1 3; 5 6], [3 4; 6 6], [1 0; 0 1]])
 pep = PEP(B);
-#nep = PNEP(B, Vector{MatrixAndFunction{Matrix{Float64}}}(0))
-emptynep=SPMF_NEP(2)
+emptynep=LowRankFactorizedNEP(2) # Create empty lowrankNEP
 nep=SumNEP(pep,emptynep)
 
 Sigma = [-10.0-2im, 10-2im, 10+2im, -10+2im]

--- a/test/nleigs/nleigs_basic.jl
+++ b/test/nleigs/nleigs_basic.jl
@@ -17,7 +17,10 @@ include("../../src/nleigs/method_nleigs.jl")
 
 n = 2
 B = Vector{Matrix{Float64}}([[1 3; 5 6], [3 4; 6 6], [1 0; 0 1]])
-nep = PNEP(B, Vector{MatrixAndFunction{Matrix{Float64}}}(0))
+pep = PEP(B);
+#nep = PNEP(B, Vector{MatrixAndFunction{Matrix{Float64}}}(0))
+emptynep=SPMF_NEP(2)
+nep=SumNEP(pep,emptynep)
 
 Sigma = [-10.0-2im, 10-2im, 10+2im, -10+2im]
 

--- a/test/nleigs/nleigs_basic.jl
+++ b/test/nleigs/nleigs_basic.jl
@@ -20,9 +20,9 @@ include("../../src/nleigs/method_nleigs.jl")
 
 n = 2
 B = Vector{Matrix{Float64}}([[1 3; 5 6], [3 4; 6 6], [1 0; 0 1]])
-pep = PEP(B);
-emptynep=LowRankFactorizedNEP(2) # Create empty lowrankNEP
-nep=SumNEP(pep,emptynep)
+pep = PEP(B)
+emptynep = LowRankFactorizedNEP(Float64, 2) # Create empty low rank NEP
+nep = SumNEP(pep, emptynep)
 
 Sigma = [-10.0-2im, 10-2im, 10+2im, -10+2im]
 

--- a/test/nleigs/nleigs_gun_variant_p.jl
+++ b/test/nleigs/nleigs_gun_variant_p.jl
@@ -5,9 +5,11 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../../src/nleigs"))
 
     using NEPCore
     using NEPTypes
+    using NleigsTypes
     using Gallery
     using IterativeSolvers
     using Base.Test

--- a/test/nleigs/nleigs_gun_variant_r1.jl
+++ b/test/nleigs/nleigs_gun_variant_r1.jl
@@ -5,9 +5,11 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../../src/nleigs"))
 
     using NEPCore
     using NEPTypes
+    using NleigsTypes
     using Gallery
     using IterativeSolvers
     using Base.Test

--- a/test/nleigs/nleigs_gun_variant_r2.jl
+++ b/test/nleigs/nleigs_gun_variant_r2.jl
@@ -5,9 +5,11 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../../src/nleigs"))
 
     using NEPCore
     using NEPTypes
+    using NleigsTypes
     using Gallery
     using IterativeSolvers
     using Base.Test

--- a/test/nleigs/nleigs_gun_variant_s.jl
+++ b/test/nleigs/nleigs_gun_variant_s.jl
@@ -5,9 +5,11 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../../src/nleigs"))
 
     using NEPCore
     using NEPTypes
+    using NleigsTypes
     using Gallery
     using IterativeSolvers
     using Base.Test

--- a/test/nleigs/nleigs_nep_types.jl
+++ b/test/nleigs/nleigs_nep_types.jl
@@ -5,9 +5,11 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../../src/nleigs"))
 
     using NEPCore
     using NEPTypes
+    using NleigsTypes
     using Gallery
     using IterativeSolvers
     using Base.Test

--- a/test/nleigs/nleigs_nep_types.jl
+++ b/test/nleigs/nleigs_nep_types.jl
@@ -25,16 +25,18 @@ f = [λ -> λ^2]
 
 Sigma = [-10.0-2im, 10-2im, 10+2im, -10+2im]
 
-pnep = PNEP(B, [MatrixAndFunction(C[1], f[1])])
+pep = PEP(B)
+spmf = LowRankFactorizedNEP([MatrixAndFunction(C[1], f[1])])
+sumnep = SumNEP(pep, spmf)
 
-@testset "NLEIGS: PNEP" begin
-    @time X, lambda = nleigs(pnep, Sigma, maxit=10, v=ones(n), blksize=5)
-    nleigs_verify_lambdas(4, pnep, X, lambda)
+@testset "NLEIGS: SumNEP" begin
+    @time X, lambda = nleigs(sumnep, Sigma, maxit=10, v=ones(n), blksize=5)
+    nleigs_verify_lambdas(4, sumnep, X, lambda)
 end
 
 @testset "NLEIGS: SPMF_NEP" begin
     spmf_nep = SPMF_NEP([B; C], [λ -> 1; λ -> λ; λ -> λ^2])
-    @test_warn "create the problem as a NEPTypes.PNEP instead of a NEPTypes.SPMF_NEP" begin
+    @test_warn "create the problem as a" begin
         @time X, lambda = nleigs(spmf_nep, Sigma, maxit=10, v=ones(n), blksize=5)
         nleigs_verify_lambdas(4, spmf_nep, X, lambda)
     end
@@ -46,8 +48,8 @@ end
 
 # implement a few methods used by the solver
 import NEPCore.compute_Mder, NEPCore.compute_Mlincomb, Base.size
-compute_Mder(::CustomNLEIGSNEP, λ::Number) = compute_Mder(pnep, λ)
-compute_Mlincomb(::CustomNLEIGSNEP, λ::Number, x) = compute_Mlincomb(pnep, λ, x)
+compute_Mder(::CustomNLEIGSNEP, λ::Number) = compute_Mder(sumnep, λ)
+compute_Mlincomb(::CustomNLEIGSNEP, λ::Number, x) = compute_Mlincomb(sumnep, λ, x)
 size(::CustomNLEIGSNEP, _) = n
 
 @testset "NLEIGS: Custom NEP type" begin

--- a/test/nleigs/nleigs_particle_variant_r2.jl
+++ b/test/nleigs/nleigs_particle_variant_r2.jl
@@ -5,9 +5,11 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../../src/nleigs"))
 
     using NEPCore
     using NEPTypes
+    using NleigsTypes
     using Gallery
     using IterativeSolvers
     using Base.Test

--- a/test/nleigs/nleigs_particle_variant_s.jl
+++ b/test/nleigs/nleigs_particle_variant_s.jl
@@ -5,9 +5,11 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../../src/nleigs"))
 
     using NEPCore
     using NEPTypes
+    using NleigsTypes
     using Gallery
     using IterativeSolvers
     using Base.Test

--- a/test/nleigs/nleigs_scalar.jl
+++ b/test/nleigs/nleigs_scalar.jl
@@ -7,9 +7,11 @@ if !isdefined(:global_modules_loaded)
     workspace()
 
     push!(LOAD_PATH, string(@__DIR__, "/../../src"))
+    push!(LOAD_PATH, string(@__DIR__, "/../../src/nleigs"))
 
     using NEPCore
     using NEPTypes
+    using NleigsTypes
     using Gallery
     using IterativeSolvers
     using Base.Test

--- a/test/nleigs/nleigs_scalar.jl
+++ b/test/nleigs/nleigs_scalar.jl
@@ -24,9 +24,7 @@ as_matrix(x::Number) = (M = Matrix{eltype(x)}(1,1); M[1] = x; M)
 n = 1
 C = [as_matrix(0.2), as_matrix(-0.6)]
 f = [λ -> sqrtm(λ), λ -> sin.(2*λ)]
-c1 = MatrixAndFunction(C[1], f[1])
-c2 = MatrixAndFunction(C[2], f[2])
-nep = PNEP(Vector{Matrix{Float64}}(0), [c1, c2])
+nep = SPMF_NEP([C[1], C[2]], [f[1], f[2]])
 
 Sigma = complex([0.01, 4])
 

--- a/test/nleigs/particle_test_utils.jl
+++ b/test/nleigs/particle_test_utils.jl
@@ -22,7 +22,7 @@ function particle_init(interval)
 
     # options
     srand(5)
-    v = randn(nep.n)
+    v = randn(size(nep, 1))
     nodes = linspace(xmin + 0im, xmax + 0im, 11)
     nodes = collect(nodes[2:2:end])
 
@@ -152,7 +152,7 @@ function particle_nep(interval)
 
     # finally assemble nep instance; note that the nonlinear matrices are defined by their LU factors only
     C = map(k -> LowRankMatrixAndFunction(similar(SL[k], 0, 0), SL[k], SU[k], f[k]), 1:length(f))
-    nep = PNEP(B, C)
+    nep = SumNEP(PEP(B), LowRankFactorizedNEP(C))
 
     return nep, brpts, U0
 end


### PR DESCRIPTION
Illustration how  `SUMNEP` type can be added.  @maxbennedich, do you think this could be integrated with your `PNEP` type?  This example shows at least how one can create a sum of SPMF and PEP:
```
  julia> nep1=PEP([randn(2,2),randn(2,2),randn(2,2)])
  julia> A0=[1 3; 4 5]; A1=[3 4; 5 6];
  julia> id_op=S -> eye(S)
  julia> exp_op=S -> expm(S)
  julia> nep2=SPMF_NEP([A0,A1],[id_op,exp_op]);
  julia> sumnep=SumNEP(nep1,nep2);
```