### PR TITLE
Faster SPMF computation

### DIFF
--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -259,7 +259,7 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
 
     function compute_Mder(nep::SPMF_NEP,λ::Number,i::Integer=0)
         if i == 0
-            x = map(i -> nep.fi[i](reshape([λ],1,1))[1], 1:length(nep.As))
+            x = map(i -> nep.fi[i](reshape([λ],1,1))[1], 1:length(nep.fi))
 
             if isempty(nep.As)
                 Z = copy(nep.Zero)

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -266,9 +266,7 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
                 n = length(Z.nzval)
                 @inbounds for a = 2:length(nep.As)
                     x = T(nep.fi[a](reshape([λ],1,1))[1])
-                    for i = 1:n
-                        Z.nzval[i] += nep.As[a].nzval[i] * x
-                    end
+                    Z.nzval .+= nep.As[a].nzval .* x
                 end
                 return Z
             end

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -117,7 +117,12 @@ for matrices in the standard matrix function sense.
 
          # Sparse zero matrix to be used for sparse matrix creation
          Zero::SparseMatrixCSC
+         As::Vector{SparseMatrixCSC{Complex128,Int}}  # A matrices with sparsity pattern of all matrices combined
     end
+
+    SPMF_NEP(n, A, fi, Schur_factorize_before, Zero) =
+        SPMF_NEP(n, A, fi, Schur_factorize_before, Zero, Vector{SparseMatrixCSC{Complex128,Int}}())
+
 """
      SPMF_NEP(AA,fii,Schur_fact=false)
 
@@ -165,18 +170,37 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
          end
 
 
+         # TODO: make this parametric instead of hardcoded complex?
+         T = complex(eltype(AA[1]))
+         As = Vector{SparseMatrixCSC{T,Int}}()
+
          if (issparse(AA[1]))
-             Zero=spones(AA[1]);
+             # Merge the sparsity pattern of all matrices without dropping any zeros
+             Zero=spones(AA[1]);            # Julia 0.7+: Zero = LinearAlgebra.fillstored!(copy(AA[1]), 1)
              for i=2:size(AA,1)
-                 Zero=Zero+spones(AA[i]);
+                 Zero=Zero+spones(AA[i]);   # Julia 0.7+: Zero += LinearAlgebra.fillstored!(copy(AA[i]), 1)
              end
-             Zero=(Zero*1im)*0
+             Zero = T.(Zero)
+             Zero.nzval[:] .= T(0)
+
+             # Create a copy of each matrix with the sparsity pattern of all matrices combined
+             @inbounds for A in AA
+                 S = copy(Zero)
+
+                 for col = 1:size(A, 2)
+                    for j in nzrange(A, col)
+                        S[A.rowval[j], col] = A.nzval[j]
+                    end
+                 end
+
+                 push!(As, S)
+             end
          else
              Zero=zeros(n,n)
          end
 
 
-         this=SPMF_NEP(n,AA,fii,Schur_fact,Zero);
+         this=SPMF_NEP(n,AA,fii,Schur_fact,Zero,As);
          return this
     end
     function SPMF_NEP(n) # Create an empty NEP of size n x n
@@ -228,11 +252,26 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
     end
     function compute_Mder(nep::SPMF_NEP,λ::Number,i::Integer=0)
         if (i==0)
-            Z=copy(nep.Zero)
-            for i=1:size(nep.A,1)
-                Z=Z+nep.A[i]*nep.fi[i](reshape([λ],1,1))[1]
+            if isempty(nep.As)
+                Z=copy(nep.Zero)
+                for i=1:size(nep.A,1)
+                    Z=Z+nep.A[i]*nep.fi[i](reshape([λ],1,1))[1]
+                end
+                return Z
+            else
+                T = Complex{Float64}
+                x = T(nep.fi[1](reshape([λ],1,1))[1])
+                Z = copy(nep.As[1])
+                Z.nzval .*= x
+                n = length(Z.nzval)
+                @inbounds for a = 2:length(nep.As)
+                    x = T(nep.fi[a](reshape([λ],1,1))[1])
+                    for i = 1:n
+                        Z.nzval[i] += nep.As[a].nzval[i] * x
+                    end
+                end
+                return Z
             end
-            return Z
         else
             # This is typically slow for i>1 (can be optimized by
             # treating the SPMF-terms individually)

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -126,13 +126,17 @@ for matrices in the standard matrix function sense.
         SPMF_NEP(n, A, fi, Schur_factorize_before, Zero, Vector{SparseMatrixCSC{Complex128,Int}}())
 
 """
-     SPMF_NEP(AA,fii,Schur_fact=false)
+     SPMF_NEP(AA, fii, Schur_fact = false, use_sparsity_pattern = true)
 
 Creates a SPMF_NEP consisting of matrices `AA` and functions `fii`. `fii` must
 be an array of functions defined for matrices. `AA` is an array of
 matrices. `Schur_fact` specifies if the computation of `compute_MM` should be
 done by first pre-computing a Schur-factorization (which can be faster).
-
+If `use_sparsity_pattern` is true, and the `AA` matrices are sparse, each
+matrix will be stored with a sparsity pattern matching the union of all `AA`
+matrices. This leads to more efficient calculation of `compute_Mder`. If
+the sparsity patterns are completely or mostly distinct, it may be more
+efficient to set this flag to false.
 
 ```julia-repl
 julia> A0=[1 3; 4 5]; A1=[3 4; 5 6];
@@ -145,7 +149,8 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
  0.0  0.0
 ```
 """
-     function SPMF_NEP(AA::Vector{<:AbstractMatrix}, fii::Vector{<:Function}, Schur_fact = false)
+     function SPMF_NEP(AA::Vector{<:AbstractMatrix}, fii::Vector{<:Function},
+            Schur_fact = false, use_sparsity_pattern = true)
 
          if (size(AA,1)==0)
              return SPMF_NEP(0); # Create empty SPMF_NEP.
@@ -176,11 +181,11 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
          T = complex(eltype(AA[1]))
          As = Vector{SparseMatrixCSC{T,Int}}()
 
-         if (issparse(AA[1]))
+         if use_sparsity_pattern && issparse(AA[1])
              # Merge the sparsity pattern of all matrices without dropping any zeros
-             Zero=spones(AA[1]);            # Julia 0.7+: Zero = LinearAlgebra.fillstored!(copy(AA[1]), 1)
-             for i=2:size(AA,1)
-                 Zero=Zero+spones(AA[i]);   # Julia 0.7+: Zero += LinearAlgebra.fillstored!(copy(AA[i]), 1)
+             Zero = spones(AA[1])           # Julia 0.7+: Zero = LinearAlgebra.fillstored!(copy(AA[1]), 1)
+             for i = 2:size(AA,1)
+                 Zero += spones(AA[i])      # Julia 0.7+: Zero += LinearAlgebra.fillstored!(copy(AA[i]), 1)
              end
              Zero = T.(Zero)
              Zero.nzval[:] .= T(0)
@@ -253,11 +258,11 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
         return Z
     end
     function compute_Mder(nep::SPMF_NEP,λ::Number,i::Integer=0)
-        if (i==0)
+        if i == 0
             if isempty(nep.As)
-                Z=copy(nep.Zero)
+                Z = copy(nep.Zero)
                 for i=1:size(nep.A,1)
-                    Z=Z+nep.A[i]*nep.fi[i](reshape([λ],1,1))[1]
+                    Z += nep.A[i] * nep.fi[i](reshape([λ],1,1))[1]
                 end
                 return Z
             else

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -263,7 +263,6 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
                 x = T(nep.fi[1](reshape([λ],1,1))[1])
                 Z = copy(nep.As[1])
                 Z.nzval .*= x
-                n = length(Z.nzval)
                 @inbounds for a = 2:length(nep.As)
                     x = T(nep.fi[a](reshape([λ],1,1))[1])
                     Z.nzval .+= nep.As[a].nzval .* x

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -256,24 +256,25 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
         end
         return Z
     end
+
     function compute_Mder(nep::SPMF_NEP,λ::Number,i::Integer=0)
         if i == 0
+            x = map(i -> nep.fi[i](reshape([λ],1,1))[1], 1:length(nep.As))
+
             if isempty(nep.As)
                 Z = copy(nep.Zero)
                 for i=1:size(nep.A,1)
-                    Z += nep.A[i] * nep.fi[i](reshape([λ],1,1))[1]
+                    Z += nep.A[i] * x[i]
                 end
                 return Z
             else
-                x = map(i -> nep.fi[i](reshape([λ],1,1))[1], 1:length(nep.As))
-
                 # figure out the return type, as the greatest type of all input
                 Tx = mapreduce(eltype, promote_type, x)
                 TA = mapreduce(eltype, promote_type, nep.As)
                 T = promote_type(Tx, TA)
 
                 Z = SparseMatrixCSC(nep.As[1].m, nep.As[1].n, nep.As[1].colptr, nep.As[1].rowval, convert.(T, nep.As[1].nzval .* x[1]))
-                @inbounds for i = 2:length(nep.As)
+                for i = 2:length(nep.As)
                     Z.nzval .+= nep.As[i].nzval .* x[i]
                 end
 


### PR DESCRIPTION
There seems to be a bug in the current implementation of the sparsity pattern `Zero` matrix for SPMF NEPs. This PR is a suggestion for a fix, and is the fastest solution I've come up with for summing sparse matrices. It works by first determining the sparsity pattern of all matrices combined, and then storing each matrix using that combined sparsity pattern. This makes the multiply/addition step very efficient since it can be done without any memory allocation at all, by just summing the `nzval` vectors.

For the Gun problem (4 matrices), this makes `compute_Mder` 4x faster than the current implementation, and uses 6x less memory. For the Particle problem, there's a huge improvement, since the problem consists of 81 nonlinear matrices, all with identical sparsity pattern, making `compute_Mder` ~70x faster. (This was the main motivation for this PR, since `compute_Mder` is a performance bottleneck for that problem.)

For matrices with very different sparsity patterns, there is a risk that this change has a negative impact, since all matrices would be stored with the combined sparsity pattern and thus use more space and operations. One could imagine making this method optional (a flag when creating the NEP), or calculating the overhead by dividing the combined `nnz` with the average matrix `nnz` and don't use this method if the factor is larger than, say, 3.

This PR is not quite ready to be merged yet, as I wanted to get some feedback first if this change makes sense, and if there are any problems, or improvements that can be made. If we decide to go ahead with this PR, what remains to be done is:

- Not hard code the type Complex128
- Optional sparsity pattern?
- Support sparsity pattern in other compute methods?
- Use this method for all matrices of `SPMFSumNEP`s (e.g. PEP + SPMF)?