### PR TITLE
compute_eigvec_from_eigval_lopcg updates

### DIFF
--- a/src/NEPSolver.jl
+++ b/src/NEPSolver.jl
@@ -119,14 +119,14 @@ Executes z if displaylevel>1.
 
         # initialization
         normalize!(x); v=A(x); ρ=x⋅v; q=zeros(ComplexF64,size(nep,1));
-        k=1; err=one(eltype(x)); tol=1e-12
+        k=1; err=one(real(eltype(x))); tol=1e-12
         while (k<maxit)&&(err>tol)
           g = v-ρ*x;
           xgq = [x -g q]
           aa = xgq' * [v -A(g) A(q)];
           aa = (aa+aa')/2;
           mm = xgq' * xgq;
-          mm = (mm+mm')/2; # why is this needed?
+          mm = (mm+mm')/2; # ensure exact symmetry (it's should be symmetric already, but there may be roundoff errors)
 
           D,V = eigen(aa,mm);
           absD=abs.(D);

--- a/src/NEPSolver.jl
+++ b/src/NEPSolver.jl
@@ -118,18 +118,21 @@ Executes z if displaylevel>1.
         A=v->compute_Mlincomb(nept,complex(conj(λ)),compute_Mlincomb(nep,complex(λ),complex(v)))
 
         # initialization
-        x/=norm(x); v=A(x); ρ=x⋅v; q=zeros(ComplexF64,size(nep,1));
-        k=1; err=1; tol=1e-12
+        normalize!(x); v=A(x); ρ=x⋅v; q=zeros(ComplexF64,size(nep,1));
+        k=1; err=one(eltype(x)); tol=1e-12
         while (k<maxit)&&(err>tol)
-          g=v-ρ*x;
-          aa=[x -g q]'*[v -A(g) A(q)]; aa=(aa+aa')/2;
-          mm=[x -g q]'*[x -g q]; mm=(mm+mm')/2;
+          g = v-ρ*x;
+          xgq = [x -g q]
+          aa = xgq' * [v -A(g) A(q)];
+          aa = (aa+aa')/2;
+          mm = xgq' * xgq;
+          mm = (mm+mm')/2; # why is this needed?
 
           D,V = eigen(aa,mm);
           absD=abs.(D);
           ii=argmin([isnan(x) ? Inf : x for x in absD]);
           ρ=D[ii]; δ=V[:,ii]; q=[-g q]*δ[2:end];
-          x=δ[1]*x+q; x/=norm(x); v=A(x); k+=1
+          x=δ[1]*x+q; normalize!(x); v=A(x); k+=1
           err=errmeasure(λ,x)
         end
         return x

--- a/test/compute_eigvec_from_eigval_lopcg.jl
+++ b/test/compute_eigvec_from_eigval_lopcg.jl
@@ -2,6 +2,7 @@ using NonlinearEigenproblems.NEPCore
 using NonlinearEigenproblems.NEPSolver
 using NonlinearEigenproblems.NEPTypes
 using NonlinearEigenproblems.Gallery
+using Random
 using Test
 
 # explicit import needed for overloading functions from packages

--- a/test/compute_eigvec_from_eigval_lopcg.jl
+++ b/test/compute_eigvec_from_eigval_lopcg.jl
@@ -9,7 +9,9 @@ import NonlinearEigenproblems.NEPCore.compute_Mlincomb
 
 @testset "compute eigvec lopcg" begin
     @testset "dep0_sparse" begin
-        nep=nep_gallery("dep0_sparse",100);nept=DEP([nep.A[1]',nep.A[2]'],nep.tauv);
+        nep = nep_gallery("dep0_sparse", 100);
+        nept = DEP([copy(nep.A[1]'), copy(nep.A[2]')], nep.tauv);
+        Random.seed!(13) # this results in a good start vector
         λ,Q,err = iar(nep,maxit=100,Neig=2,σ=1.0,γ=1,displaylevel=0,check_error_every=1);
         v=compute_eigvec_from_eigval_lopcg(nep,nept,λ[1]);
         errormeasure=default_errmeasure(nep);
@@ -17,8 +19,8 @@ import NonlinearEigenproblems.NEPCore.compute_Mlincomb
     end
 
     @testset "pep0" begin
-        nep=nep_gallery("pep0",100);
-        nept=PEP([nep.A[1]',nep.A[2]',nep.A[3]'])
+        nep = nep_gallery("pep0", 100);
+        nept = PEP([copy(nep.A[1]'), copy(nep.A[2]'), copy(nep.A[3]')])
         λ,Q,err = iar(nep,maxit=100,Neig=2,σ=1.0,γ=1,displaylevel=0,check_error_every=1);
         v=compute_eigvec_from_eigval_lopcg(nep,nept,λ[1]);
         errormeasure=default_errmeasure(nep);

--- a/test/infbilanczos.jl
+++ b/test/infbilanczos.jl
@@ -8,7 +8,7 @@ using LinearAlgebra
 
 @testset "Infbilanczos σ=0" begin
     nep=nep_gallery("qdep0");
-    nept=SPMF_NEP([nep.A[1]',nep.A[2]',nep.A[3]'],nep.fi)
+    nept=SPMF_NEP([copy(nep.A[1]'), copy(nep.A[2]'), copy(nep.A[3]')], nep.fi)
     n=size(nep,1);
 
     m=40;

--- a/test/newton_test.jl
+++ b/test/newton_test.jl
@@ -64,7 +64,7 @@ using LinearAlgebra
     @testset "Rayleigh Function Iteration" begin
         println("Running two-sided RFI on random dep")
         nepd=nep_gallery("dep0")
-        nept=DEP([nepd.A[1]',nepd.A[2]'],copy(nepd.tauv))
+        nept=DEP([copy(nepd.A[1]'), copy(nepd.A[2]')],copy(nepd.tauv))
 
         n=size(nepd,1);
         u0=ones(n);


### PR DESCRIPTION
As described in issue #65 

With these fixes, the test runs in **0.7 s** and uses **548 MB** memory on Julia 1.0 on my system. Compare with **3.1 s** and **4.76 GB** without this fix, and **1.3 s** and **880 MB** with the old version in Julia 0.6.