### PR TITLE
Proj_NEP update

### DIFF
--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -833,20 +833,14 @@ julia> compute_Mder(nep,3.0)[1:2,1:2]
         T=eltype(nep.V);
 
         T_sub = SubArray{T,2,Array{T,2},Tuple{UnitRange{Int64},UnitRange{Int64}},false}
-        #T_sub = SubArray{T,2}
         B = Vector{T_sub}(undef,m);
         k=size(V,2);
-        println("typeof=",typeof(B))
         for i=1:m
-            #println("i=",i, " k=",k," sz=", size(copy(W')*nep.orgnep_Av[i]*V));
             nep.projnep_B_mem[i][1:k,1:k]=copy(W')*nep.orgnep_Av[i]*V;
-            Btmp=view(nep.projnep_B_mem[i],1:k,1:k);
-            B[i]=Btmp
-
+            B[i]=view(nep.projnep_B_mem[i],1:k,1:k);
         end
-        println("eltype(W):",eltype(W));
-        println("eltype(nep.W):",eltype(nep.W));
 
+        # Save it. Is it really necessary to store?
         nep.W[:,1:size(W,2)]=W;
         nep.V[:,1:size(V,2)]=V;
         # Keep the sequence of functions for SPMFs

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -718,12 +718,14 @@ Proj_NEP represents a projected NEP
     abstract type Proj_NEP <: NEP end
 
 """
-    pnep=create_proj_NEP(orgnep::ProjectableNEP)
+    pnep=create_proj_NEP(orgnep::ProjectableNEP[,maxsize [,T]])
 
 Create a NEP representing a projected problem. The projection is defined
-as the problem ``N(λ)=W^HM(λ)V``
-where ``M(λ)`` is represented by `orgnep`. Use
-`set_projectionmatrices!()` to specify projection matrices
+as the problem ``N(λ)=W^HM(λ)V`` where ``M(λ)`` is represented by `orgnep`.
+The optional parameter `maxsize` determines how large the projected
+problem can be and `T` determines which Number type to use (default `ComplexF64`).
+These are needed for memory allocation reasons.
+Use `set_projectionmatrices!()` to specify projection matrices
 ``V`` and ``W``.
 """
     function create_proj_NEP(orgnep::ProjectableNEP)

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -727,7 +727,7 @@ where ``M(λ)`` is represented by `orgnep`. Use
     #            error("Projection of this NEP is not available");
     #        end
     #    end
-    function create_proj_NEP(orgnep::AbstractSPMF)
+    function create_proj_NEP(orgnep::AbstractSPMF,sz::Int)
          return Proj_SPMF_NEP(orgnep);
     end
 

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -762,8 +762,6 @@ Use `set_projectionmatrices!()` to specify projection matrices
 
     mutable struct Proj_SPMF_NEP <: Proj_NEP
         orgnep::AbstractSPMF
-        V::Matrix
-        W::Matrix
         nep_proj::SPMF_NEP; # An instance of the projected NEP
         orgnep_Av::Vector
         orgnep_fv::Vector
@@ -790,8 +788,6 @@ Use `set_projectionmatrices!()` to specify projection matrices
                 error("The given array should be a vector but is of size ", size(this.orgnep_fv), ".")
             end
 
-            this.V=zeros(T,size(this.orgnep,1),maxsize)
-            this.W=zeros(T,size(this.orgnep,1),maxsize)
             this.projnep_B_mem=Vector{Matrix{T}}(undef,size(this.orgnep_fv,1));
             for k=1:size(this.orgnep_fv,1)
                 this.projnep_B_mem[k]=zeros(T,maxsize,maxsize);
@@ -832,19 +828,16 @@ julia> compute_Mder(nep,3.0)[1:2,1:2]
         ## Sets the left and right projected basis and computes
         ## the underlying projected NEP
         m = size(nep.orgnep_Av,1);
-        T=eltype(nep.V);
+        T=eltype(eltype(nep.projnep_B_mem));
 
         T_sub = SubArray{T,2,Array{T,2},Tuple{UnitRange{Int64},UnitRange{Int64}},false}
-        B = Vector{T_sub}(undef,m);
+        B = Vector{T_sub}(undef,m); # The coeff matrices for the SPMF_NEP created in the end
         k=size(V,2);
         for i=1:m
             nep.projnep_B_mem[i][1:k,1:k]=copy(W')*nep.orgnep_Av[i]*V;
             B[i]=view(nep.projnep_B_mem[i],1:k,1:k);
         end
 
-        # Save it. Is it really necessary to store?
-        nep.W[:,1:size(W,2)]=W;
-        nep.V[:,1:size(V,2)]=V;
         # Keep the sequence of functions for SPMFs
         nep.nep_proj=SPMF_NEP(B,nep.orgnep_fv)
     end

--- a/src/inner_solver.jl
+++ b/src/inner_solver.jl
@@ -104,7 +104,11 @@ end
 function inner_solve(TT::Type{IARChebInnerSolver},T_arit::DataType,nep::NEPTypes.Proj_NEP;σ=0,Neig=10,kwargs...)
     if isa(nep.orgnep, NEPTypes.DEP)
         AA = get_Av(nep)
-        BB = Vector{eltype(AA)}(undef, size(AA,1)-1)
+        TT = eltype(AA);
+        if (TT  <: SubArray) # If it's better to transform to store in Matrix instead
+            TT=Matrix{eltype(AA[1])};
+        end
+        BB = Vector{TT}(undef, size(AA,1)-1)
         for i = 1:(size(AA,1)-1)
             BB[i] = AA[1]\AA[1+i]
         end

--- a/src/method_jd.jl
+++ b/src/method_jd.jl
@@ -100,7 +100,7 @@ function jd_betcke(::Type{T},
     # More allocations and preparations
     pk::Vector{T} = zeros(T,n)
     s_memory::Vector{T} = zeros(T,n)
-    proj_nep = create_proj_NEP(nep)
+    proj_nep = create_proj_NEP(nep,maxit,T)
     dummy_vector::Vector{T} = zeros(T,maxit+1)
 
     V_memory::Matrix{T} = zeros(T, size(nep,1), maxit+1)

--- a/src/method_jd.jl
+++ b/src/method_jd.jl
@@ -340,7 +340,7 @@ function jd_effenberger_inner!(::Type{T},
     newton_step::Vector{T} = Vector{T}(rand(n+m))
     pk::Vector{T} = zeros(T,n+m)
     s_memory::Vector{T} = zeros(T,maxit+1-nrof_its)
-    proj_nep = jd_create_proj_NEP(target_nep)
+    proj_nep = jd_create_proj_NEP(target_nep,maxit+1-nrof_its,T)
     dummy_vector::Vector{T} = zeros(T,maxit+1-nrof_its)
 
     V_memory[:,1] = u
@@ -529,14 +529,14 @@ mutable struct JD_Inner_Effenberger_Projected_NEP <: Proj_NEP
     V2
     W1
     W2
-    function JD_Inner_Effenberger_Projected_NEP(deflated_nep::DeflatedNEP)
-        org_proj_nep = create_proj_NEP(deflated_nep.orgnep)
+    function JD_Inner_Effenberger_Projected_NEP(deflated_nep::DeflatedNEP,maxsize,T)
+        org_proj_nep = create_proj_NEP(deflated_nep.orgnep,maxsize,T)
         this = new(deflated_nep, org_proj_nep, deflated_nep.V0, deflated_nep.S0)
         return this
     end
 end
-jd_create_proj_NEP(deflated_nep::DeflatedNEP) = JD_Inner_Effenberger_Projected_NEP(deflated_nep::DeflatedNEP)
-jd_create_proj_NEP(nep::ProjectableNEP) = create_proj_NEP(nep)
+jd_create_proj_NEP(deflated_nep::DeflatedNEP,maxsize,T) = JD_Inner_Effenberger_Projected_NEP(deflated_nep::DeflatedNEP,maxsize,T)
+jd_create_proj_NEP(nep::ProjectableNEP,maxsize,T) = create_proj_NEP(nep,maxsize,T)
 
 function set_projectmatrices!(nep::JD_Inner_Effenberger_Projected_NEP, W, V)
     n = size(nep.X,1)

--- a/src/method_nlar.jl
+++ b/src/method_nlar.jl
@@ -154,7 +154,7 @@ function nlar(::Type{T},
         m = 0; #Number of converged eigenvalues
         k = 1;
 
-        proj_nep = create_proj_NEP(nep);
+        proj_nep = create_proj_NEP(nep,maxit,T);
 
         local linsolver::LinSolver = linsolvercreator(nep,σ);
 

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -84,7 +84,7 @@ function tiar(
 
     local pnep::NEP;
     if (proj_solve)
-        pnep=create_proj_NEP(nep);
+        pnep=create_proj_NEP(nep,maxit,T);
     end
 
     k=1; conv_eig=0;


### PR DESCRIPTION
This is a preparation for #59 where we want to eventually extend projected problems. This PR changes the storage of the `Proj_SPMF_NEP`. For memory reasons the projected NEP is created from the `pnep.projnep_B_mem` which is an vector of (large) matrices. The projected problems are created as SubArrays of this, when `set_proj_matrices!` is called.

This required changes in `nlar`, `tiar`, `jd`. 

Based on the benchmark report from travis, this PR creates a slight regression in nlar and jd, but I think we will take this back once we actually implement an `extend_proj_matrices!`: 
Before PR:
```
  Nonlinear Arnoldi                                          59.2 s    12.7 GiB
  Jacobi–Davidson                                            1.99 s     460 MiB
```
After PR:
```
  Nonlinear Arnoldi                                          64.5 s    13.2 GiB
  Jacobi–Davidson                                            2.02 s     467 MiB
```
