### PR TITLE
Logging

### DIFF
--- a/test/nleigs/nleigs_basic.jl
+++ b/test/nleigs/nleigs_basic.jl
@@ -22,21 +22,21 @@ function nleigs_basic()
     end
 
     @bench @testset "Non-convergent linearization" begin
-        @test_logs (:warn, r".*Linearization not converged.*") begin
+        @test_logs (:warn, r".*Linearization not converged.*") match_mode = :any begin
             @time lambda, X = nleigs(pep, Σ, maxit=10, v=ones(n).+0im, maxdgr=5, blksize=5)
             nleigs_verify_lambdas(4, pep, X, lambda)
         end
     end
 
     @bench @testset "Non-convergent linearization (static)" begin
-        @test_logs (:warn, r".*Linearization not converged.*") begin
+        @test_logs (:warn, r".*Linearization not converged.*") match_mode = :any begin
             @time lambda, X = nleigs(pep, Σ, maxit=10, v=ones(n).+0im, maxdgr=5, blksize=5, static=true)
             nleigs_verify_lambdas(4, pep, X, lambda)
         end
     end
 
     @bench @testset "Non-convergent linearization (return_details)" begin
-        @test_logs (:warn, r".*Linearization not converged.*") begin
+        @test_logs (:warn, r".*Linearization not converged.*") match_mode = :any begin
             @time lambda, X, _ = nleigs(pep, Σ, maxit=5, v=ones(n).+0im, blksize=5, return_details=true)
             nleigs_verify_lambdas(0, pep, X, lambda)
         end

--- a/test/nleigs/nleigs_test_utils.jl
+++ b/test/nleigs/nleigs_test_utils.jl
@@ -3,11 +3,11 @@ using Printf
 
 function nleigs_verify_lambdas(nrlambda, nep::NEP, X, lambda, tol = 1e-5)
     @test length(lambda) == nrlambda
-    @printf("Found %d lambdas:\n", length(lambda))
+    @info "Found $(length(lambda)) lambdas:"
     for i in eachindex(lambda)
         λ = lambda[i]
         nrm = default_errmeasure(nep)(λ, X[:, i])
         @test nrm < tol
-        @printf("λ[%d] = %s (norm = %.3g)\n", i, λ, nrm)
+        @info "λ[$i] = $λ (norm = $(@sprintf("%.3g", nrm)))"
     end
 end


### PR DESCRIPTION
Using logging framework in NLEIGS tests. We could do similarly in other unit tests as well, in order to allow customizing and disabling logging produced by tests.