### PR TITLE
Fix spmf nep keyword arg

### DIFF
--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -133,7 +133,7 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
  0.0  0.0
 ```
 """
-     function SPMF_NEP(AA::Vector{<:AbstractMatrix}, fii::Vector{<:Function},
+     function SPMF_NEP(AA::Vector{<:AbstractMatrix}, fii::Vector{<:Function};
             Schur_fact = false, use_sparsity_pattern = true, check_consistency=false)
 
             T=Float64;

--- a/src/gallery_extra/waveguide/Waveguide.jl
+++ b/src/gallery_extra/waveguide/Waveguide.jl
@@ -43,7 +43,7 @@ function assemble_waveguide_spmf_fd(nx::Integer, nz::Integer, hx, Dxx::SparseMat
         E_j = E_j * (E_j/nz)'
         A[j+nz+3] =  hvcat((2,2), spzeros(ComplexF64,nx*nz,nx*nz), spzeros(ComplexF64,nx*nz, 2*nz), spzeros(ComplexF64,2*nz, nx*nz), E_j)
     end
-    return SPMF_NEP(A,f,pre_Schur_fact)
+    return SPMF_NEP(A,f;Schur_fact=pre_Schur_fact)
 end
 
 

--- a/src/nep_transformations.jl
+++ b/src/nep_transformations.jl
@@ -76,7 +76,7 @@ function shift_and_scale(orgnep::SPMF_NEP;shift=0,scale=1)
         fv[i] = S -> orgfv[i](scale*S + shift*I)
     end
     # create a new SPMF with transformed functions
-    return SPMF_NEP(get_Av(orgnep),fv,orgnep.Schur_factorize_before);
+    return SPMF_NEP(get_Av(orgnep),fv;Schur_fact=orgnep.Schur_factorize_before);
 end
 
 
@@ -143,7 +143,7 @@ function mobius_transform(orgnep::SPMF_NEP;a=1,b=0,c=0,d=1)
         fv[i] = S -> orgfv[i]((a*S + b*I) / (c*S + d*I))
     end
     # create a new SPMF with transformed functions
-    return SPMF_NEP(get_Av(orgnep),fv,orgnep.Schur_factorize_before);
+    return SPMF_NEP(get_Av(orgnep),fv;Schur_fact=orgnep.Schur_factorize_before);
 end
 
 

--- a/test/spmf.jl
+++ b/test/spmf.jl
@@ -22,7 +22,7 @@ using SparseArrays
 
     J = SparseMatrixCSC(1.0I, n, n)
     nep1 = SPMF_NEP([J, A0, A1], fi)
-    nep2 = SPMF_NEP([J, A0, A1], fi, true)
+    nep2 = SPMF_NEP([J, A0, A1], fi; Schur_fact=true)
 
     @bench @testset "compute_MM" begin
 


### PR DESCRIPTION
I did not write the function  `SPMF_NEP` but I think that there was a typo in the keyword arguments. More precisely  `SPMF_NEP` should have `Schur_fact` as keyword argument. It was already like that, but with a typo.

As soon as I fixed this, other tests failed since they where written without setting properly this `Schur_fact` as keyword argument.

I have done the fix in a way that all the tests pass but I am not sure anymore this is the way we want  the function  `SPMF_NEP`, therefore I ask for a review.

As related question: do we really need `Schur_factorize_before` as field in the structure `SPMF_NEP`? If so, is there a way to avoid to pass `Schur_fact` as keyword argument to the function  `SPMF_NEP`? The fact that `Schur_factorize_before` is somehow a field of the structure `SPMF_NEP` and (with a different name) an argument of the function `SPMF_NEP`  confuses me. But I assume I did not fully understood the code.