### PR TITLE
Detect invalid tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,8 +31,9 @@ function runtests()
     end)
 end
 
-function is_test_script(dir::::AbstractString, file::AbstractString)
-    if occursin(r"(?i)\.jl$", file)
+function is_test_script(dir::AbstractString, file::AbstractString)
+    # match files ending in ".jl" and not containing # or ~ (emacs temp files)
+    if occursin(r"(?i)^[^#~]+\.jl$", file)
         src = read(joinpath(dir, file), String)
 
         pos = 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ function runtests()
     report_benchmarks(@testset "All tests" begin
         root = string(@__DIR__)
         tests_to_run = [joinpath(dir, file) for (dir, _, files) in walkdir(root) for file in files
-            if is_test_script(joinpath(dir, file)) && !in(uppercase(file), tests_not_to_run)]
+            if is_test_script(dir, file) && !in(uppercase(file), tests_not_to_run)]
 
         for i = 1:length(tests_to_run)
             file = tests_to_run[i]
@@ -31,9 +31,9 @@ function runtests()
     end)
 end
 
-function is_test_script(file::AbstractString)
+function is_test_script(dir::::AbstractString, file::AbstractString)
     if occursin(r"(?i)\.jl$", file)
-        src = read(file, String)
+        src = read(joinpath(dir, file), String)
 
         pos = 1
         while pos <= length(src)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,9 +38,11 @@ function is_test_script(file::AbstractString)
         pos = 1
         while pos <= length(src)
             expr, pos = Meta.parse(src, pos)
-            if contains_test_macro(expr)
-                return true
+            if expr.head == :incomplete
+                msg = join(map(string, expr.args), "; ")
+                throw(Meta.ParseError("While parsing file $file got invalid expression: $msg"))
             end
+            contains_test_macro(expr) && return true
         end
     end
     return false


### PR DESCRIPTION
Fixes #92. Two updates:

1. While parsing scripts to look for test macros, detect invalid expressions and throw an error instead of ignoring the file
1. Don't try to run tests with names containing # or ~ (emacs temp files)

An invalid test script will now make the build fail immediately, without running any test at all, as can be seen in [this build](https://travis-ci.org/nep-pack/NonlinearEigenproblems.jl/jobs/430986826). Here's what the error message looks like for the invalid SPMF test in #92:
```
All tests: Error During Test at /home/travis/build/nep-pack/NonlinearEigenproblems.jl/test/runtests.jl:20
  Got exception outside of a @test
  Base.Meta.ParseError("While parsing file spmf.jl got invalid expression: incomplete: \"begin\" at none:2 requires end")
  Stacktrace:
   [1] is_test_script(::String, ::String) at /home/travis/build/nep-pack/NonlinearEigenproblems.jl/test/runtests.jl:44
...
```