### PR TITLE
Optimization in compute_Mlincomb(PEP)

### DIFF
--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -1066,23 +1066,21 @@ Returns true/false if the NEP is sparse (if compute_Mder() returns sparse)
         z=zeros(TT,n)
         d=length(nep.A)-1
         k=min(size(V,2),d+1)
+        tmp = Vector{TT}(undef, n)
 
         if iszero(λ)
             for j=0:k-1
-                z[:]+=a[j+1]*factorial(j)*(nep.A[j+1]*V[:,j+1])
+                mul!(tmp, nep.A[j+1], view(V,:,j+1))
+                z .+= a[j+1] .* factorial(j) .* tmp
             end
         else
             for j=0:k-1
                 for i=j:d
-                    z[:]+=a[j+1]*λ^(i-j)*(factorial(i)/factorial(i-j))*(nep.A[i+1]*V[:,j+1])
+                    mul!(tmp, nep.A[i+1], view(V,:,j+1))
+                    z .+= a[j+1] .* λ^(i-j) .* (factorial(i)/factorial(i-j)) .* tmp
                 end
             end
         end
-        return z[:]
+        return z
     end
-
-
-
-
-
 end


### PR DESCRIPTION
@meleg I tried to squeeze a bit more performance out of your optimized compute_Mlincomb(PEP). For the previous implementation (without the fix in this PR), I get the following:
```julia
julia> @btime z1=compute_Mlincomb(nep,λ,V,a);
  20.102 ms (125 allocations: 64.09 MiB)
```
With this update, I get the following:
```julia
julia> @btime z2=compute_Mlincomb(nep,λ,V,a);
  5.423 ms (76 allocations: 3.05 MiB)
```
There were three ideas behind this speedup:

1. Use fusing dots to operate in-place instead of allocating temporary arrays
2. Use `view(V,:,j+1)` instead of `V[:,j+1]` to avoid allocating a new temporary array
3. Use `mul!` with a temporary array to do the matrix-vector multiplication in place

There are a few further optimizations one could make, but I doubt are worthwhile:

1. Handle the first loop iteration separately to populate the `z` vector, to not have to fill it with zeros. This will complicate the code a bit, and I don't think it will make a noticeable difference.
2. If we know that the `A` matrices will always be either full or sparse, we could write optimized code to do the `z` update fully in place. For full matrices, this is quite easy. For sparse matrices, it is trickier, since it will probably require preparing and storing the matrices in a special format for optimal performance. I did this in NLEIGS, by creating a compacted `Vector` of `SparseVector`s (see the construction of `LL` in `get_nleigs_nep(...)` in `method_nleigs.jl` if you're curious). This could probably lead to a substantial speedup for some matrices A, but the code will be a lot more complex, so I doubt it is worth it.