### PR TITLE
SPMF rewrite part 1

### DIFF
--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -115,7 +115,7 @@ for matrices in the standard matrix function sense.
 # Logic behind Ftype:
 #  The eltype(F(λ))=promote_type(eltype(λ),Ftype)
 
-    struct SPMF_NEP_dense{T,Ftype}  <: AbstractSPMF{T}  # T should be a AbstractMatrix
+    struct SPMF_NEP_dense{T<:AbstractMatrix,Ftype}  <: AbstractSPMF{T}  # T should be a AbstractMatrix
         n::Int
         A::Vector{T}   # Array of Array of matrices
         fi::Vector{Function}  # Array of functions
@@ -233,7 +233,7 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
     end
     function SPMF_NEP(n) # Create an empty NEP of size n x n
         Z=zeros(n,n)
-        return SPMF_NEP_dense{AbstractMatrix}(n,Vector{Matrix}(),Vector{Function}(),false);
+        return SPMF_NEP_dense{AbstractMatrix,Complex}}(n,Vector{Matrix}(),Vector{Function}(),false);
     end
     function compute_MM(nep::SPMF_NEP{T,Ftype},S::AbstractMatrix,V::AbstractMatrix) where {T,Ftype}
 

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -262,7 +262,7 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
                 Sd=diag(S);
                 local Fid::Vector{FStype}
                 if (norm(Sd .- Sd[1])==0) # Optimize further if S is a multiple of identity
-                    Fid=nep.fi[i](Sd[1])*ones(T0,p)
+                    Fid=fill(nep.fi[i](Sd[1]),p)
                 else  # Diagonal but not constant
                     Fid0=Vector{Number}(undef,p)
                     for j=1:p
@@ -1044,19 +1044,21 @@ Returns true/false if the NEP is sparse (if compute_Mder() returns sparse)
     	# we need to assume that the elements of a are different than zero.
     	V[:,findall(x->x==0,a)] .= 0
     	a[findall(x->x==0,a)] .= 1
-        local S;
+        local S,TS;
         if (V isa AbstractVector)
             #Vector means just compute matrix vector
             #S=λ # We should use this once #71 is complete
             S=reshape([λ],1,1)
+            TS = eltype(λ)
         else
             # V matrix means compute linear combination of derivatives. Use
             # scaling trick
-       	    S=diagm(0 => λ*ones(eltype(λ),k)) + diagm(-1 => (a[2:k]./a[1:k-1]).*(1:k-1))
+            TS= promote_type(typeof(λ),eltype(a));
+       	    S=diagm(0 => fill(λ,k), -1 => (a[2:k]./a[1:k-1]).*(1:k-1))
         end
 
         # Type logic
-        Fλtype=promote_type(eltype(λ),Ftype);
+        Fλtype=promote_type(TS,Ftype);
         TT=promote_type(Fλtype,eltype(V)); # Return type
 
         z=zeros(TT,n)

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -878,8 +878,10 @@ julia> compute_Mder(nep,3.0)[1:2,1:2]
     # Use delagation to the nep_proj
     compute_MM(nep::Union{Proj_SPMF_NEP},par...)=compute_MM(nep.nep_proj,par...)
     # Use MM to compute Mlincomb for SPMFs
-    compute_Mlincomb(nep::Proj_SPMF_NEP,par...)=
-             compute_Mlincomb(nep.nep_proj,par...)
+    compute_Mlincomb(nep::Proj_SPMF_NEP,λ::Number,V::AbstractVecOrMat)=
+             compute_Mlincomb(nep.nep_proj,λ,V)
+    compute_Mlincomb(nep::Proj_SPMF_NEP,λ::Number,V::AbstractVecOrMat,a::Vector)=
+             compute_Mlincomb(nep.nep_proj,λ,V,a)
     compute_Mder(nep::Union{Proj_SPMF_NEP},λ::Number)=compute_Mder(nep.nep_proj,λ,0)
     compute_Mder(nep::Union{Proj_SPMF_NEP},λ::Number,i::Integer)=compute_Mder(nep.nep_proj,λ,i)
 
@@ -1070,6 +1072,7 @@ Returns true/false if the NEP is sparse (if compute_Mder() returns sparse)
         else
             for i=1:size(nep.A,1)
                 Fi1=nep.fi[i](S)[:,1]; # Get all the scaled derivatives as well
+                VFi1=V*Fi1
                 if (isa(nep.A[i],SubArray) && (eltype(nep.A[i]) != eltype(VFi1)))
                     # https://github.com/JuliaLang/julia/issues/29224
                     z[:] += copy(nep.A[i])*VFi1

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -270,9 +270,9 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
                     end
                     Fid=Vector{FStype}(Fid0);
                 end
-                Fi[:,:]=Diagonal(Fid)
+                Fi .= Diagonal(Fid)
             else
-                Fi[:,:]=ff[i](S);
+                Fi .= ff[i](S);
             end
             mul!(VFi,V,Fi);
             Z[:,:] .+= AA[i]*VFi;
@@ -1061,7 +1061,7 @@ Returns true/false if the NEP is sparse (if compute_Mder() returns sparse)
             # otherwise get a vector of scaled derivatives
             Fi1=(V isa AbstractVector) ? nep.fi[i](S) : nep.fi[i](S)[:,1]
             VFi1=V*Fi1
-            z[:] += nep.A[i]*VFi1
+            z .+= nep.A[i]*VFi1
         end
 
     	return a[1]*z;

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -115,14 +115,14 @@ for matrices in the standard matrix function sense.
 # Logic behind Ftype:
 #  The eltype(F(λ))=promote_type(eltype(λ),Ftype)
 
-    struct SPMF_NEP_dense{T<:AbstractMatrix,Ftype}  <: AbstractSPMF{T}  # T should be a AbstractMatrix
+    struct SPMF_NEP_dense{T<:AbstractMatrix,Ftype}  <: AbstractSPMF{T}
         n::Int
         A::Vector{T}   # Array of Array of matrices
         fi::Vector{Function}  # Array of functions
         Schur_factorize_before::Bool # Tells if you want to do the Schur-factorization
     end
 
-    struct SPMF_NEP_sparse{T,Ftype}  <: AbstractSPMF{T}  # T should be a AbstractMatrix
+    struct SPMF_NEP_sparse{T<:AbstractMatrix,Ftype}  <: AbstractSPMF{T}
          n::Int
          A::Vector{T}   # Array of Array of matrices
          fi::Vector{Function}  # Array of functions

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -183,6 +183,7 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
          T = eltype(AA[1])
          As = Vector{SparseMatrixCSC{T,Int}}()
 
+
          if use_sparsity_pattern && issparse(AA[1])
              # Merge the sparsity pattern of all matrices without dropping any zeros
              Zero = LinearAlgebra.fillstored!(copy(AA[1]), 1)

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -233,15 +233,27 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
         AA=get_Av(nep);
         ff=get_fv(nep);
         m=size(ff,1); n=size(nep,1); p=size(S,1);
-        # Precompute all the fi(S) so we can determine the output type
-        FF=Vector{AbstractMatrix}(undef,m); # Will contain all the fi(S)
-        FStype=promote_type(eltype(S),Ftype)
-        T0=promote_type(eltype(V),eltype(AA[1]),FStype)
+
+        # Type logic including Ftype
+        FStype=promote_type(eltype(S),Ftype) # eltype of f(S)
+        T0=promote_type(eltype(V),eltype(AA[1]),FStype) # Output type
+
+
+        # Always return a dense matrix
+        Z=zeros(T0,n,p);
+
+        # Sum together all the terms in the SPMF: (temporarily disabled)
+        #if (nep.Schur_factorize_before) #Optimize if allowed to factorize before
+        #    (TT, Q, ) = schur(S)  # Currently not used
+        #end
+
+        VFi=Matrix{promote_type(FStype,eltype(V))}(undef,n,p); # Type of V*f(S)
+        local Fi=Matrix{FStype}(undef,p,p);
         for i=1:m
-            local Fi::AbstractMatrix
+            ## Compute Fi=f_i(S) in an optimized way
             if (isdiag(S)) # optimize if S is diagonal
                 Sd=diag(S);
-                local Fid
+                local Fid::Vector{FStype}
                 if (norm(Sd .- Sd[1])==0) # Optimize further if S is a multiple of identity
                     Fid=nep.fi[i](Sd[1])*ones(T0,p)
                 else  # Diagonal but not constant
@@ -249,36 +261,20 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
                     for j=1:p
                         Fid0[j]=nep.fi[i](Sd[j])
                     end
-                    # Find the common type of all the computed values in the vector
-                    Tz=mapreduce(typeof,promote_type,Fid0)
-                    Fid=Vector{Tz}(Fid0);
+                    Fid=Vector{FStype}(Fid0);
                 end
-                Fi=Diagonal(Fid)
+                Fi[:,:]=Diagonal(Fid)
             else
-                Fi=ff[i](S);
+                Fi[:,:]=ff[i](S);
             end
-            FF[i]=Fi;
-            #T0=promote_type(eltype(Fi),T0); # The common type of the matrix function
-        end
-        # Always return a dense matrix
-        Z=zeros(T0,n,p);
-
-        # Sum together all the terms in the SPMF:
-        if (nep.Schur_factorize_before) #Optimize if allowed to factorize before
-            (TT, Q, ) = schur(S)  # Currently not used
-        end
-
-        for i=1:m
-            ## Compute Fi=f_i(S) in an optimized way
-            Fi=FF[i]
-            VFi::Matrix{promote_type(FStype,eltype(V))}=V*Fi;
+            mul!(VFi,V,Fi);
             if (isa(nep.A[i],SubArray) && (eltype(nep.A[i]) != eltype(VFi)))
                 # 2018-09-14: SubArray x Matrix of different types do not work on julia 1.0.0
                 # https://github.com/JuliaLang/julia/issues/29224
                 # Workaround by making a matrix copy.
-                Z[:,:] += copy(nep.A[i])*VFi;
+                Z[:,:] += copy(AA[i])*VFi;
             else
-                Z[:,:] += nep.A[i]*VFi;
+                Z[:,:] .+= AA[i]*VFi;
             end
         end
         return Z

--- a/src/nleigs/NleigsTypes.jl
+++ b/src/nleigs/NleigsTypes.jl
@@ -80,7 +80,7 @@ function compactlu(L, U)
 end
 
 "SPMF with low rank LU factors for each matrix."
-struct LowRankFactorizedNEP{S<:AbstractMatrix{<:Number}} <: AbstractSPMF
+struct LowRankFactorizedNEP{S<:AbstractMatrix{<:Number}} <: AbstractSPMF{AbstractMatrix}
     spmf::SPMF_NEP
     r::Int          # Sum of ranks of matrices
     L::Vector{S}    # Low rank L factors of matrices

--- a/test/compute_types.jl
+++ b/test/compute_types.jl
@@ -290,21 +290,21 @@ end
         B0=randn(3,3); B1=randn(3,3);
         oneop= S-> S;
         sqrop= S-> S^2;
-        spmf_nep=SPMF_NEP([B0,B1],[oneop,sqrop])
+        spmf_nep=SPMF_NEP([B0,B1],[oneop,sqrop],Ftype=Float64)
         push!(testlist,compute_types_metadata(spmf_nep,Float64,true,[],[],[],false, "#1"));
 
         # SPMF 2
         B0=randn(3,3); B1=randn(3,3);
         oneop= S-> 1im*S;
         sqrop= S-> S^2;
-        spmf_nep2=SPMF_NEP([B0,B1],[oneop,sqrop])
+        spmf_nep2=SPMF_NEP([B0,B1],[oneop,sqrop],Ftype=ComplexF64)
         push!(testlist,compute_types_metadata(spmf_nep2,ComplexF64,false,[],[],[],false, "#2"));
 
         # SPMF 3
         expmop= S -> exp(S)
         B0b=Matrix{BigFloat}(B0);
         B1b=Matrix{BigFloat}(B1);
-        spmf_nep3=SPMF_NEP([B0b,B1b],[oneop,expmop])
+        spmf_nep3=SPMF_NEP([B0b,B1b],[oneop,expmop],Ftype=Float64)
 
 
         # Skip these since expm not supported
@@ -317,7 +317,7 @@ end
         # SPMF nep 4
         oneop= S-> 1im*S;
         sqrop= S-> S^2;
-        spmf_nep4=SPMF_NEP([A0_sparse,A1_sparse],[oneop,sqrop])
+        spmf_nep4=SPMF_NEP([A0_sparse,A1_sparse],[oneop,sqrop],Ftype=ComplexF64)
 
         push!(testlist,compute_types_metadata(spmf_nep4,ComplexF64,false,[],[],[],false, "#4"));
 

--- a/test/spmf.jl
+++ b/test/spmf.jl
@@ -147,7 +147,7 @@ using SparseArrays
 
     end
 
-    @testset "SPMF benchmark" begin
+    @onlybench @testset "SPMF benchmark" begin
         # To check performance of SPMF-compute_MM function
         large_benchmark = false
         if large_benchmark

--- a/test/spmf.jl
+++ b/test/spmf.jl
@@ -147,7 +147,7 @@ using SparseArrays
 
     end
 
-    @onlybench @testset "SPMF benchmark" begin
+    @testset "SPMF benchmark" begin
         # To check performance of SPMF-compute_MM function
         large_benchmark = false
         if large_benchmark
@@ -168,7 +168,7 @@ using SparseArrays
                 fv=[S->S, S->cos(S)]
                 A0=randn(n,n);
                 A1=randn(n,n);
-                spmf1=SPMF_NEP([A0,A1],fv,Schur_fact = Schur_fact);
+                spmf1=SPMF_NEP([A0,A1],fv,Schur_fact = Schur_fact,Ftype=Float64);
                 @testset "two-term SPMF (n=$n,schur=$Schur_fact): MM S-matrix p x p: p=$p" for p in p_mm_values
                     V=randn(size(spmf1,1),p);
                     S=randn(p,p);
@@ -190,7 +190,7 @@ using SparseArrays
                     Av[k] = randn(n,n)
                 end
 
-                spmf2=SPMF_NEP(Av,fv,Schur_fact = Schur_fact);
+                spmf2=SPMF_NEP(Av,fv,Schur_fact = Schur_fact, Ftype=Float64);
                 @testset "$m-term SPMF (n=$n,schur=$Schur_fact): MM S-matrix p x p: p=$p" for p in p_mm_values
                     p=5;
                     V=randn(size(spmf2,1),p);

--- a/test/spmf_stability.jl
+++ b/test/spmf_stability.jl
@@ -1,0 +1,43 @@
+# Tests for SPMF-code
+
+push!(LOAD_PATH, @__DIR__); using TestUtils
+using NonlinearEigenproblems
+using Test
+using LinearAlgebra
+using Random
+using SparseArrays
+
+@testset "SPMF stability" begin
+    n=5;
+    Random.seed!(1)
+    A0=sparse(randn(n,n));
+    A1=sparse(randn(n,n));
+    t=3.0
+
+    minusop = S -> -S
+    oneop = S -> one(S)
+    expmop = S -> exp(-t*S)
+    fi=[minusop, oneop, expmop];
+
+    J = SparseMatrixCSC(1.0I, n, n)
+    nep1 = SPMF_NEP([J, A0, A1], fi)
+    nep2 = SPMF_NEP([J, A0, A1], fi; Schur_fact=true)
+
+    m=4;
+    V=randn(n,m);
+    λ=3;
+    S=randn(m,m);
+    @inferred compute_MM(nep1,S,V)
+
+    compute_Mlincomb(nep1,λ,V)
+
+
+    @inferred compute_Mlincomb(nep1,3,V)
+    @inferred compute_Mlincomb(nep1,3+1im,V)
+
+    nep2=SPMF_NEP(get_Av(nep1),get_fv(nep1),Ftype=Float64);
+
+    @inferred compute_Mlincomb(nep1,3,V)
+    @inferred compute_Mlincomb(nep1,3+1im,V)
+
+end


### PR DESCRIPTION
This is a quite big rewrite of the SPMFs. 

* Separation of SPMF_NEP into SPMF_dense and SPMF_sparse. From a user-perspective nothing changed. It makes @maxbennedich sparsity pattern optimization more separated from the rest.
* compute_MM rewrite, with type logic. The output of compute_MM is now type stable (but there are some red Any in `code_warntype` which I don't know if they matter).
* compute_Mder now has two different functions for SPMF_dense and SPMF_sparse 
* The SPMFs are now parametric both wrt to the T:matrices, but also Ftype. Ftype defines a type logic for the f-functions. More precisely  `eltype(F(λ))=promote_type(eltype(λ),Ftype)`. That way the output type can inferred from the input types of  compute_MM. 

I thought making it type stable would make a much bigger difference. I did find a (somewhat strange) example where it makes a difference.  Standalone illustration between current master (91fdc26ca972d60c67ae2b6f2a433dc44f160b42) and this PR:
```julia
    n=100; m=10000; p=5; Schur_fact=false;
    fv=Vector{Function}(undef,m);
    Av=Vector{Matrix{Float64}}(undef,m);
    for k=1:m
        if (mod(k,2)==1)
            fv[k] = S-> inv((1im+sqrt(k))*one(S)-S); # 1/((i+√k)I-S)
        else
            fv[k] = S-> inv(sqrt(k)*one(S)-S); # 1/(I√k-S)
        end
        Av[k] = randn(n,n)
    end
    V=randn(n,p)+1im*randn(n,p);
    S=randn(p,p);
    spmf2=SPMF_NEP(Av,fv,Schur_fact = Schur_fact,check_consistency=false);
    @btime compute_MM(spmf2,S,V);
```
On master: 
```
  742.639 ms (248469 allocations: 292.95 MiB)
```
This PR:
```
  688.245 ms (205003 allocations: 214.63 MiB)
```

I'm not quite finished with this. I also want to implement `compute_Mder` for higher derivatives, and double check that there was no regression in the sparse summation code. 