### PR TITLE
SPMF rewrite2: compute_Mder + sparsity alignment

### DIFF
--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -130,11 +130,12 @@ for matrices in the standard matrix function sense.
 
 
 """
-     SPMF_NEP(AA, fii, Schur_fact = false, use_sparsity_pattern = true, check_consistency=true)
+     SPMF_NEP(AA, fii, Schur_fact = false, join_sparsity_patterns = false, check_consistency=true)
 
-Creates a `SPMF_NEP` consisting of matrices `AA` and functions `fii`. `fii` must be an array of functions defined for matrices and numbers. `AA` is an array of matrices. `Schur_fact` specifies if the computation of `compute_MM` should be done by first pre-computing a Schur-factorization (which can be faster). If `use_sparsity_pattern` is true, and the `AA` matrices are sparse, each matrix will be stored with a sparsity pattern matching the union of all `AA` matrices. This leads to more efficient calculation of `compute_Mder`. If the sparsity patterns are completely or mostly distinct, it may be more efficient to set this flag to false. If check_consistency is true the input
+Creates a `SPMF_NEP` consisting of matrices `AA` and functions `fii`. `fii` must be an array of functions defined for matrices and numbers. `AA` is an array of matrices. `Schur_fact` specifies if the computation of `compute_MM` should be done by first pre-computing a Schur-factorization (which can be faster). If `join_sparsity_patterns` is true, and the `AA` matrices are sparse, each matrix will be stored with a sparsity pattern matching the union of all `AA` matrices.  This leads to more efficient calculation of `compute_Mder`. If the sparsity patterns are completely or mostly distinct, it may be more efficient to set this flag to false. If `join_sparsity pattern=true` the `A`-matrices in the SPMF object should be viewed as read-only. If `check_consistency` is `true` input
 checking will be performed.
 
+# Example
 ```julia-repl
 julia> A0=[1 3; 4 5]; A1=[3 4; 5 6];
 julia> id_op=S -> one(S)
@@ -224,7 +225,8 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
         As = Vector{SparseMatrixCSC{T,Int}}()
         @inbounds for A in AA
             # Create a new zero matrix. Note all S-matrices have the same colptr, so
-            # modification of As[i] will change all. Not advisable.
+            # modification of As[i] will change all. The As[i] matrices should therefore
+            # be viewed as read-only objects.
             S = SparseMatrixCSC(Zero.m, Zero.n,
                                 Zero.colptr, Zero.rowval,
                                 fill(zero(T),size(Zero.nzval,1)))

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -196,7 +196,7 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
                  this=SPMF_NEP{typeof(AA[1]),Ftype}(n,AA,fii,Schur_fact,false);
              else
                  TT = eltype(AA[1])
-                 As=align_sparsity_patterns(AA,TT)
+                 As=form_aligned_sparsity_patterns(AA,TT)
                  this=SPMF_NEP{typeof(As[1]),Ftype}(n,As,fii,Schur_fact,true);
              end
          end
@@ -208,7 +208,7 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
     end
 
 """ Return a vector of sparse matrices which are the same as AA but also have the same sparsity pattern. """
-    function align_sparsity_patterns(AA::Vector{SparseMatrixCSC},T)
+    function form_aligned_sparsity_patterns(AA::Vector{<:SparseMatrixCSC},T)
 
         # Create a Zero matrix with the correct sparsity pattern.
         Zero = LinearAlgebra.fillstored!(copy(AA[1]), 1)
@@ -300,8 +300,8 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
 
     # For general matrices
     function compute_Mder(nep::SPMF_NEP,λ::Number)
-         TZ,x = compute_Mder_fi_and_output_type(nep,λ)
-         Z = zeros(TZ,size(nep,1),size(nep,1));
+        TZ,x = compute_Mder_fi_and_output_type(nep,λ)
+        Z = zeros(TZ,size(nep,1),size(nep,1));
          for k=1:size(nep.A,1)
              Z += nep.A[k] * x[k]
          end
@@ -320,14 +320,13 @@ julia> compute_Mder(nep,1)-(A0+A1*exp(1))
                  Z.nzval .+= nep.A[k].nzval .* x[k]
              end
          else
-             Z::SparseMatrixCSC{TZ,Int} = copy(nep.A[1])*x[1]
+             # No alignment of sparsity pattern. Naive summing.
+             Z::SparseMatrixCSC{TZ,Int} = nep.A[1]*x[1]
              for k = 2:length(nep.A)
                  Z .+= nep.A[k] * x[k];
              end
          end
-
          return Z
-
     end
 
     function compute_Mder(nep::SPMF_NEP,λ::Number,i::Integer)

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -130,9 +130,9 @@ for matrices in the standard matrix function sense.
 
 
 """
-     SPMF_NEP(AA, fii, Schur_fact = false, join_sparsity_patterns = false, check_consistency=true)
+     SPMF_NEP(AA, fii, Schur_fact = false, align_sparsity_patterns = false, check_consistency=true)
 
-Creates a `SPMF_NEP` consisting of matrices `AA` and functions `fii`. `fii` must be an array of functions defined for matrices and numbers. `AA` is an array of matrices. `Schur_fact` specifies if the computation of `compute_MM` should be done by first pre-computing a Schur-factorization (which can be faster). If `join_sparsity_patterns` is true, and the `AA` matrices are sparse, each matrix will be stored with a sparsity pattern matching the union of all `AA` matrices.  This leads to more efficient calculation of `compute_Mder`. If the sparsity patterns are completely or mostly distinct, it may be more efficient to set this flag to false. If `join_sparsity pattern=true` the `A`-matrices in the SPMF object should be viewed as read-only. If `check_consistency` is `true` input
+Creates a `SPMF_NEP` consisting of matrices `AA` and functions `fii`. `fii` must be an array of functions defined for matrices and numbers. `AA` is an array of matrices. `Schur_fact` specifies if the computation of `compute_MM` should be done by first pre-computing a Schur-factorization (which can be faster). If `align_sparsity_patterns` is true, and the `AA` matrices are sparse, each matrix will be stored with a sparsity pattern matching the union of all `AA` matrices.  This leads to more efficient calculation of `compute_Mder`. If the sparsity patterns are completely or mostly distinct, it may be more efficient to set this flag to false. If `align_sparsity pattern=true` the `A`-matrices in the SPMF object should be viewed as read-only. If `check_consistency` is `true` input
 checking will be performed.
 
 # Example

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -130,7 +130,7 @@ for matrices in the standard matrix function sense.
 
          # Sparse zero matrix to be used for sparse matrix creation
          Zero::T
-         As::Vector{SparseMatrixCSC{<:Number,Int}}  # 'A' matrices with sparsity pattern of all matrices combined
+         As::Vector{SparseMatrixCSC{<:Number, Int}}  # 'A' matrices with sparsity pattern of all matrices combined
     end
     SPMF_NEP{T,Ftype} = Union{SPMF_NEP_dense{T,Ftype},SPMF_NEP_sparse{T,Ftype}}
 

--- a/src/nleigs/NleigsTypes.jl
+++ b/src/nleigs/NleigsTypes.jl
@@ -104,7 +104,7 @@ function LowRankFactorizedNEP(Amf::AbstractVector{LowRankMatrixAndFunction{S}}) 
         r += size(U[k], 2)
     end
 
-    return LowRankFactorizedNEP(SPMF_NEP(A, f), r, L, U)
+    return LowRankFactorizedNEP(SPMF_NEP(A, f, align_sparsity_patterns=true), r, L, U)
 end
 
 "Create an empty LowRankFactorizedNEP."

--- a/test/spmf.jl
+++ b/test/spmf.jl
@@ -34,6 +34,7 @@ using SparseArrays
         @test norm(V-W)>sqrt(eps())*100
     end
 
+
     @bench @testset "compute_MM" begin
 
         S=randn(3,3);
@@ -61,6 +62,36 @@ using SparseArrays
         @test opnorm(N1-N2)<sqrt(eps())
 
     end
+#    @bench @testset "SPMF sparse" begin
+#
+#
+#        Random.seed!(0)
+#        B0=sprandn(5,5,0.2)
+#        B1=sprandn(5,5,0.2)
+#
+#        fv=[S->one(S),S->sin(S)];
+#        spmf1=SPMF_NEP([B0,B1],fv,align_sparsity_patterns=false)
+#        spmf2=SPMF_NEP([copy(B0),copy(B1)],fv,align_sparsity_patterns=true)
+#
+#        spmf3=SPMF_NEP([Matrix(B0),Matrix(B1)],fv)
+#
+#        λ=1.0;
+#        Ma1=compute_Mder(spmf1,λ);
+#        Ma2=compute_Mder(spmf2,λ);
+#        Ma3=compute_Mder(spmf3,λ);
+#        @test Ma1 ≈ Ma2
+#        @test Matrix(Ma1) ≈ Matrix(Ma3)
+#
+#
+#        λ=1.0+3im;
+#        Mb1=compute_Mder(spmf1,λ);
+#        Mb2=compute_Mder(spmf2,λ);
+#        Mb3=compute_Mder(spmf3,λ);
+#        @test Matrix(Mb1) ≈ Matrix(Mb2)
+#        @test Matrix(Mb1) ≈ Matrix(Mb3)
+#
+#
+#    end
     @bench @testset "compute_Mder_from_MM" begin
 
         S=randn(3,3);
@@ -146,6 +177,7 @@ using SparseArrays
         end
 
     end
+
 
     @onlybench @testset "SPMF benchmark" begin
         # To check performance of SPMF-compute_MM function


### PR DESCRIPTION
Here is the second round of SPMF rewrite:

* After moving the sparsity alignment trick to the constructor, I was able to remove the need for `As` in `SPMF_NEP_sparse`. This lead to the fact that SPMF_dense and SPMF_sparse were so similar that they could be merged to one type again. Quite a bit of cleanup work. Not so much efficiency issues.  
* I tried to factorize the code into helper functions, since I believe the same problems will later need to be solved for more sparse AbstractSPMF, e.g., DEP{SparseMatrixCSC}.  
* I wrote a specialized version of `compute_Mder(::SPMF_NEP`. This lead to a huge improvement for higher derivatives, mostly due to how slow compute_Mder_from_MM is when size(nep) is large:

```julia
julia> nep=nep_gallery("qdep0");
julia> @btime Z=compute_Mder_from_MM(nep,λ,1); # Old
  4.377 s (158 allocations: 1.27 GiB)
julia> @btime Z=compute_Mder(nep,λ,1); # New
  168.745 μs (138 allocations: 818.25 KiB)
```
The only method I know using derivative matrices (and not compute_Mlincomb) is mslp, so there will be some benefits. 

@maxbennedich: I moved around the sparsity alignment code. The sparsity alignment was very important for you in the nleigs-tests. Do you think you could see that the benefits are not lost? Or tell me how to check it. 