### PR TITLE
Restart nlar

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -119,10 +119,10 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[OrderedCollections]]
-deps = ["InteractiveUtils", "Pkg", "Random", "Serialization", "Test"]
-git-tree-sha1 = "27af6dc22697bf20ace8e3a45f404a34eaf0b819"
+deps = ["Pkg", "Random", "Serialization", "Test"]
+git-tree-sha1 = "41da1edba028376b58520ca01d9a41e29f855d55"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.0.0"
+version = "1.0.1"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -184,9 +184,9 @@ version = "0.2.0"
 
 [[Revise]]
 deps = ["Distributed", "FileWatching", "InteractiveUtils", "LibGit2", "OrderedCollections", "Pkg", "REPL", "Random", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "48ad8dcdacf24185eb1bc4253a17dc39e1485079"
+git-tree-sha1 = "e45f79d83a61ee6fc229b22df6836d18b6dcb89e"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "0.7.10"
+version = "0.7.11"
 
 [[Roots]]
 deps = ["Compat", "Printf"]

--- a/profiling/nlar.jl
+++ b/profiling/nlar.jl
@@ -1,0 +1,32 @@
+#Profiler for the Nonlinear Arnoldi method implement in src/method_nlar.jl
+using ..NEPSolver 
+using Profile
+using Test
+using LinearAlgebra
+using Random
+
+Profile.clear()
+
+TOL = 1e-10;
+
+Random.seed!(0)
+
+nep = nep_gallery("nlevp_native_gun")
+n = size(nep,1);
+
+#The eigenvalues of the gun problem lie within a semi-circle centred approximately around the "shift" with an approximate radius "scale"
+shift = 250^2;
+scale = 330^2-220^2;
+
+#Run Quasi-Newton for initial guess obtained from the knowledge of the eigenvalue distribution
+λ_ref,v_ref = quasinewton(nep, λ = shift+scale*(-0.131403+0.00759532im), v = ones(n), displaylevel = 2, tol = TOL/50, maxit = 500)
+
+#Shift and scale the NEP(mainly to avoid round-off errors because of the large entries in the coefficient matrices)
+nep1_spmf = SPMF_NEP(get_Av(nep),get_fv(nep))
+nep1 = shift_and_scale(nep1_spmf,shift=shift,scale=scale);
+
+#Start profiling
+Profile.init(n = 10^7, delay = 0.01);
+#Run NLAR on the shifted and scaled NEP (nev set to 1 to save time.
+@profile nlar(nep1, tol=TOL, λ0 = 0,maxit=500, nev = 10, R=0.01,displaylevel=1,v0=ones(n),eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false,num_restart_ritz_vecs=8,max_subspace=50);
+Profile.print(format=:flat,sortedby=:count);

--- a/profiling/nlar.jl
+++ b/profiling/nlar.jl
@@ -19,14 +19,15 @@ shift = 250^2;
 scale = 330^2-220^2;
 
 #Run Quasi-Newton for initial guess obtained from the knowledge of the eigenvalue distribution
-λ_ref,v_ref = quasinewton(nep, λ = shift+scale*(-0.131403+0.00759532im), v = ones(n), displaylevel = 2, tol = TOL/50, maxit = 500)
+λ_ref,v_ref = quasinewton(nep, λ = shift+scale*(-0.131403+0.00759532im), v = ones(n), displaylevel = 0, tol = TOL/50, maxit = 500)
 
 #Shift and scale the NEP(mainly to avoid round-off errors because of the large entries in the coefficient matrices)
 nep1_spmf = SPMF_NEP(get_Av(nep),get_fv(nep))
 nep1 = shift_and_scale(nep1_spmf,shift=shift,scale=scale);
 
 #Start profiling
-Profile.init(n = 10^7, delay = 0.01);
+println("Running profiler on NLAR with n = 1e+7 and delay = 1.0")
+Profile.init(n = 10^7, delay = 1.0);
 #Run NLAR on the shifted and scaled NEP (nev set to 1 to save time.
-@profile nlar(nep1, tol=TOL, λ0 = 0,maxit=500, nev = 10, R=0.01,displaylevel=1,v0=ones(n),eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false,num_restart_ritz_vecs=8,max_subspace=50);
+@profile nlar(nep1, tol=TOL, λ0 = 0,maxit=500, nev = 5, R=0.01,displaylevel=1,v0=ones(n),eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false,num_restart_ritz_vecs=3,max_subspace=50);
 Profile.print(format=:flat,sortedby=:count);

--- a/src/method_nlar.jl
+++ b/src/method_nlar.jl
@@ -80,7 +80,7 @@ function nlar(::Type{T},
         cbs = 1;#Current basis size
 
         D::Vector{T} = zeros(T,nev);#To store the converged eigenvalues
-        err_hyst=eps()*ones(maxit,nev) ;# Giampaolo's edit
+        err_hist=eps()*ones(maxit,nev) ;#Error history
 
         Z::Matrix{T} = zeros(T,n,nev+num_restart_ritz_vecs);#The matrix used for constructing the restarted basis
         m = 0; #Number of converged eigenvalues
@@ -105,9 +105,7 @@ function nlar(::Type{T},
             #Use inner_solve() to solve the smaller projected problem
             dd,vv = inner_solve(inner_solver_method,T,proj_nep,Neig=nev,σ=σ);
 
-            # Sort the eigenvalues of the projected problem by measuring the distance from the eigenvalues,
-            # in D and exclude all eigenvalues that lie within a unit disk of radius R from one of the
-            # eigenvalues in D.
+            # Sort the eigenvalues of the projected problem 
             nuv,yv = eigval_sorter(nep,dd,vv,σ,D,R,Vk);
             
             nu = nuv[1]; y=yv[:,1];
@@ -130,7 +128,7 @@ function nlar(::Type{T},
             if(displaylevel == 1)
                 println(k," Error:",err," Eigval :",nu)
             end
-            err_hyst[k,m+1]=err;    # Giampaolo's edit
+            err_hist[k,m+1]=err;
             if(err < tol)
                 if(displaylevel == 1)
                     println("****** ",m+1,"th converged to eigenvalue: ",nu," errmeasure:",err,"  ******")

--- a/src/method_nlar.jl
+++ b/src/method_nlar.jl
@@ -39,8 +39,8 @@ function nlar(::Type{T},
             errmeasure::Function = default_errmeasure(nep),
             tol = eps(real(T))*100,
             maxit::Int = 100,
-            λ0::Number = zero(T),
-            v0::Vector = randn(T,size(nep,1)),
+            λ::Number = zero(T),
+            v::Vector = randn(T,size(nep,1)),
             displaylevel::Int = 0,
             linsolvercreator::Function = default_linsolvercreator,
             R = 0.01,
@@ -50,7 +50,7 @@ function nlar(::Type{T},
             num_restart_ritz_vecs::Int=8,
             inner_solver_method = NEPSolver.DefaultInnerSolver) where {T<:Number,T_orth<:IterativeSolvers.OrthogonalizationMethod}
 
-        local σ::T = T(λ0); #Initial pole
+        local σ::T = T(λ); #Initial pole
 
         #Check if maxit is larger than problem size
         if (maxit > size(nep,1))
@@ -70,13 +70,13 @@ function nlar(::Type{T},
             max_subspace = num_restart_ritz_vecs+20; #20 is hardcoded.
         end
 
-        λ0::T = T(λ0);
+        λ::T = T(λ);
         n = size(nep,1);
 
         #Initialize the basis V_1
         V::Matrix{T}= zeros(T,n,max_subspace);
         X::Matrix{T} = zeros(T,n,nev);
-        V[:,1] = normalize(ones(T,n));
+        V[:,1] = normalize(v);
         cbs = 1;#Current basis size
 
         D::Vector{T} = zeros(T,nev);#To store the converged eigenvalues
@@ -92,8 +92,6 @@ function nlar(::Type{T},
         local linsolver::LinSolver = linsolvercreator(nep,σ);
 
         err = Inf;
-        nu = λ0;
-        u = v0;
 
         if(displaylevel == 1)
             println("##### Using inner solver:",inner_solver_method," #####");

--- a/src/method_nlar.jl
+++ b/src/method_nlar.jl
@@ -12,14 +12,14 @@ export threshold_eigval_sorter
 """
     function nlar([eltype],nep::ProjectableNEP,[orthmethod=ModifiedGramSchmidt],[nev=10],[errmeasure=default_errmeasure],[tol=eps(real(T))*100],[maxit=100],[λ0=0],[v0=randn(T,size(nep,1))],[displaylevel=0],[linsolvercreator=default_linsolvercreator],[R=0.01],[eigval_sorter=residual_eigval_sorter],[qrfact_orth=false],[max_subspace=100],[num_restart_ritz_vecs=8],[inner_solver_method=NEPSolver.DefaultInnerSolver])
  
-The function implements the Nonlinear Arnoldi method, which finds 'nev' eigenpairs(or throws a 'NoConvergenceException') by projecting the problem to a subspace that is expanded in the course  of the algorithm. 
-The basis is orthogonalized either by using the QR method if 'qrfact_orth' is 'true' or else by an orthogonalization method 'orthmethod'). 
-This entails solving a smaller projected problem using a method specified by 'inner_solver_method'. 
-('λ0','v0') is the initial guess for the eigenpair. 'linsolvercreator' specifies how the linear system is created and solved. 
-'R' is a parameter used by the function specified by 'eigval_sorter' to reject those ritz values that are within a distance 'R' from any of the converged eigenvalues, so that repeated convergence to the same eigenpair can be avoided. 
-'max_subspace' is the maximum allowable size of the basis befor the algorithm restarts using a basis made of 'num_restart_ritz_vecs' ritz vectors and the eigenvectors that the algorithm has converged to.
+The function implements the Nonlinear Arnoldi method, which finds `nev` eigenpairs(or throws a `NoConvergenceException`) by projecting the problem to a subspace that is expanded in the course  of the algorithm. 
+The basis is orthogonalized either by using the QR method if `qrfact_orth` is `true` or else by an orthogonalization method `orthmethod`). 
+This entails solving a smaller projected problem using a method specified by `inner_solver_method`. 
+(`λ0`,`v0`) is the initial guess for the eigenpair. `linsolvercreator` specifies how the linear system is created and solved. 
+`R` is a parameter used by the function specified by `eigval_sorter` to reject those ritz values that are within a distance `R` from any of the converged eigenvalues, so that repeated convergence to the same eigenpair can be avoided. 
+`max_subspace` is the maximum allowable size of the basis befor the algorithm restarts using a basis made of `num_restart_ritz_vecs` ritz vectors and the eigenvectors that the algorithm has converged to.
 
-#Example
+# Example
 ```julia-repl
 julia> nep=nep_gallery("dep0_tridiag");
 julia> λ,v=nlar(nep,tol=1e-5,nev=1,maxit=50);
@@ -27,7 +27,7 @@ julia> norm(compute_Mlincomb(nep,λ[1],v))
 7.722757003764154e-7
 ```
 
-#References
+# References
 * H. Voss, An Arnoldi method for nonlinear eigenvalue problems. BIT. Numer. Math. 44: 387-401, 2004.
 
 """

--- a/src/method_nlar.jl
+++ b/src/method_nlar.jl
@@ -195,7 +195,7 @@ function nlar(::Type{T},
             throw(NoConvergenceException(nu,u,err,msg))
         end
 
-        return D,X,err_hyst;
+        return D,X,err_hist;
     end
 
 

--- a/src/method_nlar.jl
+++ b/src/method_nlar.jl
@@ -10,25 +10,24 @@ export threshold_eigval_sorter
 
 
 """
- function nlar([eltype],nep::ProjectableNEP,[orthmethod=ModifiedGramSchmidt],[nev=10],[errmeasure=default_errmeasure],[tol=eps(real(T))*100],[maxit=100],[λ0=0],[v0=randn(T,size(nep,1))],[displaylevel=0],[linsolvercreator=default_linsolvercreator],[R=0.01],[eigval_sorter=residual_eigval_sorter],[qrfact_orth=false],[max_subspace=100],[num_restart_ritz_vecs=8],[inner_solver_method=NEPSolver.DefaultInnerSolver])
+    function nlar([eltype],nep::ProjectableNEP,[orthmethod=ModifiedGramSchmidt],[nev=10],[errmeasure=default_errmeasure],[tol=eps(real(T))*100],[maxit=100],[λ0=0],[v0=randn(T,size(nep,1))],[displaylevel=0],[linsolvercreator=default_linsolvercreator],[R=0.01],[eigval_sorter=residual_eigval_sorter],[qrfact_orth=false],[max_subspace=100],[num_restart_ritz_vecs=8],[inner_solver_method=NEPSolver.DefaultInnerSolver])
  
- The function implements the Nonlinear Arnoldi method, which finds 'nev' eigenpairs(or throws a 'NoConvergenceException') by projecting the problem to a subspace that is expanded in the course  of the algorithm. 
- The basis is orthogonalized either by using the QR method if 'qrfact_orth' is 'true' or else by an orthogonalization method 'orthmethod'). 
- This entails solving a smaller projected problem using a method specified by 'inner_solver_method'. 
- ('λ0','v0') is the initial guess for the eigenpair. 'linsolvercreator' specifies how the linear system is created and solved. 
- 'R' is a parameter used by the function specified by 'eigval_sorter' to reject those ritz values that are within a distance 'R' from any of the converged eigenvalues, so that repeated convergence to the same eigenpair can be avoided. 
- 'max_subspace' is the maximum allowable size of the basis befor the algorithm restarts using a basis made of 'num_restart_ritz_vecs' ritz vectors and the eigenvectors that the algorithm has converged to.
+The function implements the Nonlinear Arnoldi method, which finds 'nev' eigenpairs(or throws a 'NoConvergenceException') by projecting the problem to a subspace that is expanded in the course  of the algorithm. 
+The basis is orthogonalized either by using the QR method if 'qrfact_orth' is 'true' or else by an orthogonalization method 'orthmethod'). 
+This entails solving a smaller projected problem using a method specified by 'inner_solver_method'. 
+('λ0','v0') is the initial guess for the eigenpair. 'linsolvercreator' specifies how the linear system is created and solved. 
+'R' is a parameter used by the function specified by 'eigval_sorter' to reject those ritz values that are within a distance 'R' from any of the converged eigenvalues, so that repeated convergence to the same eigenpair can be avoided. 
+'max_subspace' is the maximum allowable size of the basis befor the algorithm restarts using a basis made of 'num_restart_ritz_vecs' ritz vectors and the eigenvectors that the algorithm has converged to.
 
- #Example:
- '''
- julia-repl
+#Example
+```julia-repl
 julia> nep=nep_gallery("dep0_tridiag");
 julia> λ,v=nlar(nep,tol=1e-5,nev=1,maxit=50);
 julia> norm(compute_Mlincomb(nep,λ[1],v))
 7.722757003764154e-7
-'''
+```
 
-#References:
+#References
 * H. Voss, An Arnoldi method for nonlinear eigenvalue problems. BIT. Numer. Math. 44: 387-401, 2004.
 
 """

--- a/src/method_nlar.jl
+++ b/src/method_nlar.jl
@@ -21,8 +21,8 @@ function nlar(::Type{T},
             errmeasure::Function = default_errmeasure(nep),
             tol = eps(real(T))*100,
             maxit::Int = 100,
-            λ0 = zero(T),
-            v0 = randn(T,size(nep,1)),
+            λ0::Number = zero(T),
+            v0::Vector = randn(T,size(nep,1)),
             displaylevel::Int = 0,
             linsolvercreator::Function = default_linsolvercreator,
             R = 0.01,
@@ -56,15 +56,15 @@ function nlar(::Type{T},
         n = size(nep,1);
 
         #Initialize the basis V_1
-        V = zeros(T,n,max_subspace);
-        X = zeros(T,n,nev);
+        V::Matrix{T}= zeros(T,n,max_subspace);
+        X::Matrix{T} = zeros(T,n,nev);
         V[:,1] = normalize(ones(T,n));
         cbs = 1;#Current basis size
 
-        D = zeros(T,nev);#To store the converged eigenvalues
+        D::Vector{T} = zeros(T,nev);#To store the converged eigenvalues
         err_hyst=eps()*ones(maxit,nev) ;# Giampaolo's edit
 
-        Z = zeros(T,n,nev+num_restart_ritz_vecs);#The matrix used for constructing the restarted basis
+        Z::Matrix{T} = zeros(T,n,nev+num_restart_ritz_vecs);#The matrix used for constructing the restarted basis
         m = 0; #Number of converged eigenvalues
         
         k = 1;

--- a/src/method_nlar.jl
+++ b/src/method_nlar.jl
@@ -7,108 +7,11 @@ export default_eigval_sorter
 export residual_eigval_sorter
 export threshold_eigval_sorter
 
-###############################################################################################################
-# Default ritzvalue sorter:
-# First discard all Ritz values within a distance R of any of the converged eigenvalues(of the original problem).
-# Then sort by distance from the shift and select the mm-th furthest value from the pole.
 
-## D = already computed eigenvalues
-## dd, vv eigenpairs of projected problem
-## σ targets
+
 """
  The Nonlinear Arnoldi method, as introduced in "An Arnoldi method for nonlinear eigenvalue problems" by H.Voss
 """
-function  default_eigval_sorter(nep::NEP,dd,vv,σ,D,R,Vk)
-    dd2=copy(dd);
-
-    ## Check distance of each eigenvalue of the projected NEP(i.e. in dd)
-    ## from each eigenvalue that as already converged(i.e. in D)
-    for i=1:size(dd,1)
-        for j=1:size(D,1)
-            if (abs(dd2[i]-D[j])<R)
-                dd2[i]=Inf; #Discard all Ritz values within a particular radius R
-            end
-        end
-    end
-
-    ii = sortperm(abs.(dd2-σ));
-
-    nu = dd2[ii];
-    y = vv[:,ii];
-
-    return nu,y;
-end
-
-
-# Residual-based Ritz value sorter:
-# First discard all Ritz values within a distance R of any of the converged eigenvalues(of the original problem).
-# Then select that Ritz value which gives the mm-th minimum product of (residual and distance from pole).
-function residual_eigval_sorter(nep::NEP,dd,vv,σ,D,R,Vk,errmeasure::Function=default_errmeasure(nep))
-
-    eig_res = zeros(size(dd,1));
-    dd2=copy(dd);
-
-    ## Check distance of each eigenvalue of the projected NEP(i.e. in dd)
-    ## from each eigenvalue that as already converged(i.e. in D)
-    for i=1:size(dd,1)
-        for j=1:size(D,1)
-            if (abs(dd2[i]-D[j])<R)
-                dd2[i]=Inf; #Discard all Ritz values within a particular radius R
-            end
-        end
-    end
-
-    #Compute residuals for each Ritz value
-    for i=1:size(dd,1)
-        eig_res[i] = errmeasure(dd[i],Vk*vv[:,i]);
-    end
-
-    #Sort according to methods
-    ii = sortperm(eig_res .* abs.(dd2 .- σ))
-
-    nu = dd[ii];
-    y = vv[:,ii];
-
-    return nu,y;
-end
-
-# Threshold residual based Ritz value sorter:
-# Same as residual_eigval_sorter() except that errors above a certain threshold are set to the threshold.
-function threshold_eigval_sorter(nep::NEP,dd,vv,σ,D,R,Vk,errmeasure::Function=default_errmeasure(nep),threshold=0.1)
-
-    eig_res = zeros(size(dd,1));
-    dd2=copy(dd);
-
-    ## Check distance of each eigenvalue of the projected NEP(i.e. in dd)
-    ## from each eigenvalue that as already converged(i.e. in D)
-    for i=1:size(dd,1)
-        for j=1:size(D,1)
-            if (abs(dd2[i]-D[j])<R)
-                dd2[i]=Inf; #Discard all Ritz values within a particular radius R
-            end
-        end
-    end
-
-    #Compute residuals for each Ritz value
-    temp_res = 0;
-    for i=1:size(dd,1)
-        temp_res = errmeasure(dd[i],Vk*vv[:,i]);
-        if(temp_res > threshold)
-            eig_res[i] = threshold;
-        else
-            eig_res[i] = temp_res;
-        end
-    end
-
-    #Sort according to methods
-    ii = sortperm(eig_res.*abs.(dd2-σ));
-
-    nu = dd[ii];
-    y = vv[:,ii];
-
-    return nu,y;
-end
-
 nlar(nep::NEP;params...) = nlar(ComplexF64,nep::NEP;params...)
 function nlar(::Type{T},
             nep::ProjectableNEP;
@@ -208,11 +111,13 @@ function nlar(::Type{T},
 
             #Check for convergence of one of the eigenvalues
             err = errmeasure(nu,u);
-            println(k," Error:",err," Eigval :",nu)
+            if(displaylevel == 1)
+                println(k," Error:",err," Eigval :",nu)
+            end
             err_hyst[k,m+1]=err;    # Giampaolo's edit
             if(err < tol)
                 if(displaylevel == 1)
-                    println("\n****** ",m+1,"th converged to eigenvalue: ",nu," errmeasure:",err,"  ******\n")
+                    println("****** ",m+1,"th converged to eigenvalue: ",nu," errmeasure:",err,"  ******")
                 end
 
                 #Add to the set of converged eigenvalues and eigenvectors
@@ -257,8 +162,6 @@ function nlar(::Type{T},
                     
                     cbs = cbs+1;
                     V[:,1:cbs]=Q;
-                    #println("Dist normalization:",opnorm(Vk'*Vk-I))
-                    #println("Size:",size(Vk), " N: ",opnorm(Vk[:,k+1]), " d:",opnorm(Δv))
                 else
                     h=zeros(T,k);
                     orthogonalize_and_normalize!(Vk,Δv,h,orthmethod);
@@ -285,3 +188,104 @@ function nlar(::Type{T},
 
         return D,X,err_hyst;
     end
+
+
+###############################################################################################################
+# Default ritzvalue sorter:
+# First discard all Ritz values within a distance R of any of the converged eigenvalues(of the original problem).
+# Then sort by distance from the shift and select the mm-th furthest value from the pole.
+
+## D = already computed eigenvalues
+## dd, vv eigenpairs of projected problem
+## σ targets
+
+function  default_eigval_sorter(nep::NEP,dd,vv,σ,D,R,Vk)
+    dd2=copy(dd);
+
+    ## Check distance of each eigenvalue of the projected NEP(i.e. in dd)
+    ## from each eigenvalue that as already converged(i.e. in D)
+    for i=1:size(dd,1)
+        for j=1:size(D,1)
+            if (abs(dd2[i]-D[j])<R)
+                dd2[i]=Inf; #Discard all Ritz values within a particular radius R
+            end
+        end
+    end
+
+    ii = sortperm(abs.(dd2-σ));
+
+    nu = dd2[ii];
+    y = vv[:,ii];
+
+    return nu,y;
+end
+
+
+# Residual-based Ritz value sorter:
+# First discard all Ritz values within a distance R of any of the converged eigenvalues(of the original problem).
+# Then select that Ritz value which gives the mm-th minimum product of (residual and distance from pole).
+function residual_eigval_sorter(nep::NEP,dd,vv,σ,D,R,Vk,errmeasure::Function=default_errmeasure(nep))
+
+    eig_res = zeros(size(dd,1));
+    dd2=copy(dd);
+
+    ## Check distance of each eigenvalue of the projected NEP(i.e. in dd)
+    ## from each eigenvalue that as already converged(i.e. in D)
+    for i=1:size(dd,1)
+        for j=1:size(D,1)
+            if (abs(dd2[i]-D[j])<R)
+                dd2[i]=Inf; #Discard all Ritz values within a particular radius R
+            end
+        end
+    end
+
+    #Compute residuals for each Ritz value
+    for i=1:size(dd,1)
+        eig_res[i] = errmeasure(dd[i],Vk*vv[:,i]);
+    end
+
+    #Sort according to methods
+    ii = sortperm(eig_res .* abs.(dd2 .- σ))
+
+    nu = dd[ii];
+    y = vv[:,ii];
+
+    return nu,y;
+end
+
+# Threshold residual based Ritz value sorter:
+# Same as residual_eigval_sorter() except that errors above a certain threshold are set to the threshold.
+function threshold_eigval_sorter(nep::NEP,dd,vv,σ,D,R,Vk,errmeasure::Function=default_errmeasure(nep),threshold=0.1)
+
+    eig_res = zeros(size(dd,1));
+    dd2=copy(dd);
+
+    ## Check distance of each eigenvalue of the projected NEP(i.e. in dd)
+    ## from each eigenvalue that as already converged(i.e. in D)
+    for i=1:size(dd,1)
+        for j=1:size(D,1)
+            if (abs(dd2[i]-D[j])<R)
+                dd2[i]=Inf; #Discard all Ritz values within a particular radius R
+            end
+        end
+    end
+
+    #Compute residuals for each Ritz value
+    temp_res = 0;
+    for i=1:size(dd,1)
+        temp_res = errmeasure(dd[i],Vk*vv[:,i]);
+        if(temp_res > threshold)
+            eig_res[i] = threshold;
+        else
+            eig_res[i] = temp_res;
+        end
+    end
+
+    #Sort according to methods
+    ii = sortperm(eig_res.*abs.(dd2-σ));
+
+    nu = dd[ii];
+    y = vv[:,ii];
+
+    return nu,y;
+end

--- a/src/method_rfi.jl
+++ b/src/method_rfi.jl
@@ -5,9 +5,11 @@ export rfi
 export rfi_b
 
 """
-    rfi(nep,nept,[λ=0,][errmeasure=default_errmeasure,][tol=eps()*100,][maxit=100,][v=randn,][u=randn,][displaylevel=0,][linsolvecreator=default_linsolvecreator,])
+rfi(nep,nept,[λ=0,][errmeasure=default_errmeasure,][tol=eps()*100,][maxit=100,][v=randn,][u=randn,][displaylevel=0,][linsolvecreator=default_linsolvecreator,])
 
-This is an implementation of the two-sided Rayleigh functional Iteration. This method requires the transpose of the NEP, which needs to be provided in nept.
+This is an implementation of the two-sided Rayleigh functional Iteration to compute an eigentriple (λ,v,u).
+This method requires the transposed problem in 'nept'.
+'λ', 'v' and 'u' are the initial guesses. 
 
 # Example:
 julia> nep=nep_gallery("dep0");
@@ -18,7 +20,7 @@ julia> opnorm(compute_Mder(nep,λ)*v) % v is a right eigenvector
 julia> opnorm(u'*compute_Mder(nep,λ)) % u is a left eigenvector
 4.1447913221215544e-16
 
-# Reference
+# References
 *  Algorithm 4 in  Schreiber, Nonlinear Eigenvalue Problems: Newton-type Methods and Nonlinear Rayleigh Functionals, PhD thesis, TU Berlin, 2008
 
 """

--- a/test/nlar.jl
+++ b/test/nlar.jl
@@ -29,7 +29,7 @@ using Random
     nep1 = shift_and_scale(nep1_spmf,shift=shift,scale=scale);
 
     #Run NLAR on the shifted and scaled NEP (nev set to 1 to save time. Method works for the case of finding multiple eigenvalues as well)
-    λ,u = nlar(nep1, tol=TOL, λ = 0,maxit=500, nev = 10, R=0.01,displaylevel=1,v=ones(n),eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false,num_restart_ritz_vecs=8,max_subspace=50);
+    λ,u = nlar(nep1, tol=TOL, λ = 0,maxit=100, nev = 2, R=0.01,displaylevel=1,v=ones(n),eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false,num_restart_ritz_vecs=8,max_subspace=150);
     λ_shifted = λ[1];v=u[:,1];
 
     #Rescale and shift back to the eigenvalue of the original problem
@@ -57,3 +57,4 @@ using Random
     @test norm(compute_Mlincomb(pepnep,λ[3],u[:,3])) < TOL
 
 end
+

--- a/test/nlar.jl
+++ b/test/nlar.jl
@@ -29,7 +29,7 @@ using Random
     nep1 = shift_and_scale(nep1_spmf,shift=shift,scale=scale);
 
     #Run NLAR on the shifted and scaled NEP (nev set to 1 to save time. Method works for the case of finding multiple eigenvalues as well)
-    λ,u = nlar(nep1, tol=TOL, λ0 = 0,maxit=500, nev = 4, R=0.01,displaylevel=1,v0=ones(n),eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false,num_restart_ritz_vecs=8,max_subspace=50);
+    λ,u = nlar(nep1, tol=TOL, λ0 = 0,maxit=500, nev = 10, R=0.01,displaylevel=1,v0=ones(n),eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false,num_restart_ritz_vecs=8,max_subspace=50);
     λ_shifted = λ[1];v=u[:,1];
 
     #Rescale and shift back to the eigenvalue of the original problem

--- a/test/nlar.jl
+++ b/test/nlar.jl
@@ -29,7 +29,7 @@ using Random
     nep1 = shift_and_scale(nep1_spmf,shift=shift,scale=scale);
 
     #Run NLAR on the shifted and scaled NEP (nev set to 1 to save time. Method works for the case of finding multiple eigenvalues as well)
-    λ,u = nlar(nep1, tol=TOL, λ0 = 0,maxit=500, nev = 4, R=0.01,mm =1,displaylevel=1,v0=ones(n),eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false);
+    λ,u = nlar(nep1, tol=TOL, λ0 = 0,maxit=500, nev = 4, R=0.01,displaylevel=1,v0=ones(n),eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false,num_restart_ritz_vecs=8,max_subspace=50);
     λ_shifted = λ[1];v=u[:,1];
 
     #Rescale and shift back to the eigenvalue of the original problem
@@ -48,7 +48,7 @@ using Random
     c = sortperm(abs.(Dc))
     @info " 6 smallest eigenvalues found by polyeig() according to the absolute values: $(Dc[c[1:6]])"
 
-    λ,u = nlar(pepnep, tol=TOL, maxit=60, nev = 3, R=0.001,mm=1,displaylevel=1, λ0=Dc[4]+1e-2,v0=ones(size(pepnep,1)), eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false);
+    λ,u = nlar(pepnep, tol=TOL, maxit=60, nev = 3, R=0.001,displaylevel=1, λ0=Dc[4]+1e-2,v0=ones(size(pepnep,1)), eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false);
     @info " Smallest eigenvalues found: $λ"
 
     # Test residuals

--- a/test/nlar.jl
+++ b/test/nlar.jl
@@ -29,7 +29,7 @@ using Random
     nep1 = shift_and_scale(nep1_spmf,shift=shift,scale=scale);
 
     #Run NLAR on the shifted and scaled NEP (nev set to 1 to save time. Method works for the case of finding multiple eigenvalues as well)
-    λ,u = nlar(nep1, tol=TOL, λ0 = 0,maxit=500, nev = 10, R=0.01,displaylevel=1,v0=ones(n),eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false,num_restart_ritz_vecs=8,max_subspace=50);
+    λ,u = nlar(nep1, tol=TOL, λ = 0,maxit=500, nev = 10, R=0.01,displaylevel=1,v=ones(n),eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false,num_restart_ritz_vecs=8,max_subspace=50);
     λ_shifted = λ[1];v=u[:,1];
 
     #Rescale and shift back to the eigenvalue of the original problem
@@ -48,7 +48,7 @@ using Random
     c = sortperm(abs.(Dc))
     @info " 6 smallest eigenvalues found by polyeig() according to the absolute values: $(Dc[c[1:6]])"
 
-    λ,u = nlar(pepnep, tol=TOL, maxit=60, nev = 3, R=0.001,displaylevel=1, λ0=Dc[4]+1e-2,v0=ones(size(pepnep,1)), eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false);
+    λ,u = nlar(pepnep, tol=TOL, maxit=60, nev = 3, R=0.001,displaylevel=1, λ=Dc[4]+1e-2,v=ones(size(pepnep,1)), eigval_sorter=residual_eigval_sorter,inner_solver_method=NEPSolver.IARInnerSolver,qrfact_orth=false);
     @info " Smallest eigenvalues found: $λ"
 
     # Test residuals


### PR DESCRIPTION
A basic version of restarting for NLAR(See Issue #83 ) has been implemented in src/method_nlar.jl. The function nlar() differs from the previous version in the following ways:

(1) The arguement 'mm' which specified how many ritz values should be returned by the sorter functions has been removed.

(2)Two new arguements: `max_subspace` which specifies the maximum allowable size of the subspace basis before we ought to restart and `num_restart_ritz_vecs` which specifies the number of ritz vectors that should be a part of the new basis. Hence, after each restart, the size of the basis is `num_restart_ritz_vecs + m`, where `m` is the number of eigenpairs to which we have already converged. 

(3)The variable `cbs` keeps track of the current basis size. The memory for the subspace basis matrix `V` is allocated apriori: `V::Matrix{T}= zeros(T,n,max_subspace)`. The following if-statement implements the restarting:
`if(size(Vk,2) >= max_subspace)
                cbs = m+num_restart_ritz_vecs; 

                #Construct the new basis
                Zv = view(Z,:,1:cbs);
                Zv[:,1:m] = X[:,1:m]; #Set the first m vectors of the restarted basis to be the converged eigenvectors
                Zv[:,m+1:cbs] = Vk*yv[:,1:num_restart_ritz_vecs]; #Set the rest to be the ritz vectors of the projected problem
                
                Q,_ = qr(Zv); #Thin QR-factorization
                V[:,1:cbs] = Matrix(Q);
else
                ..................
end`