### PR TITLE
Naive poly_roots 

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,9 +1,3 @@
-[[AbstractAlgebra]]
-deps = ["InteractiveUtils", "LinearAlgebra", "Markdown", "Pkg", "Random", "SparseArrays", "Test"]
-git-tree-sha1 = "71feaaa29a5ce42f45c2814bc2993c46b141c338"
-uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.1.3"
-
 [[AbstractFFTs]]
 deps = ["Compat", "LinearAlgebra"]
 git-tree-sha1 = "8d59c3b1463b5e0ad05a3698167f85fac90e184d"
@@ -112,24 +106,6 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-
-[[PolynomialFactors]]
-deps = ["AbstractAlgebra", "Combinatorics", "LinearAlgebra", "Primes", "Test"]
-git-tree-sha1 = "b6669bc583e224fda09917771b4f3874c3cee99a"
-uuid = "ec145902-31c2-532e-934a-7c64254c4b82"
-version = "0.2.0"
-
-[[PolynomialRoots]]
-deps = ["Pkg", "Test"]
-git-tree-sha1 = "0ba43554d01a5f4d63e4ac51623d3d8595b7146e"
-uuid = "3a141323-8675-5d76-9d11-e1df1406c778"
-version = "0.2.0"
-
-[[PolynomialZeros]]
-deps = ["AbstractAlgebra", "LinearAlgebra", "PolynomialFactors", "PolynomialRoots", "Polynomials", "Printf", "Random", "Roots", "Test"]
-git-tree-sha1 = "048b773c30f7a0563eed4c70d5dae2625f41b0ec"
-uuid = "11d3f387-6b1b-5124-abbd-847758a5de3c"
-version = "0.2.0"
 
 [[Polynomials]]
 deps = ["LinearAlgebra", "SparseArrays", "Test"]

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -570,8 +570,14 @@ julia> compute_Mder(pep,3)-(A0+A1*3+A2*9)
         for i=1:size(nep.A,1)
             a[i]=dot(y,nep.A[i]*x);
         end
-        p=Poly(a);
-        rr=real(poly_roots(p));  # Only works if polynomial roots are real
+        m=size(nep.A,1);
+        A=zeros(T,m-1,m-1);
+        for k=1:m-1
+            A[ķ,k+1]=1;
+            A[end,k]=-a[k]/a[end]
+        end
+        pp=eigvals(A);
+        rr=real(pp);  # This function only works if polynomial roots are real
         return rr
     end
 

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -578,9 +578,12 @@ julia> compute_Mder(pep,3)-(A0+A1*3+A2*9)
             A[end,k]=-a[k]/a[end]
         end
         pp=eigvals(A);
-        rr=real(pp);  # This function only works if polynomial roots are real
-        II=sortperm(abs.(rr .- target))
-        return rr[II];
+        if (T <: Real) # If we specify real arithmetic, return real eigvals
+            pp=real(pp);
+        end
+
+        II=sortperm(abs.(pp .- target))
+        return pp[II];
     end
 
     # Overload a version of eigvals(::Matrix{BigFloat}) for compute_rf

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -2,8 +2,6 @@ module NEPTypes
     using ..NEPCore
     using SparseArrays
     using LinearAlgebra
-    using PolynomialZeros
-    using Polynomials
     using InteractiveUtils
 
     # Specializalized NEPs

--- a/test/sgiter.jl
+++ b/test/sgiter.jl
@@ -16,7 +16,7 @@ using LinearAlgebra
                  λ = -10,
                  displaylevel = displaylevel,
                  maxit = 100, tol=1e-12)
-   @test norm(compute_Mlincomb(nep,λ,v)) < eps(Float64)*100
+   @test norm(compute_Mlincomb(nep,λ,v)) < 1e-9
 
 
    λ,v = sgiter(Float64,

--- a/test/sgiter.jl
+++ b/test/sgiter.jl
@@ -15,7 +15,7 @@ using LinearAlgebra
                  λ_max = 0,
                  λ = -10,
                  displaylevel = displaylevel,
-                 maxit = 100)
+                 maxit = 100, tol=1e-12)
    @test norm(compute_Mlincomb(nep,λ,v)) < eps(Float64)*100
 
 


### PR DESCRIPTION
This contains a naive fix for #120 where we rely on companion matrix construction and do a couple of steps of Rayleigh qoutient iteration with output of `eig(::Matrix{Float64})` as starting values . We only used `poly_roots` in one place, so the fix is not so intrusive.  