### PR TITLE
LowRankFactorizationNEP to NEPTypes

### DIFF
--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -1220,6 +1220,7 @@ Returns true/false if the NEP is sparse (if compute_Mder() returns sparse)
 
 
     include("nep_transformations.jl")
+    include("low_rank_nep.jl")
 
     # structure exploitation for DEP
     function compute_Mlincomb(nep::DEP,λ::Number,V::AbstractVecOrMat,
@@ -1436,5 +1437,8 @@ Returns true/false if the NEP is sparse (if compute_Mder() returns sparse)
             return z
         end
     end
+
+
+
 
 end  # End Module

--- a/src/gallery_extra/gallery_examples.jl
+++ b/src/gallery_extra/gallery_examples.jl
@@ -171,7 +171,7 @@ function sine_nep()
 end
 
 
-# From the tutorial on NEP-PACK online user's manual
+# From the tutorial on NEP-PACK online user's manual (except we use LowRankNEP)
 function schrodinger_movebc(n=1000,L0=1,L1=8,α=25*pi/2,V0=10.0)
 
     # Discreatization matrices
@@ -191,7 +191,19 @@ function schrodinger_movebc(n=1000,L0=1,L1=8,α=25*pi/2,V0=10.0)
     g=S-> cosh((L1-L0)*hh(S))
     f=S-> inv(hh(S))*sinh((L1-L0)*hh(S))
 
-    # Construct NEP (This could be a low-rank SPMF NEP since G & F are low rank)
-    nep=SPMF_NEP([Dn-Vn,In,G,F],[f1,f2,g,f]);
+    # First NEP
+    nep1=SPMF_NEP([Dn-Vn,In],[f1,f2]);
+
+    # Second NEP. Construct as a LowRankFactorizedNEP
+    nep2=SPMF_NEP([G,F],[g,f])
+
+    Lv1=sparse([zeros(n-1,1);1.0]);
+    Lv2=sparse([zeros(n-1,1);1.0]);
+    Uv1=sparse([zeros(n-1,1);1.0]);
+    Uv2=sparse(reshape(F[end,:],n,1));
+    nep2=LowRankFactorizedNEP([Lv1,Lv2],[Uv1,Uv2],[g,f]);
+
+    # Create a sum of the two
+    nep=SumNEP(nep1,nep2b);
     return nep
 end

--- a/src/gallery_extra/gallery_examples.jl
+++ b/src/gallery_extra/gallery_examples.jl
@@ -204,6 +204,6 @@ function schrodinger_movebc(n=1000,L0=1,L1=8,α=25*pi/2,V0=10.0)
     nep2=LowRankFactorizedNEP([Lv1,Lv2],[Uv1,Uv2],[g,f]);
 
     # Create a sum of the two
-    nep=SumNEP(nep1,nep2b);
+    nep=SumNEP(nep1,nep2);
     return nep
 end

--- a/src/low_rank_nep.jl
+++ b/src/low_rank_nep.jl
@@ -1,6 +1,26 @@
 export LowRankFactorizedNEP
 
-"SPMF with low rank LU factors for each matrix."
+"
+    struct LowRankFactorizedNEP <: AbstractSPMF
+    function LowRankFactorizedNEP(L::Vector,U::Vector,f::Vector)
+    function LowRankFactorizedNEP(L::Vector,U::Vector,A::Vector, f::Vector)
+
+Representation of a `NEP` which has low rank in the sense that it is an `SPMF`
+where each of the terms are factorized: `A[i]=L[i]*U[i]'`. The factorization
+is provided in the `L` and `U` vectors and the full matrix `A[i]` can be
+either provided (or is otherwise implicitly computed).
+
+# Example:
+```
+julia> L=randn(5,1); U=randn(5,1);
+julia> f=S->exp(S)
+julia> nep=LowRankFactorizedNEP([L],[U],[f]);
+julia> X=randn(5,2);
+julia> norm(compute_Mlincomb(nep,0.0,X)-L*U'*X*ones(2),1)
+6.661338147750939e-16
+```
+
+"
 struct LowRankFactorizedNEP{S<:AbstractMatrix{<:Number}} <: AbstractSPMF{AbstractMatrix}
     spmf::SPMF_NEP
     r::Int          # Sum of ranks of matrices
@@ -35,7 +55,6 @@ end
 
 
 
-"Create an empty LowRankFactorizedNEP."
 LowRankFactorizedNEP(::Type{T}, n) where T<:Number =
     LowRankFactorizedNEP(SPMF_NEP(n), 0, Vector{Matrix{T}}(), Vector{Matrix{T}}())
 

--- a/src/low_rank_nep.jl
+++ b/src/low_rank_nep.jl
@@ -1,0 +1,56 @@
+export LowRankFactorizedNEP
+
+"SPMF with low rank LU factors for each matrix."
+struct LowRankFactorizedNEP{S<:AbstractMatrix{<:Number}} <: AbstractSPMF{AbstractMatrix}
+    spmf::SPMF_NEP
+    r::Int          # Sum of ranks of matrices
+    L::Vector{S}    # Low rank L factors of matrices
+    U::Vector{S}    # Low rank U factors of matrices
+end
+
+function LowRankFactorizedNEP(L::Vector{S},U::Vector{S},f) where {S<:AbstractMatrix}
+    q=size(L,1);
+    A = Vector{S}(undef, q)
+    r::Int=0
+
+    for k = 1:q
+        # if A is not specified, create it from LU factors
+        A[k] = L[k] * U[k]'
+        r += size(U[k], 2)
+    end
+    return LowRankFactorizedNEP{S}(SPMF_NEP(A, f, align_sparsity_patterns=true), r, L, U)
+
+
+end
+function LowRankFactorizedNEP(L::Vector{S},U::Vector{S},A, f) where {S<:AbstractMatrix}
+    q=size(L,1);
+    r::Int=0
+    for k = 1:q
+        r += size(U[k], 2)     # Compute the rank
+    end
+    return LowRankFactorizedNEP{S}(SPMF_NEP(A, f, align_sparsity_patterns=true), r, L, U)
+
+
+end
+
+
+
+"Create an empty LowRankFactorizedNEP."
+LowRankFactorizedNEP(::Type{T}, n) where T<:Number =
+    LowRankFactorizedNEP(SPMF_NEP(n), 0, Vector{Matrix{T}}(), Vector{Matrix{T}}())
+
+# forward function calls to SPMF
+compute_Mder(nep::LowRankFactorizedNEP, λ::T, i::Int = 0) where T<:Number =
+    compute_Mder(nep.spmf, λ, i)
+
+compute_Mlincomb(nep::LowRankFactorizedNEP, λ::T, V::Union{Vector{T}, Matrix{T}}, a::Vector = ones(T, size(V, 2))) where T<:Number =
+    compute_Mlincomb(nep.spmf, λ, V, a)
+
+compute_MM(nep::LowRankFactorizedNEP, par...)  =
+    compute_MM(nep.spmf, par...)
+
+size(nep::LowRankFactorizedNEP) = size(nep.spmf)
+size(nep::LowRankFactorizedNEP, dim) = size(nep.spmf, dim)
+
+get_Av(nep::LowRankFactorizedNEP) = get_Av(nep.spmf)
+get_fv(nep::LowRankFactorizedNEP) = get_fv(nep.spmf)

--- a/src/rk_helper/rk_nep.jl
+++ b/src/rk_helper/rk_nep.jl
@@ -4,7 +4,7 @@ using SparseArrays
 export RKNEP
 export MatrixAndFunction
 export LowRankMatrixAndFunction
-export LowRankFactorizedNEP
+
 
 export get_rk_nep
 
@@ -13,6 +13,27 @@ import ..NEPCore.compute_Mder
 import ..NEPCore.compute_Mlincomb
 import ..NEPTypes.get_Av
 import ..NEPTypes.get_fv
+
+# Additional constructor for particle example
+function LowRankFactorizedNEP(Amf::AbstractVector{LowRankMatrixAndFunction{S}}) where {T<:Number, S<:AbstractMatrix{T}}
+    q = length(Amf)
+    r = 0
+    f = Vector{Function}(undef, q)
+    A = Vector{S}(undef, q)
+    L = Vector{S}(undef, q)
+    U = Vector{S}(undef, q)
+
+    for k = 1:q
+        f[k] = Amf[k].f
+        L[k] = Amf[k].L
+        U[k] = Amf[k].U
+        # if A is not specified, create it from LU factors
+        A[k] = isempty(Amf[k].A) ? L[k] * U[k]' : Amf[k].A
+        r += size(U[k], 2)
+    end
+
+    return LowRankFactorizedNEP(SPMF_NEP(A, f, align_sparsity_patterns=true), r, L, U)
+end
 
 "NEP instance supplemented with various structures used for rational Krylov problems."
 struct RKNEP{S<:AbstractMatrix{<:Number}, T<:Number}
@@ -82,50 +103,6 @@ function compactlu(L, U)
     return L[:,select], U[select,:]
 end
 
-"SPMF with low rank LU factors for each matrix."
-struct LowRankFactorizedNEP{S<:AbstractMatrix{<:Number}} <: AbstractSPMF{AbstractMatrix}
-    spmf::SPMF_NEP
-    r::Int          # Sum of ranks of matrices
-    L::Vector{S}    # Low rank L factors of matrices
-    U::Vector{S}    # Low rank U factors of matrices
-end
-
-function LowRankFactorizedNEP(Amf::AbstractVector{LowRankMatrixAndFunction{S}}) where {T<:Number, S<:AbstractMatrix{T}}
-    q = length(Amf)
-    r = 0
-    f = Vector{Function}(undef, q)
-    A = Vector{S}(undef, q)
-    L = Vector{S}(undef, q)
-    U = Vector{S}(undef, q)
-
-    for k = 1:q
-        f[k] = Amf[k].f
-        L[k] = Amf[k].L
-        U[k] = Amf[k].U
-        # if A is not specified, create it from LU factors
-        A[k] = isempty(Amf[k].A) ? L[k] * U[k]' : Amf[k].A
-        r += size(U[k], 2)
-    end
-
-    return LowRankFactorizedNEP(SPMF_NEP(A, f, align_sparsity_patterns=true), r, L, U)
-end
-
-"Create an empty LowRankFactorizedNEP."
-LowRankFactorizedNEP(::Type{T}, n) where T<:Number =
-    LowRankFactorizedNEP(SPMF_NEP(n), 0, Vector{Matrix{T}}(), Vector{Matrix{T}}())
-
-# forward function calls to SPMF
-compute_Mder(nep::LowRankFactorizedNEP, λ::T, i::Int = 0) where T<:Number =
-    compute_Mder(nep.spmf, λ, i)
-
-compute_Mlincomb(nep::LowRankFactorizedNEP, λ::T, V::Union{Vector{T}, Matrix{T}}, a::Vector = ones(T, size(V, 2))) where T<:Number =
-    compute_Mlincomb(nep.spmf, λ, V, a)
-
-size(nep::LowRankFactorizedNEP) = size(nep.spmf)
-size(nep::LowRankFactorizedNEP, dim) = size(nep.spmf, dim)
-
-get_Av(nep::LowRankFactorizedNEP) = get_Av(nep.spmf)
-get_fv(nep::LowRankFactorizedNEP) = get_fv(nep.spmf)
 
 "Create RKNEP instance, exploiting the type of the input NEP as much as possible"
 function get_rk_nep(::Type{T}, nep::NEP) where T<:Real


### PR DESCRIPTION
Moved the `LowRankFactorizedNEP` to NEPTypes. Made `schrodinger_movebc` use it + added a bit of functionality.  Not in this PR: Some of the compute functions can be made more efficient by not constructing the full matrix, but only working with the factorizations. Some more Gallery examples could benefit from using this (as commented in the gallery).

I'm adding max as reviewer as courtesy. I know you're busy.