### PR TITLE
Simple NEP creator helpers 

### DIFF
--- a/docs/src/bemtutorial.md
+++ b/docs/src/bemtutorial.md
@@ -113,3 +113,7 @@ for k=1:size(nep.mesh,1);
     plot_wireframe(X,Y,Z,color=[0;0;0],linewidth=1,alpha=0.5,);
 end
 ```
+
+Note: The above functionality can also be achieved with  `Mder_NEP` in the development version of NEP-PACK
+
+![To the top](http://jarlebring.se/onepixel.png?NEPPACKDOC_BEMTUTORIAL)

--- a/docs/src/tutorial_call_python.md
+++ b/docs/src/tutorial_call_python.md
@@ -157,4 +157,6 @@ julia> r=A*v+λ*B*v+exp(λ)*C*v;
 ```
 Residual is almost zero, so we have a solution.
 
+Note: The above functionality can also be achieved with  `Mder_NEP` in the development version of NEP-PACK
+
 ![To the top](http://jarlebring.se/onepixel.png?NEPPACKDOC_PYTHON1)

--- a/docs/src/tutorial_matlab1.md
+++ b/docs/src/tutorial_matlab1.md
@@ -82,4 +82,7 @@ The residual is small and we have a solution
 julia> norm(compute_Mlincomb(nep,λ,v))
 3.111596859559977e-15
 ```
+
+Note: The above functionality can also be achieved with  `Mder_NEP` in the development version of NEP-PACK
+
 ![To the top](http://jarlebring.se/onepixel.png?NEPPACKDOC_MATLAB1)

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -1439,6 +1439,6 @@ Returns true/false if the NEP is sparse (if compute_Mder() returns sparse)
     end
 
 
-
+    include("nep_type_helpers.jl");
 
 end  # End Module

--- a/src/nep_type_helpers.jl
+++ b/src/nep_type_helpers.jl
@@ -1,0 +1,67 @@
+# Helper functions for NEPTypes (imported from NEPTypes.jl)
+export Mder_NEP;
+
+struct Mder_NEP <: NEP
+    n::Int;
+    Mder_fun::Function
+    maxder::Int;
+end
+"""
+    Mder_NEP(Mder_fun,n; maxder=max)
+
+Creates a `NEP` from its `compute_Mder` function defined by the
+function handle `Mder_fun`. The `Mder_fun(s,der)` takes two parameters a
+scalar `s::Number`, derivative number  `der`. The size `n::Int` must also
+be specified. The function `Mder_fun(s,der)` should return the n x n matrix
+corresponding to the  `der`th derivatve. If only a
+limited number of derivatives are available, `maxder` should be set, e.g.,
+if not derivatives are implemented, set `maxder=0`. The function
+`compute_Mlicomb` is automatically available by (delegation) to
+`compute_Mlincomb_from_Mder`.
+
+Note: This is a convenience function it is not recommended for high performance computations, since, e.g., it will not maintain type stability.
+
+# Example
+
+The following example defines a linear eigenvalue problem
+`A0+λA1` defined in an external function.
+```julia-repl
+julia> using LinearAlgebra; # For the I function
+julia> function my_Mder(s,der)
+    A0=ones(Float64,3,3)-I; A0[1,1]=-1;
+    A1=ones(Float64,3,3)*3; A1[2,3]=0;
+    if (der==0)
+       return A0+A1*s;
+    elseif (der==1)
+       return A1;
+    else
+       return zero(A0);
+    end
+end
+julia> nep=Mder_NEP(my_Mder,3);
+julia> (λ,v)=augnewton(nep,v=ones(3));
+julia> norm(compute_Mder(nep,λ)*v)
+5.551115123125783e-17
+```
+"""
+function Mder_NEP(Mder_fun::Function,n; maxder=typemax(Int64))
+    return Mder_NEP(n,Mder_fun,maxder);
+end
+
+function compute_Mder(nep::Mder_NEP,s::Number,der::Integer=0)
+    if (der>nep.maxder)
+        error("Derivatives higher than ",nep.maxder," not available.");
+    end
+    return nep.Mder_fun(s,der);
+end
+
+# Delegate compute_Mlincomb to compute_Mlincomb_from_Mder
+compute_Mlincomb(nep::Mder_NEP,λ::Number,V::AbstractVecOrMat, a::Vector) = compute_Mlincomb_from_Mder(nep,λ,V,a)
+compute_Mlincomb(nep::Mder_NEP,λ::Number,V::AbstractVecOrMat) = compute_Mlincomb(nep,λ,V, ones(eltype(V),size(V,2)))
+
+function size(nep::Union{Mder_NEP})
+    return (nep.n,nep.n)
+end
+function size(nep::Union{Mder_NEP},dim)
+    return nep.n
+end

--- a/src/nep_type_helpers.jl
+++ b/src/nep_type_helpers.jl
@@ -1,5 +1,6 @@
 # Helper functions for NEPTypes (imported from NEPTypes.jl)
 export Mder_NEP;
+export Mder_Mlincomb_NEP;
 
 struct Mder_Mlincomb_NEP <: NEP
     n::Int;
@@ -12,9 +13,9 @@ end
     Mder_NEP(Mder_fun,n; maxder=max)
 
 Creates a `NEP` from its `compute_Mder` function defined by the
-function handle `Mder_fun`. The `Mder_fun(s,der)` takes two parameters a
-scalar `s::Number`, derivative number  `der`. The size `n::Int` must also
-be specified. The function `Mder_fun(s,der)` should return the n x n matrix
+function handle `Mder_fun`. The `Mder_fun(λ,der)` takes two parameters a
+scalar `λ::Number`, derivative number  `der`. The size `n::Int` must also
+be specified. The function `Mder_fun(λ,der)` should return the n x n matrix
 corresponding to the  `der`th derivatve. If only a
 limited number of derivatives are available, `maxder` should be set, e.g.,
 if not derivatives are implemented, set `maxder=0`. The function
@@ -24,8 +25,7 @@ if not derivatives are implemented, set `maxder=0`. The function
 Note: This is a convenience function it is not recommended for high performance computations, since, e.g., it will not maintain type stability.
 
 # Example
-
-The following example defines a linear eigenvalue problem
+ The following example defines a linear eigenvalue problem
 `A0+λA1` defined in an external function.
 ```julia-repl
 julia> using LinearAlgebra; # For the I function
@@ -54,16 +54,74 @@ function Mder_NEP(Mder_fun::Function,n; maxder=typemax(Int64))
                              Mlincomb_fun,maxder_Mlincomb);
 end
 
-function compute_Mder(nep::Mder_Mlincomb_NEP,s::Number,der::Integer=0)
-    if (der>nep.maxder)
+
+"""
+    Mder_Mlincomb_NEP(n,Mder_fun [,maxder_Mder] Mlincomb_fun, [maxder_Mlincomb])
+
+Creates a `NEP` from its `compute_Mder` and `compute_Mlincomb`functions
+ defined by the function handles `Mder_fun` and `Mlincomb_fun`. The `Mlincomb_fun(λ,X)` takes two parameters a
+scalar `λ::Number` and a matrix `X`.  The size `n::Int` must also
+be specified. The function `Mlincomb_fun(λ,X)` should return a vector corresponding of the linear combination of derivatives multiplied with the vectors in X. If only a
+limited number of derivatives are implemented, `maxder_Mder` or
+`maxder_Mlincomb` should be set, e.g., if not derivatives are implemented,
+set `maxder=0`.
+
+See also `Mder_NEP`.
+
+Note: This is a convenience function it is not recommended for high performance computations, since, e.g., it will not maintain type stability.
+
+# Example
+
+The following example defines a linear eigenvalue problem
+`A0+λA1` defined in an external function.
+```julia-repl
+julia> using LinearAlgebra; # For the I function
+julia> function my_Mder(s,der)
+    A0=ones(Float64,3,3)-I; A0[1,1]=-1;
+    A1=ones(Float64,3,3)*3; A1[2,3]=0;
+    if (der==0)
+       return A0+A1*s;
+    elseif (der==1)
+       return A1;
+    else
+       return zero(A0);
+    end
+end
+julia> function my_Mlincomb(s,X) # Compute linear comb of derivatives
+    A0=ones(Float64,3,3)-I; A0[1,1]=-1;
+    A1=ones(Float64,3,3)*3; A1[2,3]=0;
+    if (size(X,2) <= 1)
+       return A0*X[:,1]+s*A1*X[:,1]
+    else # This means: size(X,2) => 2
+       return A0*X[:,1]+A1*(s*X[:,1]+X[:,2]);
+    end
+end
+julia> nep=Mder_Mlincomb_NEP(3,my_Mder,my_Mlincomb);
+julia> (λ,v)=augnewton(nep,v=[1.0; 2.3; 0.0])
+julia> norm(compute_Mder(nep,λ)*v)
+6.798699777552591e-17
+```
+"""
+function Mder_Mlincomb_NEP(n,
+                           Mder_fun::Function, maxder_Mder,
+                           Mlincomb_fun::Function, maxder_Mlincomb::Int=typemax(Int64))
+    return Mder_Mlincomb_NEP(n,Mder_fun,maxder,
+                             Mlincomb_fun,maxder_Mlincomb);
+end
+Mder_Mlincomb_NEP(n,Mder_fun::Function,Mlincomb_fun::Function) = Mder_Mlincomb_NEP(n,Mder_fun,typemax(Int64),Mlincomb_fun);
+
+
+
+function compute_Mder(nep::Mder_Mlincomb_NEP,λ::Number,der::Integer=0)
+    if (der>nep.maxder_Mder)
         error("Derivatives higher than ",nep.maxder," not available.");
     end
-    return nep.Mder_fun(s,der);
+    return nep.Mder_fun(λ,der);
 end
 
-function compute_Mlincomb(nep::Mder_Mlincomb_NEP,s::Number,V::AbstractVecOrMat)
-    if (size(X,2)<=nep.maxder_Mlincomb)
-        return nep.Mlincomb_fun(s,V); # Call external routine
+function compute_Mlincomb(nep::Mder_Mlincomb_NEP,λ::Number,V::AbstractVecOrMat)
+    if (size(V,2)<=nep.maxder_Mlincomb)
+        return nep.Mlincomb_fun(λ,V); # Call external routine
     else
         # Delegate to if we do not have implementation of Mlincomb
         return compute_Mlincomb_from_Mder(nep,λ,V,ones(eltype(V),size(V,2)))

--- a/test/nep_creator_helpers.jl
+++ b/test/nep_creator_helpers.jl
@@ -2,8 +2,10 @@
 using NonlinearEigenproblemsTest
 using NonlinearEigenproblems
 using Test
+using LinearAlgebra
 
 @bench @testset "NEPTypes: creat help" begin
+    # Mder_NEP
     function my_Mder(s,der)
         A0=ones(Float64,3,3);
         A1=ones(Float64,3,3)*3; A1[2,3]=0;
@@ -20,5 +22,21 @@ using Test
     λ=-1.2+0.2im;
     X=[ -0.715845   0.865534   0.254796 ; -0.856405  -0.482516   0.0265129;
   1.02593   -0.62892   -2.09615  ]
-    norm(compute_Mlincomb(nep,λ,X)-compute_Mlincomb(nep_ref,λ,X))
+    @test norm(compute_Mlincomb(nep,λ,X)-compute_Mlincomb(nep_ref,λ,X))<eps()*100
+
+
+    # Mder_Mlincomb_NEP
+    function my_Mlincomb(s,X)
+        A0=ones(Float64,3,3);
+        A1=ones(Float64,3,3)*3; A1[2,3]=0;
+        z=zeros(size(A0,1))
+        for k=1:size(X,2)
+            der=k-1;
+            z+=(3^der)*exp(3*s)*(A0*X[:,k]);
+            z+=(factorial(der)*((-1)^der)/(3.3+s)^(der+1))*(A1*X[:,k]);
+        end
+        return z;
+    end
+    nep_mlincomb=Mder_Mlincomb_NEP(3,my_Mder, my_Mlincomb)
+    @test norm(compute_Mlincomb(nep,λ,X)-compute_Mlincomb(nep_mlincomb,λ,X))<eps()*100
 end

--- a/test/nep_creator_helpers.jl
+++ b/test/nep_creator_helpers.jl
@@ -1,0 +1,24 @@
+# Test for nep helper creators
+using NonlinearEigenproblemsTest
+using NonlinearEigenproblems
+using Test
+
+@bench @testset "NEPTypes: creat help" begin
+    function my_Mder(s,der)
+        A0=ones(Float64,3,3);
+        A1=ones(Float64,3,3)*3; A1[2,3]=0;
+        return (3^der)*exp(3*s)*A0+factorial(der)*((-1)^der)*A1/(3.3+s)^(der+1)
+    end
+    AA0=ones(Float64,3,3);
+    AA1=ones(Float64,3,3)*3; AA1[2,3]=0;
+    nep_ref=SPMF_NEP([AA0,AA1],[s->exp(3*s), S->inv(3.3*I+S)]);
+    nep=Mder_NEP(my_Mder,3)
+
+    λ=3.3;
+    norm(compute_Mder(nep,λ,4)-compute_Mder(nep_ref,λ,4))
+
+    λ=-1.2+0.2im;
+    X=[ -0.715845   0.865534   0.254796 ; -0.856405  -0.482516   0.0265129;
+  1.02593   -0.62892   -2.09615  ]
+    norm(compute_Mlincomb(nep,λ,X)-compute_Mlincomb(nep_ref,λ,X))
+end

--- a/test/nep_creator_helpers.jl
+++ b/test/nep_creator_helpers.jl
@@ -14,7 +14,7 @@ using LinearAlgebra
     AA0=ones(Float64,3,3);
     AA1=ones(Float64,3,3)*3; AA1[2,3]=0;
     nep_ref=SPMF_NEP([AA0,AA1],[s->exp(3*s), S->inv(3.3*I+S)]);
-    nep=Mder_NEP(my_Mder,3)
+    nep=Mder_NEP(3,my_Mder)
 
     λ=3.3;
     norm(compute_Mder(nep,λ,4)-compute_Mder(nep_ref,λ,4))


### PR DESCRIPTION
This should resolve #159. It adds two creators:
```
Mder_NEP
Mder_Mlincomb_NEP
```
Simple example from documentation:
```julia
julia> using LinearAlgebra; # For the I function
julia> function my_Mder(s,der)
    A0=ones(Float64,3,3)-I; A0[1,1]=-1;
    A1=ones(Float64,3,3)*3; A1[2,3]=0;
    if (der==0)
       return A0+A1*s;
    elseif (der==1)
       return A1;
    else
       return zero(A0);
    end
end
julia> nep=Mder_NEP(3,my_Mder);
julia> (λ,v)=augnewton(nep,v=ones(3));
julia> norm(compute_Mder(nep,λ)*v)
5.551115123125783e-17

```
The tutorials have only been updated with a note that this can be done easier in the development version. We can update the tutorials after the next release. 
