### PR TITLE
method_beyn: compute eigvecs from the SVD as in Beyn's paper

### DIFF
--- a/src/inner_solver.jl
+++ b/src/inner_solver.jl
@@ -244,6 +244,6 @@ function inner_solve(TT::Type{ContourBeynInnerSolver},T_arit::Type,nep::NEPTypes
     # Radius  computed as the largest distance σ and λv and a litte more
     radius = maximum(abs.(σ .- λv))*1.5
     Neig = min(Neig,size(nep,1))
-    λ,V = contour_beyn(T_arit,nep,k=Neig,σ=σ,radius=radius,compute_eigenvectors=true)
+    λ,V = contour_beyn(T_arit,nep,k=Neig,σ=σ,radius=radius)
     return λ,V
 end

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -14,16 +14,19 @@ The function computes eigenvalues using Beyn's contour integral approach,
 using a circle centered at `σ` with radius `radius`. The quadrature method
 is specified in `quad_method` (`:ptrapz`, `:quadg`,`:quadg_parallel`,`:quadgk`). `k`
 specifies the number of computed eigenvalues. `N` corresponds to the
-number of quadrature points. Circles is the only supported contour. The
+number of quadrature points. Circles are the only supported contours. The
 `linsolvercreator` must create a linsolver that can handle (rectangular) matrices
-as right-hand sides.
+as right-hand sides, not only vectors.
 
 # Example
 ```julia-repl
+julia> using LinearAlgebra
 julia> nep=nep_gallery("dep0");
 julia> λv,V=contour_beyn(nep,radius=1,k=2,quad_method=:ptrapz);
-julia> minimum(svdvals(compute_Mder(nep,λv[1])))
-1.6106898471314257e-16
+julia> norm(compute_Mlincomb(nep,λv[1],V[:,1])) # Eigenpair 1
+5.778617503485546e-15
+julia> norm(compute_Mlincomb(nep,λv[2],V[:,2])) # Eigenpair 2
+3.095638020248726e-14
 ```
 # References
 * Wolf-Jürgen Beyn, An integral method for solving nonlinear eigenvalue problems, Linear Algebra and its Applications 436 (2012) 3839–3863

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -14,7 +14,9 @@ The function computes eigenvalues using Beyn's contour integral approach,
 using a circle centered at `σ` with radius `radius`. The quadrature method
 is specified in `quad_method` (`:ptrapz`, `:quadg`,`:quadg_parallel`,`:quadgk`). `k`
 specifies the number of computed eigenvalues. `N` corresponds to the
-number of quadrature points.
+number of quadrature points. Circles is the only supported contour. The
+`linsolvercreator` must create a linsolver that can handle (rectangular) matrices
+as right-hand sides.
 
 # Example
 ```julia-repl
@@ -39,16 +41,16 @@ function contour_beyn(::Type{T},
                          N::Integer=1000,  # Nof quadrature nodes
                          )where{T<:Number}
 
+    # Geometry
     g=t -> radius*exp(1im*t)
-    gp=t -> 1im*radius*exp(1im*t)
+    gp=t -> 1im*radius*exp(1im*t) # Derivative
 
     n=size(nep,1);
     Random.seed!(10); # Reproducability
     Vh=Array{T,2}(randn(real(T),n,k)) # randn only works for real
 
     if (k>n)
-        println("k=",k," n=",n);
-        error("Cannot compute more eigenvalues than the size of the NEP with contour_beyn()");
+        error("Cannot compute more eigenvalues than the size of the NEP with contour_beyn() k=",k," n=",n);
 
     end
 
@@ -71,10 +73,9 @@ function contour_beyn(::Type{T},
 
     local A0,A1
     if (quad_method == :quadg_parallel)
-        #@ifd(print(" using quadg_parallel"))
-        #A0=quadg_parallel(f1,0,2*pi,N);
-        #A1=quadg_parallel(f2,0,2*pi,N);
-        error("disabled");
+        @ifd(print(" using quadg_parallel"))
+        A0=quadg_parallel(f1,0,2*pi,N);
+        A1=quadg_parallel(f2,0,2*pi,N);
     elseif (quad_method == :quadg)
         #@ifd(print(" using quadg"))
         #A0=quadg(f1,0,2*pi,N);

--- a/test/beyn.jl
+++ b/test/beyn.jl
@@ -5,18 +5,19 @@ using NonlinearEigenproblems
 using Test
 using LinearAlgebra
 
+
 @testset "Beyn contour" begin
     nep=nep_gallery("dep0")
     @bench @testset "disk at origin" begin
 
-        λ,v=contour_beyn(nep,displaylevel=displaylevel,radius=1,k=2,quad_method=:ptrapz,compute_eigenvectors=true)
+        λ,v=contour_beyn(nep,displaylevel=displaylevel,radius=1,k=2,quad_method=:ptrapz)
 
         for i = 1:2
             @info "$i: $(λ[i])"
             M=compute_Mder(nep,λ[i])
             minimum(svdvals(M))
             @test minimum(svdvals(M)) < eps()*1000
-            @test norm(compute_Mlincomb(nep,λ[i],v[:,i]))/norm(v[:,i]) < eps()*100
+            @test norm(compute_Mlincomb(nep,λ[i],v[:,i]))/norm(v[:,i]) < eps()*500
         end
 
 
@@ -24,19 +25,19 @@ using LinearAlgebra
         M=compute_Mder(nep,λ[1])
         minimum(svdvals(M))
         @test minimum(svdvals(M))<eps()*1000
-        @test all(isnan.(v))
 
     end
     @bench @testset "shifted disk" begin
 
-        λ,v=contour_beyn(nep,displaylevel=displaylevel,σ=-0.2,radius=1.5,k=4,quad_method=:ptrapz,compute_eigenvectors=true)
+        λ,v=contour_beyn(nep,displaylevel=displaylevel,σ=-0.2,radius=1.5,
+                         k=4,quad_method=:ptrapz)
 
         for i = 1:4
             @info "$i: $(λ[i])"
             M=compute_Mder(nep,λ[i])
             minimum(svdvals(M))
             @test minimum(svdvals(M)) < eps()*1000
-            @test norm(compute_Mlincomb(nep,λ[i],v[:,i]))/norm(v[:,i]) < eps()*100
+            @test norm(compute_Mlincomb(nep,λ[i],v[:,i]))/norm(v[:,i]) < eps()*500
         end
 
     end

--- a/test/inner_solves.jl
+++ b/test/inner_solves.jl
@@ -34,5 +34,5 @@ using LinearAlgebra
     # TODO: this test results in a "Rank drop" warning, and a third eigenvalue that's not converged
     λv,V = inner_solve(ContourBeynInnerSolver, ComplexF64, pnep; λv=[0,1] .+ 0.0im, Neig=3)
     # @test minimum(svdvals(compute_Mder(pnep,λv[1]))) < eps()*100
-    verify_lambdas(2, pnep, λv[1:2], V[:,1:2], eps()*500)
+    verify_lambdas(2, pnep, λv[1:2], V[:,1:2], eps()*1000)
 end


### PR DESCRIPTION
This changes the eigvec extractions in method_beyn, to be based on more precisely what is proposed in Beyn's paper, i.e. use the singular vectors. I also removed the kwarg `compute_eigenvectors` so we always compute eigenvectors. The eigenvector computation is cheap in comparison to everything else in the algorithm, so I don't see any reason it should be optional here. 

Preparing to handle #162 and #154.

Could you give an Okay, @eringh? 