### PR TITLE
Beyn rankdrop checking

### DIFF
--- a/src/inner_solver.jl
+++ b/src/inner_solver.jl
@@ -244,6 +244,6 @@ function inner_solve(TT::Type{ContourBeynInnerSolver},T_arit::Type,nep::NEPTypes
     # Radius  computed as the largest distance σ and λv and a litte more
     radius = maximum(abs.(σ .- λv))*1.5
     Neig = min(Neig,size(nep,1))
-    λ,V = contour_beyn(T_arit,nep,k=Neig,σ=σ,radius=radius)
+    λ,V = contour_beyn(T_arit,nep,neigs=Neig,σ=σ,radius=radius)
     return λ,V
 end

--- a/src/inner_solver.jl
+++ b/src/inner_solver.jl
@@ -244,6 +244,6 @@ function inner_solve(TT::Type{ContourBeynInnerSolver},T_arit::Type,nep::NEPTypes
     # Radius  computed as the largest distance σ and λv and a litte more
     radius = maximum(abs.(σ .- λv))*1.5
     Neig = min(Neig,size(nep,1))
-    λ,V = contour_beyn(T_arit,nep,k=Neig,σ=σ,radius=radius,compute_eigenvectors=true)
+    λ,V = contour_beyn(T_arit,nep,k=Neig,σ=σ,radius=radius)
     return λ,V
 end

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -20,8 +20,9 @@ as right-hand sides, not only vectors.
 
 The kwargs `neigs` specifies the number of wanted eigvals, and `k` is the number
 of columns in the subspace (default `k=neigs+1`). The kwarg `sanity_check`
-disables the checking of eigenvalues and just returns (potentially inaccurate)
-eigpairs. The parameters `errmeasure` and `tol` are used for the sanity check.
+decides if checking of eigpars should be done. If disabled, the method
+returns `k` (potentially inaccurate) eigpairs. The parameters `errmeasure` and
+`tol` are used for the sanity check.
 
 # Example
 ```julia-repl
@@ -150,7 +151,7 @@ function contour_beyn(::Type{T},
         if (p==k)
             @warn "Rank-drop not detected and insufficient number of eigenvalues. Try increasing k." S
         else
-            @warn "Rank-drop detected and insufficient number of eigenvalues. Try increasing the domain, or the radius r." S errmeasures
+            @warn "Rank-drop detected and insufficient number of eigenvalues. Try increasing `tol`, the number of discretization points `N`, or the radius r." S errmeasures
         end
     end
 

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -14,16 +14,19 @@ The function computes eigenvalues using Beyn's contour integral approach,
 using a circle centered at `σ` with radius `radius`. The quadrature method
 is specified in `quad_method` (`:ptrapz`, `:quadg`,`:quadg_parallel`,`:quadgk`). `k`
 specifies the number of computed eigenvalues. `N` corresponds to the
-number of quadrature points. Circles is the only supported contour. The
+number of quadrature points. Circles are the only supported contours. The
 `linsolvercreator` must create a linsolver that can handle (rectangular) matrices
-as right-hand sides.
+as right-hand sides, not only vectors.
 
 # Example
 ```julia-repl
+julia> using LinearAlgebra
 julia> nep=nep_gallery("dep0");
 julia> λv,V=contour_beyn(nep,radius=1,k=2,quad_method=:ptrapz);
-julia> minimum(svdvals(compute_Mder(nep,λv[1])))
-1.6106898471314257e-16
+julia> norm(compute_Mlincomb(nep,λv[1],V[:,1])) # Eigenpair 1
+5.778617503485546e-15
+julia> norm(compute_Mlincomb(nep,λv[2],V[:,2])) # Eigenpair 2
+3.095638020248726e-14
 ```
 # References
 * Wolf-Jürgen Beyn, An integral method for solving nonlinear eigenvalue problems, Linear Algebra and its Applications 436 (2012) 3839–3863

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -8,7 +8,7 @@ using Random
 export contour_beyn
 
 """
-    λv,V=contour_beyn([eltype],nep;[tol,][displaylevel,][σ,],[linsolvercreator,][k,][radius,][quad_method,][N,])
+    λv,V=contour_beyn([eltype],nep;[tol,][displaylevel,][σ,],[linsolvercreator,][k,][radius,][quad_method,][N,][neigs,])
 
 The function computes eigenvalues using Beyn's contour integral approach,
 using a circle centered at `σ` with radius `radius`. The quadrature method
@@ -18,11 +18,16 @@ number of quadrature points. Circles are the only supported contours. The
 `linsolvercreator` must create a linsolver that can handle (rectangular) matrices
 as right-hand sides, not only vectors.
 
+The kwargs `neigs` specifies the number of wanted eigvals, and `k` is the number
+of columns in the subspace (default `k=neigs+1`). The kwarg `sanity_check`
+disables the checking of eigenvalues and just returns (potentially inaccurate)
+eigpairs. The parameters `errmeasure` and `tol` are used for the sanity check.
+
 # Example
 ```julia-repl
 julia> using LinearAlgebra
 julia> nep=nep_gallery("dep0");
-julia> λv,V=contour_beyn(nep,radius=1,k=2,quad_method=:ptrapz);
+julia> λv,V=contour_beyn(nep,radius=1,neigs=2,quad_method=:ptrapz);
 julia> norm(compute_Mlincomb(nep,λv[1],V[:,1])) # Eigenpair 1
 5.778617503485546e-15
 julia> norm(compute_Mlincomb(nep,λv[2],V[:,2])) # Eigenpair 2
@@ -34,15 +39,19 @@ julia> norm(compute_Mlincomb(nep,λv[2],V[:,2])) # Eigenpair 2
 contour_beyn(nep::NEP;params...)=contour_beyn(ComplexF64,nep;params...)
 function contour_beyn(::Type{T},
                          nep::NEP;
-                         tol::Real=eps(real(T))*100,
+                         tol::Real=sqrt(eps(real(T))), # Note tol is quite high for this method
                          σ::Number=zero(complex(T)),
                          displaylevel::Integer=0,
                          linsolvercreator::Function=backslash_linsolvercreator,
-                         k::Integer=3, # Number of eigenvals to compute
+                         neigs::Integer=2, # Number of wanted eigvals
+                         k::Integer=neigs+1, # Columns in matrix to integrate
                          radius::Real=1, # integration radius
                          quad_method::Symbol=:ptrapz, # which method to run. :quadg, :quadg_parallel, :quadgk, :ptrapz
                          N::Integer=1000,  # Nof quadrature nodes
-                         )where{T<:Number}
+                         errmeasure::Function =
+                           default_errmeasure(nep::NEP),
+                         sanity_check=true
+                        )where{T<:Number}
 
     # Geometry
     g=t -> radius*exp(1im*t)
@@ -107,9 +116,8 @@ function contour_beyn(::Type{T},
     W0 = W[:,1:k]
     B = (copy(V0')*A1*W0) * Diagonal(1 ./ S[1:k])
 
-    if ((maximum(S)/minimum(S))>1/sqrt(eps()))
-        @warn "Rank drop detected in A0. The disc probably has fewer eigenvalues than those in the disc. Try decreasing k in contour integral solver" S
-    end
+    rank_drop_tol=tol;
+    p = count( S/S[1] .> rank_drop_tol);
 
     # Extract eigenval and eigvec approximations according to
     # step 6 on page 3849 in the reference
@@ -118,13 +126,35 @@ function contour_beyn(::Type{T},
     λ[:] = λ .+ σ
 
     @ifd(println("Computing eigenvectors "))
-    v = V0 * VB;
+    V = V0 * VB;
     for i = 1:k
-        normalize!(v[:,i]);
+        normalize!(V[:,i]);
     end
 
+    if (!sanity_check)
+        return (λ,V)
+    end
 
-    return (λ,v)
+    # Compute all the errors
+    errmeasures=zeros(real(T),k);
+    for i = 1:k
+        errmeasures[i]=errmeasure(λ[i],V[:,i]);
+    end
+
+    good_index=(errmeasures .< tol);
+
+    Vgood=V[:,good_index];
+    λgood=λ[good_index];
+
+    if (size(λgood,1)<neigs)
+        if (p==k)
+            @warn "Rank-drop not detected and insufficient number of eigenvalues. Try increasing k." S
+        else
+            @warn "Rank-drop detected and insufficient number of eigenvalues. Try increasing the domain, or the radius r." S errmeasures
+        end
+    end
+
+    return (λgood,Vgood)
 end
 
 #  Carries out Gauss quadrature (with N) discretization points

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -14,7 +14,9 @@ The function computes eigenvalues using Beyn's contour integral approach,
 using a circle centered at `σ` with radius `radius`. The quadrature method
 is specified in `quad_method` (`:ptrapz`, `:quadg`,`:quadg_parallel`,`:quadgk`). `k`
 specifies the number of computed eigenvalues. `N` corresponds to the
-number of quadrature points.
+number of quadrature points. Circles is the only supported contour. The
+`linsolvercreator` must create a linsolver that can handle (rectangular) matrices
+as right-hand sides.
 
 # Example
 ```julia-repl
@@ -39,16 +41,16 @@ function contour_beyn(::Type{T},
                          N::Integer=1000,  # Nof quadrature nodes
                          )where{T<:Number}
 
+    # Geometry
     g=t -> radius*exp(1im*t)
-    gp=t -> 1im*radius*exp(1im*t)
+    gp=t -> 1im*radius*exp(1im*t) # Derivative
 
     n=size(nep,1);
     Random.seed!(10); # Reproducability
     Vh=Array{T,2}(randn(real(T),n,k)) # randn only works for real
 
     if (k>n)
-        println("k=",k," n=",n);
-        error("Cannot compute more eigenvalues than the size of the NEP with contour_beyn()");
+        error("Cannot compute more eigenvalues than the size of the NEP with contour_beyn() k=",k," n=",n);
 
     end
 
@@ -71,10 +73,9 @@ function contour_beyn(::Type{T},
 
     local A0,A1
     if (quad_method == :quadg_parallel)
-        #@ifd(print(" using quadg_parallel"))
-        #A0=quadg_parallel(f1,0,2*pi,N);
-        #A1=quadg_parallel(f2,0,2*pi,N);
-        error("disabled");
+        @ifd(print(" using quadg_parallel"))
+        A0=quadg_parallel(f1,0,2*pi,N);
+        A1=quadg_parallel(f2,0,2*pi,N);
     elseif (quad_method == :quadg)
         #@ifd(print(" using quadg"))
         #A0=quadg(f1,0,2*pi,N);

--- a/test/beyn.jl
+++ b/test/beyn.jl
@@ -5,18 +5,19 @@ using NonlinearEigenproblems
 using Test
 using LinearAlgebra
 
+
 @testset "Beyn contour" begin
     nep=nep_gallery("dep0")
     @bench @testset "disk at origin" begin
 
-        λ,v=contour_beyn(nep,displaylevel=displaylevel,radius=1,k=2,quad_method=:ptrapz,compute_eigenvectors=true)
+        λ,v=contour_beyn(nep,displaylevel=displaylevel,radius=1,k=2,quad_method=:ptrapz)
 
         for i = 1:2
             @info "$i: $(λ[i])"
             M=compute_Mder(nep,λ[i])
             minimum(svdvals(M))
             @test minimum(svdvals(M)) < eps()*1000
-            @test norm(compute_Mlincomb(nep,λ[i],v[:,i]))/norm(v[:,i]) < eps()*100
+            @test norm(compute_Mlincomb(nep,λ[i],v[:,i]))/norm(v[:,i]) < eps()*500
         end
 
 
@@ -24,19 +25,19 @@ using LinearAlgebra
         M=compute_Mder(nep,λ[1])
         minimum(svdvals(M))
         @test minimum(svdvals(M))<eps()*1000
-        @test all(isnan.(v))
 
     end
     @bench @testset "shifted disk" begin
 
-        λ,v=contour_beyn(nep,displaylevel=displaylevel,σ=-0.2,radius=1.5,k=4,quad_method=:ptrapz,compute_eigenvectors=true)
+        λ,v=contour_beyn(nep,displaylevel=displaylevel,σ=-0.2,radius=1.5,
+                         k=4,quad_method=:ptrapz)
 
         for i = 1:4
             @info "$i: $(λ[i])"
             M=compute_Mder(nep,λ[i])
             minimum(svdvals(M))
             @test minimum(svdvals(M)) < eps()*1000
-            @test norm(compute_Mlincomb(nep,λ[i],v[:,i]))/norm(v[:,i]) < eps()*100
+            @test norm(compute_Mlincomb(nep,λ[i],v[:,i]))/norm(v[:,i]) < eps()*500
         end
 
     end

--- a/test/beyn.jl
+++ b/test/beyn.jl
@@ -10,7 +10,7 @@ using LinearAlgebra
     nep=nep_gallery("dep0")
     @bench @testset "disk at origin" begin
 
-        λ,v=contour_beyn(nep,displaylevel=displaylevel,radius=1,k=2,quad_method=:ptrapz)
+        λ,v=contour_beyn(nep,displaylevel=displaylevel,radius=1,neigs=2,quad_method=:ptrapz)
 
         for i = 1:2
             @info "$i: $(λ[i])"
@@ -30,14 +30,15 @@ using LinearAlgebra
     @bench @testset "shifted disk" begin
 
         λ,v=contour_beyn(nep,displaylevel=displaylevel,σ=-0.2,radius=1.5,
-                         k=4,quad_method=:ptrapz)
+                         neigs=4,quad_method=:ptrapz)
 
+        @test size(λ,1)==4
         for i = 1:4
             @info "$i: $(λ[i])"
             M=compute_Mder(nep,λ[i])
             minimum(svdvals(M))
-            @test minimum(svdvals(M)) < eps()*1000
-            @test norm(compute_Mlincomb(nep,λ[i],v[:,i]))/norm(v[:,i]) < eps()*500
+            @test minimum(svdvals(M)) < eps()*10000
+            @test norm(compute_Mlincomb(nep,λ[i],v[:,i]))/norm(v[:,i]) < eps()*10000
         end
 
     end

--- a/test/inner_solves.jl
+++ b/test/inner_solves.jl
@@ -34,5 +34,5 @@ using LinearAlgebra
     # TODO: this test results in a "Rank drop" warning, and a third eigenvalue that's not converged
     λv,V = inner_solve(ContourBeynInnerSolver, ComplexF64, pnep; λv=[0,1] .+ 0.0im, Neig=3)
     # @test minimum(svdvals(compute_Mder(pnep,λv[1]))) < eps()*100
-    verify_lambdas(2, pnep, λv[1:2], V[:,1:2], eps()*500)
+    verify_lambdas(2, pnep, λv[1:2], V[:,1:2], eps()*1000)
 end

--- a/test/inner_solves.jl
+++ b/test/inner_solves.jl
@@ -34,5 +34,5 @@ using LinearAlgebra
     # TODO: this test results in a "Rank drop" warning, and a third eigenvalue that's not converged
     λv,V = inner_solve(ContourBeynInnerSolver, ComplexF64, pnep; λv=[0,1] .+ 0.0im, Neig=3)
     # @test minimum(svdvals(compute_Mder(pnep,λv[1]))) < eps()*100
-    verify_lambdas(2, pnep, λv[1:2], V[:,1:2], eps()*1000)
+    verify_lambdas(2, pnep, λv[1:2], V[:,1:2], sqrt(eps()))
 end


### PR DESCRIPTION
This aims to fix #162.

* Added (optional) sanity checking with errmeasure and tol
* Added neigs=wanted eigs
* Added user recommendations in case of insufficient eigvals found

Currently, the rankdrop is only used to decide on what the user recommendation should be in case insufficient eigvals are found. 
