### PR TITLE
ellipse, combine A0 and A1 integral, sort !sanity_check, parallel ptrapz

### DIFF
--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -66,6 +66,7 @@ function contour_beyn(::Type{T},
 
     n=size(nep,1);
 
+    
     if (k>n)
         error("Cannot compute more eigenvalues than the size of the NEP with contour_beyn() k=",k," n=",n);
     end

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -55,8 +55,8 @@ function contour_beyn(::Type{T},
                          N::Integer=1000,  # Nof quadrature nodes
                          errmeasure::Function =
                            default_errmeasure(nep::NEP),
-                         sanity_check=true
-                      rank_drop_tol=tol # Used in sanity checking
+                         sanity_check=true,
+                         rank_drop_tol=tol # Used in sanity checking
                         )where{T<:Number}
 
     # Geometry

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -43,21 +43,21 @@ julia> norm(compute_Mlincomb(nep,λv[2],V[:,2])) # Eigenpair 2
 """
 contour_beyn(nep::NEP;params...)=contour_beyn(ComplexF64,nep;params...)
 function contour_beyn(::Type{T},
-                         nep::NEP;
-                         tol::Real=sqrt(eps(real(T))), # Note tol is quite high for this method
-                         σ::Number=zero(complex(T)),
-                         displaylevel::Integer=0,
-                         linsolvercreator::Function=backslash_linsolvercreator,
-                         neigs::Integer=2, # Number of wanted eigvals
-                         k::Integer=neigs+1, # Columns in matrix to integrate
-                         radius::Union{Real,Tuple,Array}=1, # integration radius
-                         quad_method::Symbol=:ptrapz, # which method to run. :quadg, :quadg_parallel, :quadgk, :ptrapz
-                         N::Integer=1000,  # Nof quadrature nodes
-                         errmeasure::Function =
-                           default_errmeasure(nep::NEP),
-                         sanity_check=true,
-                         rank_drop_tol=tol # Used in sanity checking
-                        )where{T<:Number}
+                      nep::NEP;
+                      tol::Real=sqrt(eps(real(T))), # Note tol is quite high for this method
+                      σ::Number=zero(complex(T)),
+                      displaylevel::Integer=0,
+                      linsolvercreator::Function=backslash_linsolvercreator,
+                      neigs::Integer=2, # Number of wanted eigvals
+                      k::Integer=neigs+1, # Columns in matrix to integrate
+                      radius::Union{Real,Tuple,Array}=1, # integration radius
+                      quad_method::Symbol=:ptrapz, # which method to run. :quadg, :quadg_parallel, :quadgk, :ptrapz
+                      N::Integer=1000,  # Nof quadrature nodes
+                      errmeasure::Function =
+                       default_errmeasure(nep::NEP),
+                      sanity_check=true,
+                      rank_drop_tol=tol # Used in sanity checking
+                      )where{T<:Number}
 
     # Geometry
     length(radius)==1 ? radius=(radius,radius) : nothing

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -69,6 +69,7 @@ function contour_beyn(::Type{T},
     
     if (k>n)
         error("Cannot compute more eigenvalues than the size of the NEP with contour_beyn() k=",k," n=",n);
+
     end
     if (k<=0)
         error("k must be positive, k=",k,

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -146,13 +146,6 @@ function contour_beyn(::Type{T},
     if (!sanity_check)
         sorted_index = sortperm(map(x->abs(σ-x), λ));
         inside_bool = (real(λ[sorted_index].-σ)/radius[1]).^2 + (imag(λ[sorted_index].-σ)/radius[2]).^2 .≤ 1
-        if any(.!inside_bool)
-            if neigs ≤ sum(inside_bool)
-                @warn "found $(sum(.!inside_bool)) evals outside contour, $p inside. all $neigs returned evals inside, but possibly inaccurate. try increasing N, decreasing tol, or changing radius"
-            else
-                @warn "found $(sum(.!inside_bool)) evals outside contour, $p inside. last $(neigs-sum(inside_bool)) returned evals outside contour. try increasing N, decreasing tol, or changing radius"
-            end
-        end
         inside_perm = sortperm(.!inside_bool)
         return (λ[sorted_index[inside_perm]],V[:,sorted_index[inside_perm]])
     end

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -54,7 +54,7 @@ function contour_beyn(::Type{T},
                       quad_method::Symbol=:ptrapz, # which method to run. :quadg, :quadg_parallel, :quadgk, :ptrapz
                       N::Integer=1000,  # Nof quadrature nodes
                       errmeasure::Function =
-                       default_errmeasure(nep::NEP),
+                      default_errmeasure(nep::NEP),
                       sanity_check=true,
                       rank_drop_tol=tol # Used in sanity checking
                       )where{T<:Number}

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -11,7 +11,7 @@ export contour_beyn
     λv,V=contour_beyn([eltype,] nep;[tol,][displaylevel,][σ,][radius,][linsolvercreator,][quad_method,][N,][neigs,][k])
 
 The function computes eigenvalues using Beyn's contour integral approach,
-using an ellipse centered at `σ` with radii given in `radius`, or if ond `radius` is given,
+using an ellipse centered at `σ` with radii given in `radius`, or if only one `radius` is given,
 the contour is a circle. The quadrature method is specified in `quad_method`
 (`:ptrapz`,`ptrapz_parallel`, `:quadg`,`:quadg_parallel`,`:quadgk`). `k`
 specifies the number of computed eigenvalues. `N` corresponds to the


### PR DESCRIPTION
### Summary of changes

Circle contour extended to ellipse (useful when, say, you are interested in complex eigenvalues close to the real axis).
More useful still would be the ability to define a polygon, which could define a strip along the real or imaginary axes, but that is not done here.

I've combined the quadratures for `A0` and `A1`, which reduces the number of calls to the linear operator by half, leading to significant speedup.

I added a the sorting step for the case when `sanity_check=false`. This means that the eval/evecs will always be sorted by their distance from `σ`, regardless of the `sanity_check` status.

Lastly, I extended the quadrature methods by a parallel version of `:ptrapz`, called `:ptrapz_parallel`.

I changed some of the function documentation to reflect this.

--------------
### Timing statistics due to the changes
Setup:
````JULIA
addprocs(7);
using BenchmarkTools, LinearAlgebra, SparseArrays, NonlinearEigenproblems
N=1000;
As = [sparse(1.0I,N,N), spdiagm(0=>1.0*(1:N))];
fns = [identity, one];
nep = SPMF_NEP(As,fns);
@benchmark contour_beyn(nep; neigs=4, σ=-3.6, radius=2, quad_method=:ptrapz)
````

The results before the changes are
````JULIA
BenchmarkTools.Trial: 
  memory estimate:  895.74 MiB
  allocs estimate:  108568
  --------------
  minimum time:     433.630 ms (16.68% GC)
  median time:      443.142 ms (17.24% GC)
  mean time:        443.792 ms (17.11% GC)
  maximum time:     455.777 ms (17.56% GC)
  --------------
  samples:          12
  evals/sample:     1
````

The results for the serial code after the changes are
````JULIA
BenchmarkTools.Trial: 
  memory estimate:  563.58 MiB
  allocs estimate:  73531
  --------------
  minimum time:     251.076 ms (19.99% GC)
  median time:      258.093 ms (21.74% GC)
  mean time:        258.392 ms (21.69% GC)
  maximum time:     270.839 ms (23.05% GC)
  --------------
  samples:          20
  evals/sample:     1
````

The results for the parallel code after changes (there is no pre-change counterpart) (use `quad_method=:ptrapz_parallel`)
````JULIA
BenchmarkTools.Trial: 
  memory estimate:  4.05 MiB
  allocs estimate:  2108
  --------------
  minimum time:     52.615 ms (0.00% GC)
  median time:      59.058 ms (0.00% GC)
  mean time:        63.584 ms (0.53% GC)
  maximum time:     123.447 ms (0.00% GC)
  --------------
  samples:          79
  evals/sample:     1
````