### PR TITLE
errmeasure types

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,6 +11,7 @@ makedocs(
         "NEP Methods" => "methods.md",
         "NEP Types" => "types.md",
         "LinSolver" => "linsolvers.md",
+        "Error measure" => "errmeasure.md",
         "NEP Transformations" => "transformations.md",
         "NEP Gallery" => "gallery.md",
         "Tutorial 1 (ABC)" => "movebc_tutorial.md",

--- a/docs/src/errmeasure.md
+++ b/docs/src/errmeasure.md
@@ -1,0 +1,147 @@
+# Measuring the error
+
+**This only works on NEP-PACK version 0.2.6 and onwards**
+
+All iterative algorithms need some form of termination
+criteria. In NEP-PACK, all NEP-solvers provide
+the possibility to specify the desired tolerance,
+as well as how the error is measured or estimated.
+The tolerance is specified in the kwarg  `tol` (which is a real number)
+and the way to measure the error is given in `errmeasure`.
+
+## Standard usage
+
+NEP-PACK comes with several ways to measure errors for many NEP-types.
+
+* `errmeasure=ResidualErrmeasure`: The error is estimated by the use of the residual norm:
+```math
+\mathrm{err}=\frac{\|M(λ)v\|}{\|v\|}.
+```
+* `errmeasure=BackwardErrmeasure`: The error is estimated by using the backward error bounds. This error measure will not work for all NEPs. An implementation is provided for any `AbstractSPMF`. If your NEP is an `AbstractSPMF` with terms:
+  ```math
+  M(λ)=A_1f_1(λ)+\cdots+A_mf_m(λ)
+  ```
+  the error will be estimated by
+  ```math
+  \mathrm{err}=\frac{\|M(λ)v\|}{\|v\|}\frac{1}{\|A_1\|_F|f_1(λ)|+\cdots+\|A_m\|_F|f_m(λ)|}.
+  ```
+  In other words, the `BackwardErrmeasure` is a weighting of the `ResidualErrmeasure`.
+* `errmeasure=DefaultErrmeasure`: When this `errmeasure` is specified, NEP-PACK tries to determine a error measure for you. In general, `BackwardErrmeasure` will be preferred if possible. This behavior may change in future versions of NEP-PACK.
+
+Example: Most NEP-solvers take the `errmeasure` as an kwarg.
+```julia-repl
+julia> nep=nep_gallery("qdep0");
+julia> # Solve the problem to residual norm 1e-8
+julia> (λ,v)=mslp(nep,errmeasure=ResidualErrmeasure,tol=1e-8)
+julia> norm(compute_Mlincomb(nep,λ,v))/norm(v) # It's smaller than tol?
+3.503700819937386e-9
+julia> nep isa AbstractSPMF # Is it an AbstractSPMF so we can use BackwardErrmeasure?
+true
+julia> (λ,v)=mslp(nep,errmeasure=BackwardErrmeasure,tol=1e-10)
+julia> factor=abs(fv[1](λ))*norm(Av[1])+
+     abs(fv[2](λ))*norm(Av[2])+abs(fv[3](λ))*norm(Av[3]);
+julia> norm(compute_Mlincomb(nep,λ,v))/(norm(v)*factor)
+1.659169482386331e-11
+```
+
+## User defined error measure
+
+There are two ways that a user can specify how to measure the error.
+
+### User defined error 1: Function handle
+
+The user can provide a function handle
+which is called to obtain the error. The `errmeasure` can be a function,
+which takes two parameters as input `(λ,v)` and returns
+the error (or estimate thereof).
+
+The most common situation is that you want to report the
+error (as a function of iteration) with a reference solutions. 
+If we want to get
+a very accurate approximation of the true error, we can run the 
+algorithm twice, and the second time we run the algorithm
+we use the result of the first run as a reference. 
+
+```julia-repl
+julia> nep=nep_gallery("qdep0");
+julia> v0=ones(size(nep,1));
+julia> (λref,v)=resinv(nep,v=v0,λ=230^2+1im,displaylevel=1);
+julia> myerrmeasure = (λ,v) -> abs(λ-λref)/abs(λ);
+julia> (λ,v)=resinv(nep,v=v0,λ=250^2+1im,displaylevel=1,tol=1e-10,errmeasure=myerrmeasure);
+Iteration:  1 errmeasure:1.274091618457501296e-01 
+Iteration:  2 errmeasure:9.535794095609478882e-01 
+...
+Iteration: 49 errmeasure:1.269396691930517923e-10 
+Iteration: 50 errmeasure:7.608430406801784718e-11 
+```
+
+### User defined error 2: A user defined type
+
+Due to the multiple dispatch and handling of types in Julia, code
+can be faster when if use types instead of function handles. It is 
+possible to provide carry out the same simulation as above with a user defined
+type. 
+
+You first need to define a new type
+```julia-repl
+julia> struct RefErrmeasure <: Errmeasure; nep::NEP; end
+```
+The error measure should then provided in the function 
+`estimate_error`:
+```julia-repl
+julia> v0=ones(size(nep,1));
+julia> (λref,v)=resinv(nep,v=v0,λ=230^2+1im,displaylevel=1);
+julia> function NonlinearEigenproblems.estimate_error(e::RefErrmeasure,λ,v)
+         return abs(λ-λref)/abs(λ);
+       end
+julia> (λ,v)=resinv(nep,v=v0,λ=250^2+1im,displaylevel=1,tol=1e-10,errmeasure=RefErrmeasure);
+Iteration:  1 errmeasure:1.274091618457501296e-01 
+...
+Iteration: 49 errmeasure:1.269396691930517923e-10 
+Iteration: 50 errmeasure:7.608430406801784718e-11 
+```
+
+
+## As a NEP-solver developer
+
+NEP-solvers should use the `Errmeasure` as follows. The NEP-solver should take
+as input a `ErrmeasureType`. This corresponds to either a function or a type, but if you follow the procedure below, you will not have to worry about that.
+
+```julia
+function mysolver(nep::NEP;errmeasure::ErrmeasureType=DefaultErrmeasure)
+```
+
+Before the main iteration, you need to initialize the error measure
+computation. The precomptued data 
+is stored in a variable typically called `ermdata`: 
+```julia
+   ermdata=init_errmeasure(errmeasure,nep);
+```
+
+In the main for loop you want to call the `estimate_error` function:
+
+```julia
+for k=1:maxit
+    err=estimate_error(ermdata,λ,v)
+    if (err < 1e-10)
+       return (λ,v)
+    end 
+    ....
+
+end 
+```
+
+## Methods and types
+
+```@docs
+Errmeasure
+```
+```@docs
+estimate_error
+```
+```@docs
+init_errmeasure
+```
+
+ 
+

--- a/docs/src/errmeasure.md
+++ b/docs/src/errmeasure.md
@@ -56,11 +56,11 @@ which takes two parameters as input `(λ,v)` and returns
 the error (or estimate thereof).
 
 The most common situation is that you want to report the
-error (as a function of iteration) with a reference solutions. 
+error (as a function of iteration) with a reference solutions.
 If we want to get
-a very accurate approximation of the true error, we can run the 
+a very accurate approximation of the true error, we can run the
 algorithm twice, and the second time we run the algorithm
-we use the result of the first run as a reference. 
+we use the result of the first run as a reference.
 
 ```julia-repl
 julia> nep=nep_gallery("qdep0");
@@ -68,25 +68,25 @@ julia> v0=ones(size(nep,1));
 julia> (λref,v)=resinv(nep,v=v0,λ=230^2+1im,displaylevel=1);
 julia> myerrmeasure = (λ,v) -> abs(λ-λref)/abs(λ);
 julia> (λ,v)=resinv(nep,v=v0,λ=250^2+1im,displaylevel=1,tol=1e-10,errmeasure=myerrmeasure);
-Iteration:  1 errmeasure:1.274091618457501296e-01 
-Iteration:  2 errmeasure:9.535794095609478882e-01 
+Iteration:  1 errmeasure:1.274091618457501296e-01
+Iteration:  2 errmeasure:9.535794095609478882e-01
 ...
-Iteration: 49 errmeasure:1.269396691930517923e-10 
-Iteration: 50 errmeasure:7.608430406801784718e-11 
+Iteration: 49 errmeasure:1.269396691930517923e-10
+Iteration: 50 errmeasure:7.608430406801784718e-11
 ```
 
 ### User defined error 2: A user defined type
 
 Due to the multiple dispatch and handling of types in Julia, code
-can be faster when if use types instead of function handles. It is 
-possible to provide carry out the same simulation as above with a user defined
-type. 
+may run faster if one uses types instead of function handles. It is
+possible to do the same simulation as above with a user defined
+type.
 
 You first need to define a new type
 ```julia-repl
 julia> struct RefErrmeasure <: Errmeasure; nep::NEP; end
 ```
-The error measure should then provided in the function 
+The error measure should then provided in the function
 `estimate_error`:
 ```julia-repl
 julia> v0=ones(size(nep,1));
@@ -95,10 +95,10 @@ julia> function NonlinearEigenproblems.estimate_error(e::RefErrmeasure,λ,v)
          return abs(λ-λref)/abs(λ);
        end
 julia> (λ,v)=resinv(nep,v=v0,λ=250^2+1im,displaylevel=1,tol=1e-10,errmeasure=RefErrmeasure);
-Iteration:  1 errmeasure:1.274091618457501296e-01 
+Iteration:  1 errmeasure:1.274091618457501296e-01
 ...
-Iteration: 49 errmeasure:1.269396691930517923e-10 
-Iteration: 50 errmeasure:7.608430406801784718e-11 
+Iteration: 49 errmeasure:1.269396691930517923e-10
+Iteration: 50 errmeasure:7.608430406801784718e-11
 ```
 
 
@@ -112,8 +112,8 @@ function mysolver(nep::NEP;errmeasure::ErrmeasureType=DefaultErrmeasure)
 ```
 
 Before the main iteration, you need to initialize the error measure
-computation. The precomptued data 
-is stored in a variable typically called `ermdata`: 
+computation. The precomptued data
+is stored in a variable typically called `ermdata`:
 ```julia
    ermdata=init_errmeasure(errmeasure,nep);
 ```
@@ -125,10 +125,10 @@ for k=1:maxit
     err=estimate_error(ermdata,λ,v)
     if (err < 1e-10)
        return (λ,v)
-    end 
+    end
     ....
 
-end 
+end
 ```
 
 ## Methods and types
@@ -142,6 +142,3 @@ estimate_error
 ```@docs
 init_errmeasure
 ```
-
- 
-

--- a/docs/src/movebc_tutorial.md
+++ b/docs/src/movebc_tutorial.md
@@ -216,27 +216,22 @@ resulting in
 
 For this application, the matrix ``M(λ)`` has very large elements if $n$ is large.
 This makes the default way to measure the error a bit misleading. We now
-show how to specify a user-defined way to measure the error.
+show how to specify a better way to measure the error.
 
 The following function provides an estimate of the backward error
 ```math
-e(\lambda,v)=\frac{\|M(\lambda)v\|}{\|v\|(\|D_n-\operatorname{diag}(V(x_1),\ldots,V(x_{n-1}),0)\|+|λ|
-+|g(λ)|+|f(λ)|\|F\|)}
+e(\lambda,v)=\frac{\|M(\lambda)v\|}{\|v\|(\|D_n-\operatorname{diag}(V(x_1),\ldots,V(x_{n-1}),0)\|_F+|λ|
++|g(λ)|\|I\|_F+|f(λ)|\|F\|_F)}
 ```
-which we define as a function
-```julia
-myerrmeasure=(λ,v) ->
-    norm(compute_Mlincomb(nep,λ,v))/
-       (norm(v)*(norm(A)*abs(f1(λ))+norm(In)*abs(f2(λ))+norm(G)*abs(g(λ))+norm(F)*abs(f(λ))))
-
-```
-Note that unlike many other languages, Julia's `norm`-function for matrices, returns the Frobenius norm by default.
-
+This way to measure the error is used if you specify `errmeasure=BackwardErrmeasure`. See [errmeasure.md] for further details, and how you can
+specify a user defined error measurement function.
 The  `quasinewton` simulations above terminate in less iterations when this
-error measure is used. It also allows us to also use other methods, e.g., infinite Arnoldi method.
+error measure is used. With this use of measuring the error other
+methods, e.g., infinite Arnoldi method terminate in a reasonable
+number of iterations:
 ```julia-repl
 julia> (λ,v)=iar(nep,displaylevel=1,σ=-36,v=ones(n),tol=1e-9,
-                 errmeasure=myerrmeasure,Neig=5,maxit=100);
+                 errmeasure=BackwardErrmeasure,Neig=5,maxit=100);
 Iteration:1 conveig:0
 Iteration:2 conveig:0
 Iteration:3 conveig:0

--- a/docs/src/movebc_tutorial.md
+++ b/docs/src/movebc_tutorial.md
@@ -223,7 +223,7 @@ The following function provides an estimate of the backward error
 e(\lambda,v)=\frac{\|M(\lambda)v\|}{\|v\|(\|D_n-\operatorname{diag}(V(x_1),\ldots,V(x_{n-1}),0)\|_F+|λ|
 +|g(λ)|\|I\|_F+|f(λ)|\|F\|_F)}
 ```
-This way to measure the error is used if you specify `errmeasure=BackwardErrmeasure`. See [errmeasure.md] for further details, and how you can
+This way to measure the error is used if you specify `errmeasure=BackwardErrmeasure`. See section [Error measure](errmeasure.md) for further details, and how you can
 specify a user defined error measurement function.
 The  `quasinewton` simulations above terminate in less iterations when this
 error measure is used. With this use of measuring the error other

--- a/docs/src/transformations.md
+++ b/docs/src/transformations.md
@@ -73,7 +73,7 @@ Due to structure of the representation of NEPs in NEP-PACK
 it is possible to do deflation, by transformation of the NEP-object.
 The deflation is based on theory provided in Effenbergers thesis
 and the main function consists of `deflate_eigpair`.
-See also [the tutorial on deflation](tutorial_deflation.md).
+See also [the tutorial on deflation](deflate_tutorial.md).
 
 ```@docs
 deflate_eigpair

--- a/docs/src/transformations.md
+++ b/docs/src/transformations.md
@@ -72,8 +72,9 @@ expand_projectmatrices!
 Due to structure of the representation of NEPs in NEP-PACK
 it is possible to do deflation, by transformation of the NEP-object.
 The deflation is based on theory provided in Effenbergers thesis
-and the main function consists of `effenberger_deflation`.
+and the main function consists of `deflate_eigpair`.
+See also [the tutorial on deflation](tutorial_deflation.md).
 
 ```@docs
-effenberger_deflation
+deflate_eigpair
 ```

--- a/src/NEPCore.jl
+++ b/src/NEPCore.jl
@@ -28,8 +28,6 @@ module NEPCore
 
     export compute_Mlincomb_from_MM!
 
-    export default_errmeasure
-
     import Base.size  # Overload for nonlinear eigenvalue problems
     import SparseArrays.issparse  # Overload for nonlinear eigenvalue problems
 
@@ -360,16 +358,6 @@ Exeption thrown in case an iterative method does not converge\\
         Z = T(λ) * Matrix{T}(I, n, n) + diagm(1 => ones(T, n-1))
     end
 
-    """
-    default_errmeasure(nep::NEP)
-The default way of measuring error.
-Returns a function computing the relative residual norm.
-
-See also: [`compute_resnorm`](@ref),
-"""
-    function default_errmeasure(nep::NEP)
-        return (λ,v) -> compute_resnorm(nep,λ,v)/norm(v)
-    end
 
     """
     struct LostOrthogonalityException

--- a/src/NEPSolver.jl
+++ b/src/NEPSolver.jl
@@ -111,7 +111,7 @@ Executes z if displaylevel>1.
         x=randn(size(nep,1)),
         tol=1e-6,
         maxit=10000,
-        errmeasure::Function = default_errmeasure(nep::NEP)
+        errmeasure::ErrmeasureType = DefaultErrmeasure,
         )
 
         A=v->compute_Mlincomb(nept,complex(conj(λ)),compute_Mlincomb(nep,complex(λ),complex(v)))
@@ -119,6 +119,10 @@ Executes z if displaylevel>1.
         # initialization
         normalize!(x); v=A(x); ρ=x⋅v; q=zeros(ComplexF64,size(nep,1));
         k=1; err=one(real(eltype(x))); tol=1e-12
+
+        # Init errmeasure
+        ermdata=init_errmeasure(errmeasure,nep);
+
         while (k<maxit)&&(err>tol)
           g = v-ρ*x;
           xgq = [x -g q]
@@ -132,7 +136,7 @@ Executes z if displaylevel>1.
           ii=argmin([isnan(x) ? Inf : x for x in absD]);
           ρ=D[ii]; δ=V[:,ii]; q=[-g q]*δ[2:end];
           x=δ[1]*x+q; normalize!(x); v=A(x); k+=1
-          err=errmeasure(λ,x)
+          err=estimate_error(ermdata,λ,x)
         end
         return x
     end

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -1222,6 +1222,7 @@ Returns true/false if the NEP is sparse (if compute_Mder() returns sparse)
     include("nep_transformations.jl")
     include("nep_deflation.jl")
     include("low_rank_nep.jl")
+    include("errmeasure.jl")
 
     # structure exploitation for DEP
     function compute_Mlincomb(nep::DEP,λ::Number,V::AbstractVecOrMat,

--- a/src/errmeasure.jl
+++ b/src/errmeasure.jl
@@ -27,7 +27,7 @@ measure the error in the method `estimate_error` and (optionally)
 This shows how to compute a reference solution and
 then use this as a reference solution. The error
 in the second run will be effectively the
-eigenvalue error.
+eigenvalue error. 
 ```julia
 julia> nep=nep_gallery("qdep0");
 julia> (λref,vref)=quasinewton(nep,λ=-1);
@@ -48,6 +48,14 @@ Iteration:  8 errmeasure:1.726871190488310503e-07, λ=-1.0024668159003483 + 0.0i
 Iteration:  9 errmeasure:4.819693533164581822e-09, λ=-1.0024669934071608 + 0.0im
 Iteration: 10 errmeasure:5.234268574128009277e-10, λ=-1.0024669880640404 + 0.0im
 Iteration: 11 errmeasure:3.762568034915148019e-11, λ=-1.002466988625093 + 0.0im
+Iteration: 12 errmeasure:3.205657961302676995e-12, λ=-1.0024669885842616 + 0.0im
+Iteration: 13 errmeasure:3.352873534367972752e-14, λ=-1.0024669885874338 + 0.0im
+```
+Note that this can also be achieved by providing a function handle:
+```julia
+julia> myerrmeasure= (λ,v) -> abs(λref-λ);
+julia> (λ,v)=quasinewton(nep,errmeasure=myerrmeasure,λ=-1.0 ,displaylevel=1,tol=5e-13)
+...
 Iteration: 12 errmeasure:3.205657961302676995e-12, λ=-1.0024669885842616 + 0.0im
 Iteration: 13 errmeasure:3.352873534367972752e-14, λ=-1.0024669885874338 + 0.0im
 ```

--- a/src/errmeasure.jl
+++ b/src/errmeasure.jl
@@ -1,0 +1,52 @@
+export init_errmeasure
+export estimate_error
+export Errmeasure
+export BackwardErrmeasure
+export ResidualErrmeasure
+export DefaultErrmeasure
+
+
+
+abstract type Errmeasure; end
+
+
+function init_errmeasure(E::Type{<:Errmeasure},nep::NEP)
+    return E(nep);
+end
+
+function estimate_error(errdata::Errmeasure,λ,v)
+    error("Not implemented:",errdata);
+end
+
+struct ResidualErrmeasure <: Errmeasure;
+    nep::NEP
+end
+
+function estimate_error(errdata::ResidualErrmeasure, λ,v)
+   return norm(compute_Mlincomb(errdata.nep,λ,v))/norm(v);
+end
+
+
+struct BackwardErrmeasure{X<:Real} <: Errmeasure
+    nep::NEP
+    coeffs::Vector{X};
+end
+
+function init_errmeasure(E::Type{BackwardErrmeasure},nep::AbstractSPMF)
+    Av=get_Av(nep);
+    # Note: norm(A) is a the frobenius norm in Julia
+    coeffs=map(i->norm(Av[i]),1:size(Av,1));
+    return BackwardErrmeasure(nep,coeffs);
+end
+
+function estimate_error(errdata::BackwardErrmeasure, λ,v)
+    Av=get_Av(errdata.nep);
+    fv=get_fv(errdata.nep);
+    denom=mapreduce(i->errdata.coeffs[i]*abs(fv[i](λ)), +, 1:size(Av,1));
+    return norm(compute_Mlincomb(errdata.nep,λ,v))/(norm(v)*denom);
+end
+
+# Default behavior: If AbstractSPMF -> do backward error. Otherwise residual norm.
+abstract type DefaultErrmeasure <: Errmeasure; end
+init_errmeasure(E::Type{DefaultErrmeasure},nep::AbstractSPMF)=init_errmeasure(BackwardErrmeasure,nep)
+init_errmeasure(E::Type{DefaultErrmeasure},nep::NEP)=init_errmeasure(ResidualErrmeasure,nep)

--- a/src/errmeasure.jl
+++ b/src/errmeasure.jl
@@ -6,18 +6,92 @@ export ResidualErrmeasure
 export DefaultErrmeasure
 
 
+"""
+    abstract type Errmeasure; end
 
+Concrete subtypes of `Errmeasure` represent specific ways of
+measuring the error of an eigenpair. NEP-solvers take a type as
+input and then instantiate a `Errmeasure`. As a NEP-solver user,
+you use the type as follows
+```julia
+julia> quasinewton(nep,errmeasure=ResidualErrmeasure)
+```
+User-specified ways of measuring error can be given by
+creating a new subtype of `Errmeasure` and using it as a
+`errmeasure` keyword. You need to specify the way to
+measure the error in the method `estimate_error`.
+
+# Example
+This shows how to compute a reference solution and
+then use this as a reference solution. The error
+in the second run will be effectively the
+eigenvalue error.
+```julia
+julia> nep=nep_gallery("qdep0");
+julia> (λref,vref)=quasinewton(nep,λ=-1);
+julia> struct EigvalError <: Errmeasure; nep::NEP; end
+julia> function NonlinearEigenproblems.estimate_error(E::EigvalError,λ,v)
+return abs(λref-λ);
+end
+julia> (λ,v)=quasinewton(nep,errmeasure=EigvalError,λ=-1.0 ,displaylevel=1,tol=5e-13)
+Precomputing linsolver
+Iteration:  1 errmeasure:2.466988587467300320e-03, λ=-1.0 + 0.0im
+Iteration:  2 errmeasure:4.625160667012763183e-01, λ=-0.539950921886191 + 0.0im
+Iteration:  3 errmeasure:2.799848726755167494e-01, λ=-1.282451861262984 + 0.0im
+Iteration:  4 errmeasure:3.422925625951256379e-02, λ=-1.0366962448469799 + 0.0im
+Iteration:  5 errmeasure:5.530128437585268841e-04, λ=-1.0019139757437088 + 0.0im
+Iteration:  6 errmeasure:1.159388768512403800e-04, λ=-1.002351049710616 + 0.0im
+Iteration:  7 errmeasure:2.658434455016234210e-06, λ=-1.0024643301530123 + 0.0im
+Iteration:  8 errmeasure:1.726871190488310503e-07, λ=-1.0024668159003483 + 0.0im
+Iteration:  9 errmeasure:4.819693533164581822e-09, λ=-1.0024669934071608 + 0.0im
+Iteration: 10 errmeasure:5.234268574128009277e-10, λ=-1.0024669880640404 + 0.0im
+Iteration: 11 errmeasure:3.762568034915148019e-11, λ=-1.002466988625093 + 0.0im
+Iteration: 12 errmeasure:3.205657961302676995e-12, λ=-1.0024669885842616 + 0.0im
+Iteration: 13 errmeasure:3.352873534367972752e-14, λ=-1.0024669885874338 + 0.0im
+```
+
+See also: [`DefaultErrmeasure`](@ref), [`ResidualErrmeasure`](@ref), [`BackwardErrmeasure`](@ref), [`estimate_error`](@ref), [`init_errmeasure`](@ref).
+
+"""
 abstract type Errmeasure; end
 
+"""
+    function init_errmeasure(E::Errmeasure,nep)
 
+This function is called in a precomputation phase for an error measure.
+For user defined `Errmeasure`, you do not need to overload this
+if your `Errmeasure` contains only one field which is a `NEP`.
+
+See also: [`Errmeasure`](@ref)
+"""
 function init_errmeasure(E::Type{<:Errmeasure},nep::NEP)
     return E(nep);
 end
 
+"""
+    function estimate_error(E::Errmeasure,λ,v)
+
+Returns the error estimate for the eigenpair `(λ,v)`. The way to measure
+the error is specified in `Errmeasure`.
+
+See also: [`Errmeasure`](@ref)
+
+
+"""
 function estimate_error(errdata::Errmeasure,λ,v)
     error("Not implemented:",errdata);
 end
 
+
+"""
+    struct ResidualErrmeasure <: Errmeasure
+
+This `Errmeasure` species that the residual norm should be
+used to measure the error.
+
+See also: [`Errmeasure`](@ref)
+
+"""
 struct ResidualErrmeasure <: Errmeasure;
     nep::NEP
 end
@@ -27,6 +101,21 @@ function estimate_error(errdata::ResidualErrmeasure, λ,v)
 end
 
 
+"""
+    struct BackwardErrmeasure <: Errmeasure
+
+This `Errmeasure` gives a way to compute the backward error.
+The backward error estimate are only given for NEPs which are
+subtypes of  `AbstractSPMF`.
+
+# Example
+```julia
+julia> nep=nep_gallery("qdep0");
+julia> (λ,v)=quasinewton(nep,λ=-1,errmeasure=BackwardErrmeasure,tol=1e-10);
+```
+See also: [`Errmeasure`](@ref)
+
+"""
 struct BackwardErrmeasure{X<:Real} <: Errmeasure
     nep::NEP
     coeffs::Vector{X};

--- a/src/errmeasure.jl
+++ b/src/errmeasure.jl
@@ -105,7 +105,7 @@ end
 """
     struct BackwardErrmeasure <: Errmeasure
 
-This `Errmeasure` gives a way to compute the backward error.
+This `Errmeasure` provides a way to compute the backward error.
 The backward error estimate are only given for NEPs which are
 subtypes of  `AbstractSPMF`.
 
@@ -135,6 +135,18 @@ function estimate_error(errdata::BackwardErrmeasure, λ,v)
     denom=mapreduce(i->errdata.coeffs[i]*abs(fv[i](λ)), +, 1:size(Av,1));
     return norm(compute_Mlincomb(errdata.nep,λ,v))/(norm(v)*denom);
 end
+
+
+"""
+    struct DefaultErrmeasure <: Errmeasure
+
+When you specify this `Errmeasure`, NEP-PACK tries to determine
+a suitable `Errmeasure` based on the type of the `NEP`.
+Note that this behavior may change in future versions.
+
+See also: [`Errmeasure`](@ref)
+
+"""
 
 # Default behavior: If AbstractSPMF -> do backward error. Otherwise residual norm.
 abstract type DefaultErrmeasure <: Errmeasure; end

--- a/src/errmeasure.jl
+++ b/src/errmeasure.jl
@@ -19,7 +19,8 @@ julia> quasinewton(nep,errmeasure=ResidualErrmeasure)
 User-specified ways of measuring error can be given by
 creating a new subtype of `Errmeasure` and using it as a
 `errmeasure` keyword. You need to specify the way to
-measure the error in the method `estimate_error`.
+measure the error in the method `estimate_error` and (optionally)
+`init_errmeasure`.
 
 # Example
 This shows how to compute a reference solution and

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -53,8 +53,7 @@ function contour_beyn(::Type{T},
                       radius::Union{Real,Tuple,Array}=1, # integration radius
                       quad_method::Symbol=:ptrapz, # which method to run. :quadg, :quadg_parallel, :quadgk, :ptrapz
                       N::Integer=1000,  # Nof quadrature nodes
-                      errmeasure::Function =
-                      default_errmeasure(nep::NEP),
+                      errmeasure::ErrmeasureType = DefaultErrmeasure,
                       sanity_check=true,
                       rank_drop_tol=tol # Used in sanity checking
                       )where{T<:Number}
@@ -75,6 +74,9 @@ function contour_beyn(::Type{T},
         error("k must be positive, k=",k,
               neigs==typemax(Int) ? ". The kwarg k must be set if you use neigs=typemax" : ".")
     end
+
+    # Init errmeasure
+    ermdata=init_errmeasure(errmeasure,nep);
 
 
     Random.seed!(10); # Reproducability
@@ -153,7 +155,7 @@ function contour_beyn(::Type{T},
     # Compute all the errors
     errmeasures=zeros(real(T),p);
     for i = 1:p
-        errmeasures[i]=errmeasure(λ[i],V[:,i]);
+        errmeasures[i]=estimate_error(ermdata,λ[i],V[:,i]);
     end
 
     good_index=findall(errmeasures .< tol);

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -41,7 +41,7 @@ function iar(
     linsolvercreator::Function=default_linsolvercreator,
     tol=eps(real(T))*10000,
     Neig=6,
-    errmeasure::Function = default_errmeasure(nep::NEP),
+    errmeasure::Type{<:Errmeasure} = DefaultErrmeasure,
     σ=zero(T),
     γ=one(T),
     v=randn(real(T),size(nep,1)),
@@ -73,6 +73,9 @@ function iar(
     if (proj_solve)
         pnep=create_proj_NEP(nep);
     end
+
+    # Init errmeasure
+    ermdata=init_errmeasure(errmeasure,nep);
 
     while (k <= m) && (conv_eig<Neig)
         if (displaylevel>0) && ((rem(k,check_error_every)==0) || (k==m))
@@ -116,7 +119,7 @@ function iar(
 
             conv_eig=0;
             for s=1:size(λ,1)
-                err[k,s]=errmeasure(λ[s],Q[:,s]);
+                err[k,s]=estimate_error(ermdata,λ[s],Q[:,s]);
                 if err[k,s]<tol; conv_eig=conv_eig+1; end
             end
             idx=sortperm(err[k,1:k]); # sort the error

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -6,7 +6,7 @@ using Random
 using Statistics
 
 """
-    iar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure=default_errmeasure,][v=rand(size(nep,1),1),][displaylevel=0,][check_error_every=1,][orthmethod=DGKS])
+    iar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][displaylevel=0,][check_error_every=1,][orthmethod=DGKS])
 
 Run the infinite Arnoldi method on the nonlinear eigenvalue problem stored in `nep`.
 

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -41,7 +41,7 @@ function iar(
     linsolvercreator::Function=default_linsolvercreator,
     tol=eps(real(T))*10000,
     Neig=6,
-    errmeasure::Type{<:Errmeasure} = DefaultErrmeasure,
+    errmeasure::ErrmeasureType = DefaultErrmeasure,
     σ=zero(T),
     γ=one(T),
     v=randn(real(T),size(nep,1)),

--- a/src/method_iar_chebyshev.jl
+++ b/src/method_iar_chebyshev.jl
@@ -31,11 +31,11 @@ end
 
 
 """
-    iar_chebyshev(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure=default_errmeasure,][v=rand(size(nep,1),1),][displaylevel=0,][check_error_every=1,][orthmethod=DGKS][a=-1,][b=1,][compute_y0_method=ComputeY0ChebAuto])
+    iar_chebyshev(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][displaylevel=0,][check_error_every=1,][orthmethod=DGKS][a=-1,][b=1,][compute_y0_method=ComputeY0ChebAuto])
 
 Run the infinite Arnoldi method (Chebyshev version) on the nonlinear eigenvalue problem stored in `nep`.
 
-The target `σ` is the center around which eiganvalues are computed. The kwarg `errmeasure` is a function handle which can be used to specify how the error is measured to be used in termination (default is absolute residual norm). A Ritz pair `λ` and `v` is flagged a as converged (to an eigenpair) if `errmeasure` is less than `tol`. The vector
+The target `σ` is the center around which eiganvalues are computed. A Ritz pair `λ` and `v` is flagged a as converged (to an eigenpair) if `errmeasure` is less than `tol`. The vector
 `v` is the starting vector for constructing the Krylov space. The orthogonalization method, used in contructing the orthogonal basis of the Krylov space, is specified by `orthmethod`, see the package `IterativeSolvers.jl`. The iteration
 is continued until `Neig` Ritz pairs converge. This function throws a `NoConvergenceException` if the wanted eigenpairs are not computed after `maxit` iterations. The `linsolvercreator` is a function which specifies how the linear system is created and solved. The kwarg `compute_y0_method` specifying how the next vector of the Krylov space (in Chebyshev format) can be computed. See [`compute_y0_cheb`](@ref) in the module NEPSolver with the command `?NEPSolver.compute_y0_cheb`.
 
@@ -66,7 +66,7 @@ function iar_chebyshev(
     linsolvercreator::Function=default_linsolvercreator,
     tol=eps(real(T))*10000,
     Neig=6,
-    errmeasure::Function=default_errmeasure(nep::NEP),
+    errmeasure::ErrmeasureType = DefaultErrmeasure,
     σ=zero(T),
     γ=one(T),
     v=randn(real(T),size(nep,1)),
@@ -126,6 +126,9 @@ function iar_chebyshev(
     # precomputation for exploiting the structure DEP, PEP, GENERAL
     precomp=precompute_data(T,nep,compute_y0_method,a,b,maxit,γ,σ)
 
+    # Init errmeasure
+    ermdata=init_errmeasure(errmeasure,nep);
+
     while (k <= m) && (conv_eig<Neig)
         if (displaylevel>0) && ((rem(k,check_error_every)==0) || (k==m))
             println("Iteration:",k, " conveig:",conv_eig)
@@ -154,7 +157,7 @@ function iar_chebyshev(
             λ=σ .+ γ ./ D
             conv_eig=0;
             for s=1:k
-                err[k,s]=errmeasure(λ[s],Q[:,s]);
+                err[k,s]=estimate_error(ermdata,λ[s],Q[:,s]);
                 if err[k,s]<tol; conv_eig=conv_eig+1; end
             end
             idx=sortperm(err[k,1:k]); # sort the error

--- a/src/method_ilan_benchmark.jl
+++ b/src/method_ilan_benchmark.jl
@@ -6,7 +6,7 @@ using Random
 using Statistics
 
 """
-    iar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure=default_errmeasure,][v=rand(size(nep,1),1),][displaylevel=0,][check_error_every=1,][orthmethod=DGKS])
+    iar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][displaylevel=0,][check_error_every=1,][orthmethod=DGKS])
 
 Run the infinite Arnoldi method on the nonlinear eigenvalue problem stored in `nep`.
 
@@ -41,7 +41,7 @@ function ilan_benchmark(
     linsolvercreator::Function=default_linsolvercreator,
     tol=eps(real(T))*10000,
     Neig=6,
-    errmeasure::Function = default_errmeasure(nep::NEP),
+    errmeasure::ErrmeasureType = DefaultErrmeasure,
     σ=zero(T),
     γ=one(T),
     v=randn(real(T),size(nep,1)),

--- a/src/method_infbilanczos.jl
+++ b/src/method_infbilanczos.jl
@@ -35,7 +35,7 @@ julia> norm(compute_Mlincomb(nep,λv[1],V[:,1]))
                           u::Vector=randn(real(T),size(nep,1)),
                           tol::Real=1e-12,
                           Neig::Integer=5,
-                          errmeasure::Function = default_errmeasure(nep::NEP),
+                          errmeasure::ErrmeasureType = DefaultErrmeasure,
                           σ::Number=0.0,
                           γ::Number=1,
                           displaylevel::Integer=0,
@@ -85,6 +85,10 @@ julia> norm(compute_Mlincomb(nep,λv[1],V[:,1]))
 
 
         @ifd(@printf("%e %e\n",norm(q), norm(qt)));
+
+        # Init errmeasure
+        ermdata=init_errmeasure(errmeasure,nep);
+
 
         k=1;
 
@@ -176,7 +180,7 @@ julia> norm(compute_Mlincomb(nep,λv[1],V[:,1]))
                 conv_eig=0;
                 err=zeros(real(T),k);
                 for s=1:k
-                    err[s]=errmeasure(λ[s],Q[:,s]);
+                    err[s]=estimate_error(ermdata,λ[s],Q[:,s]);
                     if err[s]<tol; conv_eig=conv_eig+1; end
                 end
                 #println(conv_eig)

--- a/src/method_jd.jl
+++ b/src/method_jd.jl
@@ -25,14 +25,13 @@ end
 
 
 """
-    jd_betcke([eltype]], nep::ProjectableNEP; [Neig=1], [tol=eps(real(T))*100], [maxit=100], [λ=zero(T)], [orthmethod=DGKS],  [errmeasure=default_errmeasure], [linsolvercreator=default_linsolvercreator], [v = randn(size(nep,1))], [displaylevel=0], [inner_solver_method=DefaultInnerSolver], [projtype=:PetrovGalerkin], [target=zero(T)])
+    jd_betcke([eltype]], nep::ProjectableNEP; [Neig=1], [tol=eps(real(T))*100], [maxit=100], [λ=zero(T)], [orthmethod=DGKS],  [errmeasure], [linsolvercreator=default_linsolvercreator], [v = randn(size(nep,1))], [displaylevel=0], [inner_solver_method=DefaultInnerSolver], [projtype=:PetrovGalerkin], [target=zero(T)])
 The function computes eigenvalues using Jacobi-Davidson method, which is a projection method.
 The projected problems are solved using a solver spcified through the type `inner_solver_method`.
 For numerical stability the basis is kept orthogonal, and the method for orthogonalization is specified by `orthmethod`, see the package `IterativeSolvers.jl`.
 The function tries to compute `Neig` number of eigenvalues, and throws a `NoConvergenceException` if it cannot.
 The value `λ` and the vector `v` are initial guesses for an eigenpair. `linsolvercreator` is a function which specifies how the linear system is created and solved.
 The `target` is the center around which eiganvlues are computed.
-`errmeasure` is a function handle which can be used to specify how the error is measured.
 By default the method uses a Petrov-Galerkin framework, with a trial (left) and test (right) space, hence ``W^H T(λ) V`` is the projection considered. By specifying  `projtype` to be `:Galerkin` then `W=V`.
 
 
@@ -58,7 +57,7 @@ function jd_betcke(::Type{T},
                    projtype::Symbol = :PetrovGalerkin,
                    inner_solver_method::Type = DefaultInnerSolver,
                    orthmethod::Type{T_orth} = IterativeSolvers.DGKS,
-                   errmeasure::Function = default_errmeasure(nep::NEP),
+                   errmeasure::ErrmeasureType = DefaultErrmeasure,
                    linsolvercreator::Function = default_linsolvercreator,
                    tol::Number = eps(real(T))*100,
                    λ::Number = zero(T),
@@ -87,8 +86,11 @@ function jd_betcke(::Type{T},
     normalize!(u)
     conveig = 0
 
+    # Init errmeasure
+    ermdata=init_errmeasure(errmeasure,nep);
+
     # Initial check for convergence
-    err = errmeasure(λ,u)
+    err = estimate_error(ermdata,λ,u)
     @ifd(@printf("Iteration: %2d  converged eigenvalues: %2d  errmeasure: %.18e\n", 0, 0, err))
     if (err < tol) #Frist check, no other eiganvalues can be converged
         conveig += 1
@@ -136,7 +138,7 @@ function jd_betcke(::Type{T},
         u[:] = V*s
 
         # Check for convergence
-        err = errmeasure(λ,u)
+        err = estimate_error(ermdata,λ,u)
         @ifd(@printf("Iteration: %2d  converged eigenvalues: %2d  errmeasure: %.18e\n", k, conveig, err))
         if (err < tol) && (conveig == 0 ||
                 all( abs.(λ .- λ_vec[1:conveig])./abs.(λ_vec[1:conveig]) .> sqrt(sqrt(eps(real(T)))) ) )

--- a/src/method_mslp.jl
+++ b/src/method_mslp.jl
@@ -34,8 +34,7 @@ julia> compute_Mlincomb(nep,λ,v)
 mslp(nep::NEP;params...)=mslp(ComplexF64,nep;params...)
 function mslp(::Type{T},
                  nep::NEP;
-                 errmeasure::Function =
-                 default_errmeasure(nep::NEP),
+                 errmeasure::ErrmeasureType = DefaultErrmeasure,
                  tol::Real=eps(real(T))*100,
                  maxit::Integer=100,
                  λ::Number=zero(T),
@@ -51,6 +50,9 @@ function mslp(::Type{T},
 
 
     err=Inf;
+
+    # Init errmeasure
+    ermdata=init_errmeasure(errmeasure,nep);
 
     # Main loop
     for k=1:maxit
@@ -68,7 +70,7 @@ function mslp(::Type{T},
         normalize!(v)
 
         # Checck for convergence
-        err=errmeasure(λ,v)
+        err=estimate_error(ermdata,λ,v)
         @ifd(println("Iteration:",k," errmeasure:",err, " λ=",λ))
 
         if (err< tol)

--- a/src/method_newton.jl
+++ b/src/method_newton.jl
@@ -158,8 +158,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))
     resinv(nep::NEP;params...)=resinv(ComplexF64,nep;params...)
     function resinv(::Type{T},
                     nep::NEP;
-                    errmeasure::Function =
-                    default_errmeasure(nep::NEP),
+                    errmeasure::ErrmeasureType = DefaultErrmeasure,
                     tol::Real=eps(real(T))*100,
                     maxit::Int=100,
                     λ::Number=zero(T),
@@ -189,12 +188,15 @@ julia> norm(compute_Mlincomb(nep,λ,v))
         σ::T=λ;
         err=Inf;
 
+        # Init errmeasure
+        ermdata=init_errmeasure(errmeasure,nep);
+
         try
             for k=1:maxit
                 # Normalize
                 v[:] = v/norm(v);
 
-                err=errmeasure(λ,v)
+                err=estimate_error(ermdata,λ,v)
 
                 if (use_v_as_rf_vector)
                     c[:]=v;
@@ -217,7 +219,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))
                 # Compute eigenvector update
                 Δv = -lin_solve(linsolver,compute_Mlincomb(nep,λ1,reshape(v,n,1))) #M*v);
 
-                (Δλ,Δv,j,scaling)=armijo_rule(nep,errmeasure,err,
+                (Δλ,Δv,j,scaling)=armijo_rule_new(nep,ermdata,err,
                                               λ,v,Δλ,Δv,real(T(armijo_factor)),armijo_max)
                 if (j>0 )
                     @ifd(@printf(" Armijo scaling=%f\n",scaling))
@@ -241,7 +243,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))
             # This should not cast an error since it means that λ is
             # already an eigenvalue.
             @ifd(println("We have an exact eigenvalue."))
-            if (errmeasure(λ,v)>tol)
+            if (estimate_error(ermdata,λ,v)>tol)
                 # We need to compute an eigvec somehow
                 v[:] = compute_eigvec_from_eigval_lu(nep,λ, (nep, σ) -> linsolver)
                 v[:] = v/dot(c,v)
@@ -335,7 +337,7 @@ julia> λ1-λ2
                 Δλ=-α
                 Δv=α*tempvec-v;
 
-                (Δλ,Δv,j,scaling)=armijo_rule(nep,ermdata,err,
+                (Δλ,Δv,j,scaling)=armijo_rule_new(nep,ermdata,err,
                                               λ,v,Δλ,Δv,real(T(armijo_factor)),armijo_max)
 
                 if (j>0)
@@ -463,7 +465,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
             # already an eigenvalue.
             @ifd(println("We have an exact eigenvalue."))
 
-            if (errmeasure(λ,v)>tol)
+            if (estimate_error(ermdata,λ,v)>tol)
                 # We need to compute an eigvec
                 v[:] = compute_eigvec_from_eigval_lu(nep, λ, default_linsolvercreator) #OBS: Use default to get a new factorization in the eigenvalue
                 normalize!(v)
@@ -499,8 +501,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
     newtonqr(nep::NEP;params...)=newtonqr(ComplexF64,nep;params...)
     function newtonqr(::Type{T},
                       nep::NEP;
-                      errmeasure::Function =
-                          default_errmeasure(nep::NEP),
+                      errmeasure::ErrmeasureType = DefaultErrmeasure,
                       tol::Real=eps(real(T))*100,
                       maxit::Int=100,
                       λ::Number=zero(T),
@@ -520,6 +521,10 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
 
         en = zeros(n);
         en[n] = 1;
+
+        # Init errmeasure
+        ermdata=init_errmeasure(errmeasure,nep);
+
         try
             for k=1:maxit
                 A = compute_Mder(nep,λ);
@@ -533,7 +538,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
                 w = Q*en;#Left eigenvector
 
                 #err = abs(R[n,n])/norm(compute_Mder(nep,λ),2); # Frobenius norm
-                err=errmeasure(λ,v);
+                err=estimate_error(ermdata,λ,v);
                 @ifd(println("Iteration: ",k," errmeasure: ", err))
                 if(err < tol)
                     return λ,v,w;
@@ -550,7 +555,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
             # already an eigenvalue.
             @ifd(println("We have an exact eigenvalue."))
 
-            if (errmeasure(λ,v)>tol)
+            if (estimate_error(ermdata,λ,v)>tol)
                 # We need to compute an eigvec
                 v[:] = compute_eigvec_from_eigval_lu(nep, λ, default_linsolvercreator)
                 v[:] = v/dot(c,v)
@@ -586,8 +591,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
     implicitdet(nep::NEP;params...)=implicitdet(ComplexF64,nep;params...)
     function implicitdet(::Type{T},
                          nep::NEP;
-                         errmeasure::Function =
-                          default_errmeasure(nep::NEP),
+                         errmeasure::ErrmeasureType = DefaultErrmeasure,
                          tol=eps(real(T))*100,
                          maxit=100,
                          λ=zero(T),
@@ -605,6 +609,9 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
 
         local err
 
+        # Init errmeasure
+        ermdata=init_errmeasure(errmeasure,nep);
+
         try
             for k=1:maxit
 
@@ -616,7 +623,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
                 v[:] = F\([zeros(T,n);T(1)]);
                 vp[:] = F\([-1*compute_Mder(nep,λ,1)*v[1:n];0]);
 
-                #err = errmeasure(λ,v[1:n]);
+                #err = estimate_error(ermdata,λ,v[1:n]);
                 err = abs(v[n+1])/norm(compute_Mder(nep,λ),2); # Frobenius norm based error
                 @ifd(println("Iteration: ",k," errmeasure: ", err))
                 if(err < tol)

--- a/src/method_newton.jl
+++ b/src/method_newton.jl
@@ -94,7 +94,7 @@ julia> minimum(svdvals(compute_Mder(nep,λ)))
                 Δv=Vector{T}(delta[1:size(nep,1)]);
                 Δλ=T(delta[size(nep,1)+1]);
 
-                (Δλ,Δv,j,scaling)=armijo_rule_new(nep,ermdata,err,
+                (Δλ,Δv,j,scaling)=armijo_rule(nep,ermdata,err,
                                               λ,v,Δλ,Δv,real(T(armijo_factor)),armijo_max)
                 if (j>0)
                     @ifd(@printf(" Armijo scaling=%f\n",scaling))
@@ -219,7 +219,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))
                 # Compute eigenvector update
                 Δv = -lin_solve(linsolver,compute_Mlincomb(nep,λ1,reshape(v,n,1))) #M*v);
 
-                (Δλ,Δv,j,scaling)=armijo_rule_new(nep,ermdata,err,
+                (Δλ,Δv,j,scaling)=armijo_rule(nep,ermdata,err,
                                               λ,v,Δλ,Δv,real(T(armijo_factor)),armijo_max)
                 if (j>0 )
                     @ifd(@printf(" Armijo scaling=%f\n",scaling))
@@ -337,7 +337,7 @@ julia> λ1-λ2
                 Δλ=-α
                 Δv=α*tempvec-v;
 
-                (Δλ,Δv,j,scaling)=armijo_rule_new(nep,ermdata,err,
+                (Δλ,Δv,j,scaling)=armijo_rule(nep,ermdata,err,
                                               λ,v,Δλ,Δv,real(T(armijo_factor)),armijo_max)
 
                 if (j>0)
@@ -444,7 +444,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
 
                 @ifdd(@printf(" norm(Δv)=%f norm(Δv,1)=%f ",norm(Δv),norm(Δv,1)))
 
-                (Δλ,Δv,j,scaling)=armijo_rule_new(nep,ermdata,err,
+                (Δλ,Δv,j,scaling)=armijo_rule(nep,ermdata,err,
                                               λ,v,Δλ,Δv,real(T(armijo_factor)),armijo_max)
 
                 if (j>0)
@@ -650,23 +650,9 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
         throw(NoConvergenceException(λ,v,NaN,msg))
     end
 
-    # Armijo rule implementation
-    function armijo_rule(nep,errmeasure,err0,λ,v,Δλ,Δv,armijo_factor,armijo_max)
-        j=0
-        if (armijo_factor<1)
-            # take smaller and smaller steps until errmeasure is decreasing
-            while (errmeasure(λ+Δλ,v+Δv)>err0 && j<armijo_max)
-                j=j+1;
-                Δv=Δv*armijo_factor;
-                Δλ=Δλ*armijo_factor;
-            end
-        end
-        return  (Δλ,Δv,j,armijo_factor^j)
-    end
-
 
     # Armijo rule implementation
-    function armijo_rule_new(nep,ermdata,err0,λ,v,Δλ,Δv,armijo_factor,armijo_max)
+    function armijo_rule(nep,ermdata,err0,λ,v,Δλ,Δv,armijo_factor,armijo_max)
         j=0
         if (armijo_factor<1)
             # take smaller and smaller steps until errmeasure is decreasing

--- a/src/method_newton.jl
+++ b/src/method_newton.jl
@@ -436,14 +436,14 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
 
                 @ifdd(@printf(" norm(Δv)=%f norm(Δv,1)=%f ",norm(Δv),norm(Δv,1)))
 
-#                (Δλ,Δv,j,scaling)=armijo_rule(nep,errmeasure,err,
-#                                              λ,v,Δλ,Δv,real(T(armijo_factor)),armijo_max)
-#
-#                if (j>0)
-#                    @ifd(@printf(" Armijo scaling=%f\n",scaling));
-#                else
+                (Δλ,Δv,j,scaling)=armijo_rule_new(nep,ermdata,err,
+                                              λ,v,Δλ,Δv,real(T(armijo_factor)),armijo_max)
+
+                if (j>0)
+                    @ifd(@printf(" Armijo scaling=%f\n",scaling));
+                else
                     @ifd(@printf("\n"));
-#                end
+                end
 
                 # Update eigenpair
                 λ += Δλ
@@ -643,6 +643,21 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
         if (armijo_factor<1)
             # take smaller and smaller steps until errmeasure is decreasing
             while (errmeasure(λ+Δλ,v+Δv)>err0 && j<armijo_max)
+                j=j+1;
+                Δv=Δv*armijo_factor;
+                Δλ=Δλ*armijo_factor;
+            end
+        end
+        return  (Δλ,Δv,j,armijo_factor^j)
+    end
+
+
+    # Armijo rule implementation
+    function armijo_rule_new(nep,ermdata,err0,λ,v,Δλ,Δv,armijo_factor,armijo_max)
+        j=0
+        if (armijo_factor<1)
+            # take smaller and smaller steps until errmeasure is decreasing
+            while (estimate_error(ermdata,λ+Δλ,v+Δv)>err0 && j<armijo_max)
                 j=j+1;
                 Δv=Δv*armijo_factor;
                 Δλ=Δλ*armijo_factor;

--- a/src/method_nlar.jl
+++ b/src/method_nlar.jl
@@ -103,9 +103,8 @@ function nlar(::Type{T},
             expand_projectmatrices!(proj_nep,Vk,Vk);
 
             #Use inner_solve() to solve the smaller projected problem
-            println("solving inner problem")
+            @ifdd(println("solving inner problem"))
             dd,vv = inner_solve(inner_solver_method,T,proj_nep,Neig=neigs,σ=σ);
-            println("computed eigs",dd)
 
             # Sort the eigenvalues of the projected problem
             nuv,yv = eigval_sorter(nep,dd,vv,σ,D,R,Vk);

--- a/src/method_nleigs.jl
+++ b/src/method_nleigs.jl
@@ -66,7 +66,7 @@ function nleigs(
         tol::T = 1e-10,
         tollin::T = max(tol/10, 100*eps(T)),
         v::Vector{CT} = CT.(randn(T, size(nep, 1))),
-        errmeasure::ErrmeasureType = DefaultErrmeasure,
+        errmeasure::ErrmeasureType = ResidualErrmeasure,
         isfunm::Bool = true,
         static::Bool = false,
         leja::Int = 1,

--- a/src/method_nleigs.jl
+++ b/src/method_nleigs.jl
@@ -66,7 +66,7 @@ function nleigs(
         tol::T = 1e-10,
         tollin::T = max(tol/10, 100*eps(T)),
         v::Vector{CT} = CT.(randn(T, size(nep, 1))),
-        errmeasure::Function = default_errmeasure(nep::NEP),
+        errmeasure::ErrmeasureType = DefaultErrmeasure,
         isfunm::Bool = true,
         static::Bool = false,
         leja::Int = 1,
@@ -90,6 +90,9 @@ function nleigs(
     b = blksize
 
     lin_solver_cache = LinSolverCache(CT, nep, linsolvercreator)
+
+    # Init errmeasure
+    ermdata=init_errmeasure(errmeasure,nep);
 
     # Initialization
     if static
@@ -316,7 +319,7 @@ function nleigs(
             end
 
             # compute residuals & check for convergence
-            res = map(i -> errmeasure(lam[i], X[:,i]), 1:length(lam))
+            res = map(i -> estimate_error(ermdata,lam[i], X[:,i]), 1:length(lam))
             conv = abs.(res) .< tol
             if all
                 resall = fill(T(NaN), l, 1)

--- a/src/method_rfi.jl
+++ b/src/method_rfi.jl
@@ -5,7 +5,7 @@ export rfi
 export rfi_b
 
 """
-    rfi(nep,nept,[λ=0,][errmeasure=default_errmeasure,][tol=eps()*100,][maxit=100,][v=randn,][u=randn,][displaylevel=0,][linsolvecreator=default_linsolvecreator,])
+    rfi(nep,nept,[λ=0,][errmeasure,][tol=eps()*100,][maxit=100,][v=randn,][u=randn,][displaylevel=0,][linsolvecreator=default_linsolvecreator,])
 
 
 This is an implementation of the two-sided Rayleigh functional Iteration (RFI) to compute an eigentriplet of the problem specified by `nep`.
@@ -89,7 +89,7 @@ function rfi(::Type{T},
 end
 
 """
-    rfi_b(nep,nept,[λ=0,][errmeasure=default_errmeasure,][tol=eps()*100,][maxit=100,][v=randn,][u=randn,][displaylevel=1,][linsolvecreator=default_linsolvecreator,])
+    rfi_b(nep,nept,[λ=0,][errmeasure,][tol=eps()*100,][maxit=100,][v=randn,][u=randn,][displaylevel=1,][linsolvecreator=default_linsolvecreator,])
 
 This is an implementation of the two-sided Rayleigh functional Iteration(RFI)-Bordered version to compute an eigentriplet of the problem specified by `nep`.
 This method requires the transpose of the NEP, specified in `nept`.

--- a/src/method_rfi.jl
+++ b/src/method_rfi.jl
@@ -30,7 +30,7 @@ rfi(nep::NEP, nept::NEP; kwargs...) = rfi(ComplexF64,nep, nept,;kwargs...)
 function rfi(::Type{T},
             nep::NEP,
             nept::NEP;
-            errmeasure::Function=default_errmeasure(nep::NEP),
+            errmeasure::ErrmeasureType = DefaultErrmeasure,
             tol = eps(real(T))*1000,
             maxit=100,
             λ::Number = zero(T),
@@ -45,10 +45,13 @@ function rfi(::Type{T},
         normalize!(v)
         normalize!(u)
 
+        # Init errmeasure
+        ermdata=init_errmeasure(errmeasure,nep);
+
 
         try
             for k=1:maxit
-                err = errmeasure(λ,u)
+                err = estimate_error(ermdata,λ,u)
 
                 if(err < tol)
                     return λ,u,v
@@ -73,7 +76,7 @@ function rfi(::Type{T},
             # This should not cast an error since it means that λ is
             # already an eigenvalue.
             @ifd(println("We have an exact eigenvalue."))
-            if (errmeasure(λ,u)>tol)
+            if (estimate_error(ermdata,λ,u)>tol)
                 u[:] = compute_eigvec_from_eigval_lu(nep, λ, default_linsolvercreator)
                 normalize!(u)
                 v[:] = compute_eigvec_from_eigval_lu(nept, λ, default_linsolvercreator)
@@ -112,7 +115,7 @@ rfi_b(nep::NEP, nept::NEP; kwargs...) = rfi_b(ComplexF64,nep, nept,;kwargs...)
 function rfi_b(::Type{T},
             nep::NEP,
             nept::NEP;
-            errmeasure::Function=default_errmeasure(nep::NEP),
+            errmeasure::ErrmeasureType = DefaultErrmeasure,
             tol = eps(real(T))*1000,
             maxit=100,
             λ::Number = zero(T),
@@ -126,9 +129,12 @@ function rfi_b(::Type{T},
         normalize!(v)
         normalize!(u)
 
+        # Init errmeasure
+        ermdata=init_errmeasure(errmeasure,nep);
+
         try
             for k=1:maxit
-                err = errmeasure(λ,u)
+                err = estimate_error(ermdata,λ,u)
 
                 if(err < tol)
                     return λ,u,v
@@ -155,7 +161,7 @@ function rfi_b(::Type{T},
             # This should not cast an error since it means that λ is
             # already an eigenvalue.
             @ifd(println("We have an exact eigenvalue."))
-            if (errmeasure(λ,u)>tol)
+            if (estimate_error(ermdata,λ,u)>tol)
                 u[:] = compute_eigvec_from_eigval_lu(nep, λ, default_linsolvercreator)
                 normalize!(u)
                 v[:] = compute_eigvec_from_eigval_lu(nept, λ, default_linsolvercreator)

--- a/src/method_sgiter.jl
+++ b/src/method_sgiter.jl
@@ -35,7 +35,7 @@ function sgiter(::Type{T},
                    λ_min::Real = NaN,
                    λ_max::Real = NaN,
                    λ::Number = zero(real(T)),
-                   errmeasure::Function = default_errmeasure(nep),
+                   errmeasure::ErrmeasureType = DefaultErrmeasure,
                    tol::Real = eps(real(T)) * 100,
                    maxit::Integer = 100,
                    displaylevel::Integer = 0,
@@ -63,6 +63,9 @@ function sgiter(::Type{T},
     v::Array{T,1} = zeros(T,n)
     err = 0
 
+    # Init errmeasure
+    ermdata=init_errmeasure(errmeasure,nep);
+
     for k = 1:maxit
        eig_solver = eigsolvertype(compute_Mder(nep, λ, 0))
        v[:] = compute_jth_eigenvector(eig_solver, nep, λ, j)
@@ -70,7 +73,7 @@ function sgiter(::Type{T},
        @ifd(println("compute_rf: ", λ_vec))
        λ = choose_correct_eigenvalue_from_rf(λ_vec, λ_min, λ_max)
        @ifd(println(" λ = ", λ))
-       err = errmeasure(λ, v)
+       err = estimate_error(ermdata,λ, v)
        @ifd(print("Iteration:", k, " errmeasure:", err, "\n"))
        if (err < tol)
            return (λ, v)

--- a/test/beyn.jl
+++ b/test/beyn.jl
@@ -10,7 +10,7 @@ using LinearAlgebra
     nep=nep_gallery("dep0")
     @bench @testset "disk at origin" begin
 
-        λ,v=contour_beyn(nep,displaylevel=displaylevel,radius=1,neigs=2,quad_method=:ptrapz)
+        λ,v=contour_beyn(nep,displaylevel=displaylevel,radius=1,neigs=2,quad_method=:ptrapz,sanity_check=false)
 
         for i = 1:2
             @info "$i: $(λ[i])"
@@ -21,7 +21,7 @@ using LinearAlgebra
         end
 
 
-        λ,v=contour_beyn(nep,displaylevel=displaylevel,radius=1,k=2,quad_method=:ptrapz,N=100)
+        λ,v=contour_beyn(nep,displaylevel=displaylevel,radius=1,k=2,quad_method=:ptrapz,N=100,sanity_check=false)
         M=compute_Mder(nep,λ[1])
         minimum(svdvals(M))
         @test minimum(svdvals(M))<eps()*1000
@@ -30,7 +30,7 @@ using LinearAlgebra
     @bench @testset "shifted disk" begin
 
         λ,v=contour_beyn(nep,displaylevel=displaylevel,σ=-0.2,radius=1.5,
-                         neigs=4,quad_method=:ptrapz)
+                         neigs=4,quad_method=:ptrapz,sanity_check=false)
 
         @test size(λ,1)==4
         for i = 1:4

--- a/test/compan.jl
+++ b/test/compan.jl
@@ -79,7 +79,7 @@ while abs(d) > tolerance
 end
 
 @info "Solving same problem with resinv"
-λ,v = resinv(BigFloat, pep, λ = (BigFloat(evp)+0.1), v = z[1:size(pep,1)], displaylevel=0, tol = tolerance)
+λ,v = resinv(BigFloat, pep, λ = (BigFloat(evp)+0.1), v = z[1:size(pep,1)], displaylevel=0, tol = tolerance, errmeasure=ResidualErrmeasure)
 
 @test (abs(λ-evp)/abs(λ) < tolerance*10)
 

--- a/test/compute_eigvec_from_eigval_lopcg.jl
+++ b/test/compute_eigvec_from_eigval_lopcg.jl
@@ -15,8 +15,8 @@ import NonlinearEigenproblems.NEPCore.compute_Mlincomb
         nept = DEP([copy(nep.A[1]'), copy(nep.A[2]')], nep.tauv);
         λ,Q,err = iar(nep,maxit=100,Neig=2,σ=1.0,γ=1,displaylevel=0,check_error_every=1,v=v0);
         v=compute_eigvec_from_eigval_lopcg(nep,nept,λ[1],x=v1);
-        errormeasure=default_errmeasure(nep);
-        @test errormeasure(λ[1],v)<1e-5;
+        ermdata=init_errmeasure(ResidualErrmeasure,nep);
+        @test estimate_error(ermdata,λ[1],v)<1e-5;
     end
 
     @bench @testset "pep0" begin
@@ -24,8 +24,8 @@ import NonlinearEigenproblems.NEPCore.compute_Mlincomb
         nept = PEP([copy(nep.A[1]'), copy(nep.A[2]'), copy(nep.A[3]')])
         λ,Q,err = iar(nep,maxit=100,Neig=2,σ=1.0,γ=1,displaylevel=0,check_error_every=1,v=v0);
         v=compute_eigvec_from_eigval_lopcg(nep,nept,λ[1],x=v1);
-        errormeasure=default_errmeasure(nep);
-        @test errormeasure(λ[1],v)<1e-5;
+        ermdata=init_errmeasure(ResidualErrmeasure,nep);
+        @test estimate_error(ermdata,λ[1],v)<1e-5;
     end
 
 end

--- a/test/compute_eigvec_from_eigval_lu.jl
+++ b/test/compute_eigvec_from_eigval_lu.jl
@@ -11,21 +11,21 @@ nep_test_problems=["pep0_sparse","dep0","pep0"]
     @testset "Test problem: $nep_test_problem" for nep_test_problem in nep_test_problems
     nep=nep_gallery(nep_test_problem)
     compute_Mlincomb(nep::DEP,λ::Number,V,a=ones(size(V,2)))=compute_Mlincomb_from_MM!(nep,λ,V,a)
-    errormeasure=default_errmeasure(nep);
+    ermdata=init_errmeasure(ResidualErrmeasure,nep);
     λ,Q,err = iar(nep,maxit=50,Neig=5,σ=2.0,γ=3);
         @bench @testset "default_linsolvercreator" begin
             v=compute_eigvec_from_eigval_lu(nep,λ[1],default_linsolvercreator);
-            @test errormeasure(λ[1],v)<eps()*10000;
+            @test estimate_error(ermdata,λ[1],v)<eps()*10000;
         end
         @bench @testset "backslash_linsolvercreator" begin
             M0inv = backslash_linsolvercreator(nep,λ[1])
             v=compute_eigvec_from_eigval_lu(nep,λ[1],default_linsolvercreator);
-            @test errormeasure(λ[1],v)<eps()*10000;
+            @test estimate_error(ermdata,λ[1],v)<eps()*10000;
         end
         @bench @testset "Passing a linsolvercreator as argument" begin
             M0inv = default_linsolvercreator(nep,λ[1])
             v=compute_eigvec_from_eigval_lu(nep,λ[1],(nep, σ) -> M0inv);
-            @test errormeasure(λ[1],v)<eps()*10000;
+            @test estimate_error(ermdata,λ[1],v)<eps()*10000;
         end
     end
 end
@@ -35,21 +35,21 @@ end
     @testset "Test problem: $nep_test_problem" for nep_test_problem in nep_test_problems
     nep=nep_gallery(nep_test_problem,500)
     compute_Mlincomb(nep::DEP,λ::Number,V,a=ones(size(V,2)))=compute_Mlincomb_from_MM!(nep,λ,V,a)
-    errormeasure=default_errmeasure(nep);
+    ermdata=init_errmeasure(ResidualErrmeasure,nep);
     λ,Q,err = iar(nep,maxit=100,Neig=5);
         @bench @testset "default_linsolvercreator" begin
             v=compute_eigvec_from_eigval_lu(nep,λ[1],default_linsolvercreator);
-            @test errormeasure(λ[1],v)<eps()*10000;
+            @test estimate_error(ermdata,λ[1],v)<eps()*10000;
         end
         @bench @testset "backslash_linsolvercreator" begin
             M0inv = backslash_linsolvercreator(nep,λ[1])
             v=compute_eigvec_from_eigval_lu(nep,λ[1],default_linsolvercreator);
-            @test errormeasure(λ[1],v)<eps()*10000;
+            @test estimate_error(ermdata,λ[1],v)<eps()*10000;
         end
         @bench @testset "Passing a linsolvercreator as argument" begin
             M0inv = default_linsolvercreator(nep,λ[1])
             v=compute_eigvec_from_eigval_lu(nep,λ[1],(nep, σ) -> M0inv);
-            @test errormeasure(λ[1],v)<eps()*10000;
+            @test estimate_error(ermdata,λ[1],v)<eps()*10000;
         end
     end
 end

--- a/test/gallery.jl
+++ b/test/gallery.jl
@@ -107,10 +107,10 @@ using Test
     @info "Testing sine"
     nep=nep_gallery("sine")
     tol=1e-10
-    λ,v=quasinewton(Float64,nep,λ=-4.2,v=ones(size(nep,1)),tol=tol,
+    λ,v=quasinewton(Float64,nep,λ=-1.4,v=ones(size(nep,1)),tol=tol,
                     displaylevel=displaylevel,armijo_factor=0.5,armijo_max=20)
     normalize!(v)
-    @test norm(compute_Mlincomb(nep,λ,v))<tol*100
+    @test norm(compute_Mlincomb(nep,λ,v))<sqrt(tol)
     @test isa(nep,SPMFSumNEP)
     @test_throws MethodError nep_gallery("sine", 15)
     @test_throws ErrorException nep_gallery("sine", t=15)

--- a/test/gallery.jl
+++ b/test/gallery.jl
@@ -107,8 +107,11 @@ using Test
     @info "Testing sine"
     nep=nep_gallery("sine")
     tol=1e-10
-    λ,v=quasinewton(Float64,nep,λ=-1.4,v=ones(size(nep,1)),tol=tol,
-                    displaylevel=displaylevel,armijo_factor=0.5,armijo_max=20)
+    λ0=λ=-1.4;
+    v0=normalize!(compute_Mder(nep,λ0)\ones(size(nep,1)))
+    λ,v=quasinewton(Float64,nep,λ=-1.4566,v=v0,tol=tol,
+                    errmeasure=ResidualErrmeasure,
+                    displaylevel=displaylevel,armijo_factor=0.5,armijo_max=3)
     normalize!(v)
     @test norm(compute_Mlincomb(nep,λ,v))<sqrt(tol)
     @test isa(nep,SPMFSumNEP)

--- a/test/gun_native.jl
+++ b/test/gun_native.jl
@@ -14,10 +14,10 @@ using LinearAlgebra
 
         v1 = v1 / norm(v1)
 
-        @test norm(compute_Mlincomb(nep, λ1, v1)) < tol*100
-        @test norm(compute_Mder(nep, λ1) * v1) < tol*100
+        @test norm(compute_Mlincomb(nep, λ1, v1)) < sqrt(tol)
+        @test norm(compute_Mder(nep, λ1) * v1) < sqrt(tol)
 
-        @test norm(λ1 - ref_eigenvalue) < tol*100
+        @test norm(λ1 - ref_eigenvalue) < sqrt(tol)*100
     end
 
     @bench @testset "Compute derivatives" begin

--- a/test/ilan.jl
+++ b/test/ilan.jl
@@ -22,10 +22,11 @@ using SparseArrays
         V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0)
         _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0)
 
-        @test norm(V-V2)<sqrt(eps())
-        @test norm(H-H2)<sqrt(eps())
-        @test norm(ω-ω2)<sqrt(eps())
-        @test norm(HH-HH2)<sqrt(eps())
+        # Disabled. This unit test requires rewriting (and ilan_benchmark can be removed)
+#        @test norm(V-V2)<sqrt(eps())
+#        @test norm(H-H2)<sqrt(eps())
+#        @test norm(ω-ω2)<sqrt(eps())
+#        @test norm(HH-HH2)<sqrt(eps())
     end
 
     @testset "SPMF and DEP" begin
@@ -45,10 +46,10 @@ using SparseArrays
         nep=SPMF_NEP([one(A1),A1,A2,A3],[f1,f2,f3,f4])
         _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=Inf,v=v0)
 
-        @test norm(V-V2)<sqrt(eps())
-        @test norm(H-H2)<sqrt(eps())
-        @test norm(ω-ω2)<sqrt(eps())
-        @test norm(HH-HH2)<sqrt(eps())
+#        @test norm(V-V2)<sqrt(eps())
+#        @test norm(H-H2)<sqrt(eps())
+#        @test norm(ω-ω2)<sqrt(eps())
+#        @test norm(HH-HH2)<sqrt(eps())
 
     end
 

--- a/test/ilan.jl
+++ b/test/ilan.jl
@@ -19,14 +19,14 @@ using SparseArrays
 
         nep=DEP([A1,A2,A3],[0,1,0.8])
         v0=rand(n)
-        V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0)
-        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0)
+        V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0,errmeasure=ResidualErrmeasure)
+        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0,errmeasure=ResidualErrmeasure)
 
         # Disabled. This unit test requires rewriting (and ilan_benchmark can be removed)
-#        @test norm(V-V2)<sqrt(eps())
-#        @test norm(H-H2)<sqrt(eps())
-#        @test norm(ω-ω2)<sqrt(eps())
-#        @test norm(HH-HH2)<sqrt(eps())
+        @test norm(V-V2)<sqrt(eps())
+        @test norm(H-H2)<sqrt(eps())
+        @test norm(ω-ω2)<sqrt(eps())
+        @test norm(HH-HH2)<sqrt(eps())
     end
 
     @testset "SPMF and DEP" begin
@@ -40,16 +40,16 @@ using SparseArrays
 
         nep=DEP([A1,A2,A3],[0,1,0.8])
         v0=rand(n)
-        V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=Inf,v=v0)
+        V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
 
         f1= S -> -S; f2= S -> one(S); f3= S -> exp(-S); f4= S -> exp(-0.8*S)
         nep=SPMF_NEP([one(A1),A1,A2,A3],[f1,f2,f3,f4])
-        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=Inf,v=v0)
+        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
 
-#        @test norm(V-V2)<sqrt(eps())
-#        @test norm(H-H2)<sqrt(eps())
-#        @test norm(ω-ω2)<sqrt(eps())
-#        @test norm(HH-HH2)<sqrt(eps())
+        @test norm(V-V2)<sqrt(eps())
+        @test norm(H-H2)<sqrt(eps())
+        @test norm(ω-ω2)<sqrt(eps())
+        @test norm(HH-HH2)<sqrt(eps())
 
     end
 

--- a/test/infbilanczos.jl
+++ b/test/infbilanczos.jl
@@ -13,7 +13,7 @@ using LinearAlgebra
     m=40;
     λ,V,T = infbilanczos(Float64,nep,nept,maxit=m,Neig=3,σ=0,displaylevel=displaylevel,
                          v=ones(Float64,n),u=ones(Float64,n),check_error_every=3,
-                         tol=1e-7);
+                         tol=1e-7, errmeasure=ResidualErrmeasure);
 
     # Produced with a different implementation
     Tstar=[  -1.665117675679600   5.780562035399026                   0                   0

--- a/test/inner_solves.jl
+++ b/test/inner_solves.jl
@@ -29,7 +29,7 @@ using LinearAlgebra
     #verify_lambdas(2, pnep, λv, V, eps()*500)
 
     λv,V = inner_solve(IARChebInnerSolver, ComplexF64, pnep; λv=[0,1,2,3] .+ 0.0im)
-    verify_lambdas(10, pnep, λv, V, eps()*500)
+    verify_lambdas(10, pnep, λv, V, sqrt(eps()))
 
     # TODO: this test results in a "Rank drop" warning, and a third eigenvalue that's not converged
     λv,V = inner_solve(ContourBeynInnerSolver, ComplexF64, pnep; λv=[0,1] .+ 0.0im, Neig=3)

--- a/test/jd.jl
+++ b/test/jd.jl
@@ -15,7 +15,7 @@ using LinearAlgebra
 @info "Testing a PEP"
 nep = nep_gallery("pep0",60)
 TOL = 1e-11;
-λ,u = jd_betcke(nep, tol=TOL, maxit=55, Neig = 3, displaylevel=displaylevel, v=ones(size(nep,1)))
+λ,u = jd_betcke(nep, tol=TOL, maxit=55, Neig = 3, displaylevel=displaylevel, v=ones(size(nep,1)),errmeasure=ResidualErrmeasure)
 @info " Smallest eigenvalue found: $λ"
 Dc,Vc = polyeig(nep,DefaultEigSolver)
 c = sortperm(abs.(Dc))

--- a/test/mslp.jl
+++ b/test/mslp.jl
@@ -28,7 +28,7 @@ using SparseArrays
     @bench @testset  "mslp + double" begin
         nep3 = nep_gallery("dep_double");
         @test_throws NoConvergenceException mslp(nep3, λ=9im, maxit=10)
-        λ,v = mslp(nep3, λ=9im, maxit=100)
+        λ,v = mslp(nep3, λ=9im, maxit=100,errmeasure=ResidualErrmeasure)
         @test norm(compute_Mlincomb(nep3, λ, v)) < eps()*100
     end
 end

--- a/test/newton.jl
+++ b/test/newton.jl
@@ -48,11 +48,11 @@ using LinearAlgebra
     @bench @testset "QuasiNewton" begin
     @info "QuasiNewton  test"
 
-        λ,x = quasinewton(nep,displaylevel=displaylevel,v=ones(size(nep,1)),λ=0,tol=1e-11)
+        λ,x = quasinewton(nep,displaylevel=displaylevel,v=ones(size(nep,1)),λ=0,tol=1e-12)
         @test compute_resnorm(nep,λ,x) < 1e-11*100
 
         @info "   eigenvector extraction"
-        λ,x = quasinewton(nep,displaylevel=displaylevel,v=ones(size(nep,1)),λ=0,errmeasure=singexcep_errmeasure)
+        λ,x = quasinewton(nep,displaylevel=displaylevel,v=ones(size(nep,1)),λ=0)
         @test compute_resnorm(nep,λ,x) < 1e-8*100
 
     end

--- a/test/newton.jl
+++ b/test/newton.jl
@@ -5,6 +5,23 @@ using NonlinearEigenproblems
 using Test
 using LinearAlgebra
 
+struct SingularErrmeasure <: Errmeasure; nep::NEP; end
+function NonlinearEigenproblems.estimate_error(e::SingularErrmeasure, λ,v)
+    err = compute_resnorm(e.nep,λ,v)/norm(v)
+    if (err < 1e-8)
+        if has_thrown_singexcep
+            err = 1
+            global has_thrown_singexcep = false
+        else
+            global has_thrown_singexcep = true
+            throw(SingularException(-1))
+        end
+    else
+        global has_thrown_singexcep = false
+    end
+    return err
+end
+
 @testset "Newton iterations" begin
     nep=nep_gallery("dep0")
 
@@ -39,8 +56,8 @@ using LinearAlgebra
         @test compute_resnorm(nep,λ2,x2) < eps()*100
 
         @info "   eigenvector extraction"
-        λ1,x1 = newton(nep,displaylevel=displaylevel,v=ones(size(nep,1)),λ=0,tol=eps()*10, errmeasure=singexcep_errmeasure)
-        λ2,x2 = augnewton(nep,displaylevel=displaylevel,v=ones(size(nep,1)),λ=0,tol=eps()*10, errmeasure=singexcep_errmeasure)
+        λ1,x1 = newton(nep,displaylevel=displaylevel,v=ones(size(nep,1)),λ=0,tol=eps()*10, errmeasure=SingularErrmeasure)
+        λ2,x2 = augnewton(nep,displaylevel=displaylevel,v=ones(size(nep,1)),λ=0,tol=eps()*10, errmeasure=SingularErrmeasure)
         @test compute_resnorm(nep,λ1,x1) < 1e-8*100
         @test compute_resnorm(nep,λ2,x2) < 1e-8*100
     end

--- a/test/nlar.jl
+++ b/test/nlar.jl
@@ -39,9 +39,9 @@ using Random
     λ_orig = shift+scale*λ_shifted;
 
     #Test residual and distance from reference eigenvalue
-    @test norm(compute_Mlincomb(nep, λ_orig, v)) < TOL*100
-    @test norm(compute_Mder(nep, λ_orig) * v) < TOL*100
-    @test norm(λ_ref - λ_orig) < TOL*1000
+    @test norm(compute_Mlincomb(nep, λ_orig, v)) < sqrt(TOL)*10
+    @test norm(compute_Mder(nep, λ_orig) * v) < sqrt(TOL)*10
+    @test norm(λ_ref - λ_orig) < sqrt(TOL)*100
     ###########################################################################################################3
 
     #Testing PEP
@@ -53,7 +53,7 @@ using Random
 
     λ,u = nlar(pepnep, tol=TOL, maxit=60, neigs=3, R=0.001, displaylevel=displaylevel,
         λ=Dc[4]+1e-2, v=ones(size(pepnep,1)), eigval_sorter=residual_eigval_sorter,
-        inner_solver_method=IARInnerSolver, qrfact_orth=false)
+        inner_solver_method=IARInnerSolver, qrfact_orth=false, errmeasure=ResidualErrmeasure)
 
     verify_lambdas(3, pepnep, λ, u, TOL)
 

--- a/test/nlar.jl
+++ b/test/nlar.jl
@@ -41,7 +41,7 @@ using Random
     #Test residual and distance from reference eigenvalue
     @test norm(compute_Mlincomb(nep, λ_orig, v)) < TOL*100
     @test norm(compute_Mder(nep, λ_orig) * v) < TOL*100
-    @test norm(λ_ref - λ_orig) < TOL*100
+    @test norm(λ_ref - λ_orig) < TOL*1000
     ###########################################################################################################3
 
     #Testing PEP

--- a/test/nleigs/nleigs_nep_types.jl
+++ b/test/nleigs/nleigs_nep_types.jl
@@ -19,7 +19,7 @@ import NonlinearEigenproblems.NEPCore.compute_Mlincomb
 import Base.size
 nep_types_test_pep = PEP([nep_types_test_B; nep_types_test_C])
 compute_Mder(::CustomNLEIGSNEP, λ::Number) = compute_Mder(nep_types_test_pep, λ)
-compute_Mlincomb(::CustomNLEIGSNEP, λ::Number, x::Matrix) = compute_Mlincomb(nep_types_test_pep, λ, x)
+compute_Mlincomb(::CustomNLEIGSNEP, λ::Number, x::AbstractVecOrMat) = compute_Mlincomb(nep_types_test_pep, λ, x)
 size(::CustomNLEIGSNEP, _) = nep_types_test_n
 
 function nleigs_nep_types()

--- a/test/run_all_tests.jl
+++ b/test/run_all_tests.jl
@@ -13,7 +13,6 @@ const tests_not_to_run = Set{String}(map(uppercase, [
     "dtn_dimer.jl", #  Needs additional files
     "NonlinearEigenproblemsTest.jl", # utilities used by other tests
     "deflation2.jl", # under development
-    "ilan.jl",
 ]))
 
 function run_all_tests(test_name_regex = "")

--- a/test/run_all_tests.jl
+++ b/test/run_all_tests.jl
@@ -13,6 +13,7 @@ const tests_not_to_run = Set{String}(map(uppercase, [
     "dtn_dimer.jl", #  Needs additional files
     "NonlinearEigenproblemsTest.jl", # utilities used by other tests
     "deflation2.jl", # under development
+    "ilan.jl",
 ]))
 
 function run_all_tests(test_name_regex = "")

--- a/test/sgiter.jl
+++ b/test/sgiter.jl
@@ -24,7 +24,8 @@ using LinearAlgebra
                 2,
                 displaylevel = displaylevel,
                 tol = 1e-9,
-                maxit = 100)
+                maxit = 100,
+                errmeasure = ResidualErrmeasure)
   @test norm(compute_Mlincomb(nep,λ,v)) < 1e-9
 
 end

--- a/test/src/NonlinearEigenproblemsTest.jl
+++ b/test/src/NonlinearEigenproblemsTest.jl
@@ -75,8 +75,9 @@ matrix are below the given tolerance.
 function verify_lambdas(expected_nr_λ, nep::NEP, λ, V, tol = 1e-5)
     @test length(λ) == expected_nr_λ
     @info "Found $(length(λ)) lambdas:"
+    ermdata=init_errmeasure(ResidualErrmeasure,nep);
     for i in eachindex(λ)
-        nrm = default_errmeasure(nep)(λ[i], V[:, i])
+        nrm = estimate_error(ermdata,λ[i], V[:, i])
         @test nrm < tol
         @info "λ[$i] = $(λ[i]) (norm = $(@sprintf("%.4g", nrm)))"
     end

--- a/test/tiar.jl
+++ b/test/tiar.jl
@@ -22,7 +22,7 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
     dep=nep_gallery("dep0",n);
 
     @bench @testset "accuracy eigenpairs" begin
-        (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),displaylevel=0,maxit=50,tol=eps()*100);
+        (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),displaylevel=0,maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
         verify_lambdas(4, dep, λ, Q, eps()*100)
     end
 
@@ -30,7 +30,7 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
 
     # NOW TEST DIFFERENT ORTHOGONALIZATION METHODS
     @bench @testset "DGKS" begin
-        (λ,Q,err,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),displaylevel=0,maxit=50,tol=eps()*100);
+        (λ,Q,err,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),displaylevel=0,maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
         @test opnorm(Z'*Z - I) < 1e-6
      end
 

--- a/test/transf.jl
+++ b/test/transf.jl
@@ -35,7 +35,7 @@ using LinearAlgebra
         λ,v= quasinewton(pep0,λ=1+1im);
         norm(compute_Mlincomb(pep0, λ, v))
         λv,V=polyeig(pep1);
-        @test minimum(abs.(λv .- (λ-σ)/α)) < eps()*100
+        @test minimum(abs.(λv .- (λ-σ)/α)) < eps()*1000
 
         # Check that real PEP with real transformation is still real
         σ=3;
@@ -49,7 +49,7 @@ using LinearAlgebra
         σ=-3+0.3im
         α=0.9;
         nep3_transf=shift_and_scale(nep3,shift=σ,scale=α);
-        @test norm(compute_Mlincomb(nep3_transf,(λ-σ)/α,v))<sqrt(eps());
+        @test norm(compute_Mlincomb(nep3_transf,(λ-σ)/α,v))<sqrt(eps())*10;
         λ,V=iar(nep3_transf,σ=0,Neig=2,maxit=60)
         @test norm(compute_Mlincomb(nep3,α*λ[1]+σ,V[:,1]))<sqrt(eps())
         @test norm(compute_Mlincomb(nep3,α*λ[2]+σ,V[:,2]))<sqrt(eps())
@@ -84,7 +84,7 @@ using LinearAlgebra
         @test isa(nep4_transf,SPMF_NEP)  # Möbius transformed SPMF-NEP is still a SPMF
         λ,v= quasinewton(nep4_transf,λ=1-0.3im,v=ones(size(nep4,1)));
         λorg=(a*λ+b)/(c*λ+d)
-        @test norm(compute_Mlincomb(nep4,λorg,v))<sqrt(eps());
+        @test norm(compute_Mlincomb(nep4,λorg,v))<sqrt(eps())*10;
 
 
         n=size(nep4,1);

--- a/test/wep_small.jl
+++ b/test/wep_small.jl
@@ -9,6 +9,9 @@ using GalleryWaveguide
 
 import GalleryWaveguide.SchurMatVec
 
+struct WEPErrmeasure <: Errmeasure; nep::NEP; end
+import NonlinearEigenproblems.estimate_error;
+
 @bench @testset "WEP" begin
 
 nx = 11
@@ -35,6 +38,10 @@ n=size(nep,1);
     λ0=-3-3.5im
     v0=ones(n); v0=v0/norm(v0);
 
+    function NonlinearEigenproblems.estimate_error(e::WEPErrmeasure,λ,v)
+        return abs(λ-λstar);
+    end
+
     myerrmeasure=(λ,v) -> abs(λ-λstar) # Use eigenvalue error as errmeasure
 
    λ,v = resinv(ComplexF64,nep,displaylevel=displaylevel,λ=λ0,v=v0,
@@ -48,7 +55,7 @@ n=size(nep,1);
     @test  norm(compute_Mlincomb(nep,λ,v))/norm(v)  < 1e-10
 
     λ,v = quasinewton(ComplexF64,nep,displaylevel=displaylevel,λ=λ0,v=v0,
-                    errmeasure=myerrmeasure,tol=1e-12)
+                    errmeasure=WEPErrmeasure,tol=1e-12)
 
     @test  norm(compute_Mlincomb(nep,λ,v))/norm(v)  < 1e-10
 

--- a/test/wep_small.jl
+++ b/test/wep_small.jl
@@ -12,6 +12,11 @@ import GalleryWaveguide.SchurMatVec
 struct WEPErrmeasure <: Errmeasure; nep::NEP; end
 import NonlinearEigenproblems.estimate_error;
 
+λstar=-2.690050173308845 - 3.1436003386330347im  # An exact eigenvalue
+function NonlinearEigenproblems.estimate_error(e::WEPErrmeasure,λ,v)
+    return abs(λ-λstar);
+end
+
 @bench @testset "WEP" begin
 
 nx = 11
@@ -32,15 +37,11 @@ b2 = ldiv!(precond, (Schur_fun*b1))
 
 nep=nep_gallery(WEP, nx = 3*5*7, nz = 3*5*7, benchmark_problem = "JARLEBRING", discretization = "FD", neptype = "WEP")
 
-λstar=-2.690050173308845 - 3.1436003386330347im  # An exact eigenvalue
 n=size(nep,1);
 
     λ0=-3-3.5im
     v0=ones(n); v0=v0/norm(v0);
 
-    function NonlinearEigenproblems.estimate_error(e::WEPErrmeasure,λ,v)
-        return abs(λ-λstar);
-    end
 
     myerrmeasure=(λ,v) -> abs(λ-λstar) # Use eigenvalue error as errmeasure
 


### PR DESCRIPTION
These are the first steps to resolve #150.

New types are introduces
```
ResidualErrmeasure
BackwardErrmeasure
DefaultErrmeasure  # Becomes BackwardErrmeasure if NEP isa AbstractSPMF otherwise ResidualErrmeasure
```
In order to use errmeasures in a NEP-solver you need to initiate it with a nep first:
```
nep=nep_gallery("nlevp_native_gun");
ermdata=init_errmeasure(ResidualErrmeasure,nep)
```
The `ermdata` contains precomputed errmeasure information (like \|A_1\| ... \|A_m\| ) and to get the error (estimate) do
```
estimate_error(ermdata,s,v)
```
I have only changed the iar-method so far. I want to make sure we get it right before changing all the others.

It seems to "work" since the default behavior solves problems now which were not solved before:
```julia
julia> (λ,v)=iar(nep,σ=200^2, γ=50^2,tol=1e-8);

julia> λ
6-element Array{Complex{Float64},1}:
  44259.41857472756 + 3.575987047379382im 
 43857.600899177254 + 20.52553168228922im 
  48788.73196043914 + 6.323957778415443im 
 48142.068793449165 + 41.89143413922458im 
  22345.04691041269 + 0.6340314337432504im
  54550.39890150822 + 459.46092126972843im

julia> (λ,v)=iar(nep,σ=200^2, γ=50^2,tol=1e-8, errmeasure=BackwardErrmeasure);

julia> λ
6-element Array{Complex{Float64},1}:
  44259.41857472755 + 3.5759870473780153im
  43857.60089917725 + 20.525531682289184im
  48788.73195992363 + 6.323958019966809im 
  48142.06879500499 + 41.891442316226495im
  54550.59086913872 + 459.4528810229781im 
 22345.020210194154 + 0.6368829115391262im
# This was the default behaviour before
julia> (λ,v)=iar(nep,σ=200^2, γ=50^2,tol=1e-8, errmeasure=ResidualErrmeasure); 
ERROR: No convergence: 'Number of iterations exceeded. maxit=30. Check that σ is not an eigenvalue.' eigenvalue approx:Complex{Float64}[43857.6+20.5255im, 44259.4+3.57599im, 48142.1+41.8914im, 48788.7+6.32396im, 54550.2+459.457im, 22345.1+0.642966im], errmeasure:[2.96099e-7, 3.84396e-7, 2.53831e-5, 4.92474e-5, 0.00250231, 0.00551035]
```
