### PR TITLE
Inf number of target eigenvalues in IAR and TIAR

### DIFF
--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -16,9 +16,10 @@ is now the eigenvalue parameter. If you want eigenvalues in a disk centered, sel
 of the disk and `γ` as the radius.
 The vector `v` is the starting vector for constructing the Krylov space. The orthogonalization
 method, used in contructing the orthogonal basis of the Krylov space, is specified by
-`orthmethod`, see the package `IterativeSolvers.jl`. The iteration is continued until `Neig` Ritz pairs have
-converged. Normally an error is thrown if  `Neig` Ritz pairs have not converged in `maxit` iterations.
-However, if `Neig` is set to `Inf` the iteration is continued until `maxit` iterations as done without an error being thrown.
+`orthmethod`, see the package `IterativeSolvers.jl`.
+The iteration is continued until `Neig` Ritz pairs have converged.
+This function throws a `NoConvergenceException` if the wanted eigenpairs are not computed after `maxit` iterations.
+However, if `Neig` is set to `Inf` the iteration is continued until `maxit` iterations without an error being thrown.
 
 See [`newton`](@ref) for other parameters.
 

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -132,13 +132,9 @@ function iar(
             err[1:k,k]=err[idx,k];
             # extract the converged Ritzpairs
             if (k==m)||(conv_eig>=Neig)
-                if Neig != Inf
-                    λ=λ[idx[1:min(length(λ),Neig)]]
-                    Q=Q[:,idx[1:length(λ)]]
-                else
-                    λ=λ[idx[1:min(length(λ))]]
-                    Q=Q[:,idx[1:length(λ)]]
-                end
+                nrof_eigs = Int(min(length(λ),Neig))
+                λ=λ[idx[1:nrof_eigs]]
+                Q=Q[:,idx[1:length(λ)]]
             end
         end
 

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -17,7 +17,8 @@ of the disk and `γ` as the radius.
 The vector `v` is the starting vector for constructing the Krylov space. The orthogonalization
 method, used in contructing the orthogonal basis of the Krylov space, is specified by
 `orthmethod`, see the package `IterativeSolvers.jl`. The iteration is continued until `Neig` Ritz pairs have
-converged.
+converged. Normally an error is thrown if  `Neig` Ritz pairs have not converged in `maxit` iterations.
+However, if `Neig` is set to `Inf` the iteration is continued until `maxit` iterations as done without an error being thrown.
 
 See [`newton`](@ref) for other parameters.
 

--- a/src/method_iar_chebyshev.jl
+++ b/src/method_iar_chebyshev.jl
@@ -37,7 +37,9 @@ Run the infinite Arnoldi method (Chebyshev version) on the nonlinear eigenvalue 
 
 The target `σ` is the center around which eiganvalues are computed. A Ritz pair `λ` and `v` is flagged a as converged (to an eigenpair) if `errmeasure` is less than `tol`. The vector
 `v` is the starting vector for constructing the Krylov space. The orthogonalization method, used in contructing the orthogonal basis of the Krylov space, is specified by `orthmethod`, see the package `IterativeSolvers.jl`. The iteration
-is continued until `Neig` Ritz pairs converge. This function throws a `NoConvergenceException` if the wanted eigenpairs are not computed after `maxit` iterations. The kwarg `compute_y0_method` specifying how the next vector of the Krylov space (in Chebyshev format) can be computed. See [`compute_y0_cheb`](@ref) in the module NEPSolver with the command `?NEPSolver.compute_y0_cheb`.
+is continued until `Neig` Ritz pairs converge. This function throws a `NoConvergenceException` if the wanted eigenpairs are not computed after `maxit` iterations.
+However, if `Neig` is set to `Inf` the iteration is continued until `maxit` iterations without an error being thrown.
+The kwarg `compute_y0_method` specifying how the next vector of the Krylov space (in Chebyshev format) can be computed. See [`compute_y0_cheb`](@ref) in the module NEPSolver with the command `?NEPSolver.compute_y0_cheb`.
 
 See [`newton`](@ref) for other parameters.
 

--- a/src/method_iar_chebyshev.jl
+++ b/src/method_iar_chebyshev.jl
@@ -166,15 +166,16 @@ function iar_chebyshev(
             err[1:k,k]=err[idx,k];
             # extract the converged Ritzpairs
             if (k==m)||(conv_eig>=Neig)
-                λ=λ[idx[1:min(length(λ),Neig)]]
+                nrof_eigs = Int(min(length(λ),Neig))
+                λ=λ[idx[1:nrof_eigs]]
                 Q=Q[:,idx[1:length(λ)]]
             end
         end
         k=k+1;
     end
-
+    k=k-1
     # NoConvergenceException
-    if conv_eig<Neig
+    if conv_eig<Neig && Neig != Inf
         err=err[end,1:Neig];
         idx=sortperm(err); # sort the error
         λ=λ[idx];  Q=Q[:,idx]; err=err[idx];
@@ -193,7 +194,9 @@ function iar_chebyshev(
         # ignore
     end
 
-    k=k-1
+    # extract the converged Ritzpairs
+    λ=λ[1:min(length(λ),conv_eig)];
+    Q=Q[:,1:min(size(Q,2),conv_eig)];
     return λ,Q,err[1:k,:],V[:,1:k],H[1:k,1:k]
 end
 

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -212,25 +212,26 @@ function tiar(
             err[1:k,k]=err[idx,k];
             # extract the converged Ritzpairs
             if (k==m)||(conv_eig>=Neig)
-                λ=λ[idx[1:min(length(λ),Neig)]]
+                nrof_eigs = Int(min(length(λ),Neig))
+                λ=λ[idx[1:nrof_eigs]]
                 Q=Q[:,idx[1:length(λ)]]
             end
             conv_eig_hist[k]=conv_eig
         end
         k=k+1;
     end
-
+    k=k-1
     # NoConvergenceException
-    # if conv_eig<Neig
-    #    err=err[end,1:Neig];
-    #    idx=sortperm(err); # sort the error
-    #    λ=λ[idx];  Q=Q[:,idx]; err=err[idx];
-    #     msg="Number of iterations exceeded. maxit=$(maxit)."
-    #     if conv_eig<3
-    #         msg=string(msg, " Check that σ is not an eigenvalue.")
-    #     end
-    #     throw(NoConvergenceException(λ,Q,err,msg))
-    # end
+    if conv_eig<Neig && Neig != Inf
+       err=err[end,1:Neig];
+       idx=sortperm(err); # sort the error
+       λ=λ[idx];  Q=Q[:,idx]; err=err[idx];
+        msg="Number of iterations exceeded. maxit=$(maxit)."
+        if conv_eig<3
+            msg=string(msg, " Check that σ is not an eigenvalue.")
+        end
+        throw(NoConvergenceException(λ,Q,err,msg))
+    end
 
     # extract the converged Ritzpairs
     λ=λ[1:min(length(λ),conv_eig)];

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -19,10 +19,10 @@ select `σ` as the center
 of the disk and `γ` as the radius.
 The vector `v` is the starting vector for constructing the Krylov space. The orthogonalization
 method, used in contructing the orthogonal basis of the Krylov space, is specified by
-`orthmethod`, see the package `IterativeSolvers.jl`. The iteration is continued until `Neig` Ritz pairs have
-converged.
-Normally an error is thrown if  `Neig` Ritz pairs have not converged in `maxit` iterations.
-However, if `Neig` is set to `Inf` the iteration is continued until `maxit` iterations as done without an error being thrown.
+`orthmethod`, see the package `IterativeSolvers.jl`.
+The iteration is continued until `Neig` Ritz pairs have converged.
+This function throws a `NoConvergenceException` if the wanted eigenpairs are not computed after `maxit` iterations.
+However, if `Neig` is set to `Inf` the iteration is continued until `maxit` iterations without an error being thrown.
 
 See [`newton`](@ref) for other parameters.
 

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -21,6 +21,8 @@ The vector `v` is the starting vector for constructing the Krylov space. The ort
 method, used in contructing the orthogonal basis of the Krylov space, is specified by
 `orthmethod`, see the package `IterativeSolvers.jl`. The iteration is continued until `Neig` Ritz pairs have
 converged.
+Normally an error is thrown if  `Neig` Ritz pairs have not converged in `maxit` iterations.
+However, if `Neig` is set to `Inf` the iteration is continued until `maxit` iterations as done without an error being thrown.
 
 See [`newton`](@ref) for other parameters.
 

--- a/test/iar.jl
+++ b/test/iar.jl
@@ -58,10 +58,10 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
     end
 
     @testset "Errors thrown" begin
-        np=1000;
-        depp=nep_gallery("dep0",np);
-        @test_throws NEPCore.NoConvergenceException (λ,Q)=iar(dep,σ=3,Neig=6,v=ones(n),
-                  displaylevel=1,maxit=7,tol=eps()*100);
+        np=100;
+        dep=nep_gallery("dep0",np);
+        @test_throws NEPCore.NoConvergenceException (λ,Q)=iar(dep,σ=3,Neig=6,v=ones(np),
+                  displaylevel=0,maxit=7,tol=eps()*100);
     end
 
 end

--- a/test/iar.jl
+++ b/test/iar.jl
@@ -23,34 +23,45 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
 
     @bench @testset "accuracy eigenpairs" begin
         (λ,Q)=iar(dep,σ=3,Neig=5,v=ones(n),
-                  displaylevel=0,maxit=100,tol=eps()*100);
-        @testset "IAR eigval[$i]" for i in 1:length(λ)
-            @test norm(compute_Mlincomb(dep,λ[i],Q[:,i]))<eps()*100;
-        end
+                  displaylevel=0,maxit=100,tol=eps()*100,errmeasure=ResidualErrmeasure);
+        verify_lambdas(5, dep, λ, Q, eps()*100)
+    end
+
+    @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
+        (λ,Q)=iar(dep,σ=3,Neig=Inf,v=ones(n),
+                  displaylevel=0,maxit=38,tol=eps()*100);
+        verify_lambdas(3, dep, λ, Q, eps()*100)
     end
 
     @testset "orthogonalization" begin
+        # NOW TEST DIFFERENT ORTHOGONALIZATION METHODS
 
-    # NOW TEST DIFFERENT ORTHOGONALIZATION METHODS
-    @bench @testset "DGKS" begin
-        (λ,Q,err,V)=iar(dep,orthmethod=DGKS,σ=3,Neig=5,v=ones(n),displaylevel=0,maxit=100,tol=eps()*100)
-        @test opnorm(V'*V - I) < 1e-6
-     end
+        @bench @testset "DGKS" begin
+            (λ,Q,err,V)=iar(dep,orthmethod=DGKS,σ=3,Neig=5,v=ones(n),displaylevel=0,maxit=100,tol=eps()*100)
+            @test opnorm(V'*V - I) < 1e-6
+        end
 
-     @bench @testset "User provided doubleGS" begin
-         (λ,Q,err,V)=iar(dep,orthmethod=DoubleGS,σ=3,Neig=5,v=ones(n),displaylevel=0,maxit=100,tol=eps()*100)
-         @test opnorm(V'*V - I) < 1e-6
-      end
+        @bench @testset "User provided doubleGS" begin
+            (λ,Q,err,V)=iar(dep,orthmethod=DoubleGS,σ=3,Neig=5,v=ones(n),displaylevel=0,maxit=100,tol=eps()*100)
+            @test opnorm(V'*V - I) < 1e-6
+        end
 
-      @bench @testset "ModifiedGramSchmidt" begin
-          (λ,Q,err,V)=iar(dep,orthmethod=ModifiedGramSchmidt,σ=3,Neig=5,v=ones(n),displaylevel=0,maxit=100,tol=eps()*100)
-          @test opnorm(V'*V - I) < 1e-6
-      end
+        @bench @testset "ModifiedGramSchmidt" begin
+            (λ,Q,err,V)=iar(dep,orthmethod=ModifiedGramSchmidt,σ=3,Neig=5,v=ones(n),displaylevel=0,maxit=100,tol=eps()*100)
+            @test opnorm(V'*V - I) < 1e-6
+        end
 
-       @bench @testset "ClassicalGramSchmidt" begin
-           (λ,Q,err,V)=iar(dep,orthmethod=ClassicalGramSchmidt,σ=3,Neig=5,v=ones(n),displaylevel=0,maxit=100,tol=eps()*100)
-           @test opnorm(V'*V - I) < 1e-6
-       end
+        @bench @testset "ClassicalGramSchmidt" begin
+            (λ,Q,err,V)=iar(dep,orthmethod=ClassicalGramSchmidt,σ=3,Neig=5,v=ones(n),displaylevel=0,maxit=100,tol=eps()*100)
+            @test opnorm(V'*V - I) < 1e-6
+        end
+    end
+
+    @testset "Errors thrown" begin
+        np=1000;
+        depp=nep_gallery("dep0",np);
+        @test_throws NEPCore.NoConvergenceException (λ,Q)=iar(dep,σ=3,Neig=6,v=ones(n),
+                  displaylevel=1,maxit=7,tol=eps()*100);
     end
 
 end

--- a/test/iar_chebyshev.jl
+++ b/test/iar_chebyshev.jl
@@ -90,6 +90,13 @@ end
         verify_lambdas(5, dep, λ, Q, n*sqrt(eps()))
     end
 
+    @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
+        (λ,Q)=iar_chebyshev(dep,σ=0,Neig=Inf,displaylevel=0,maxit=30,tol=eps()*100);
+        verify_lambdas(8, dep, λ, Q, n*sqrt(eps()))
+    end
+
+
+
     @testset "orthogonalization" begin
 
     # NOW TEST DIFFERENT ORTHOGONALIZATION METHODS
@@ -224,5 +231,11 @@ end
 
             @test opnorm(V[:,1:10]-V2[:,1:10])+opnorm(H[1:10,1:10]-H2[1:10,1:10])<1e-10;
         end
+    end
+
+    @testset "Errors thrown" begin
+        np=100;
+        dep=nep_gallery("dep0",np);
+        @test_throws NEPCore.NoConvergenceException (λ,Q)=iar_chebyshev(dep,σ=0,Neig=8,displaylevel=0,maxit=10,tol=eps()*100);
     end
 end

--- a/test/tiar.jl
+++ b/test/tiar.jl
@@ -79,9 +79,9 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
     end
 
     @testset "Errors thrown" begin
-        np=1000;
-        depp=nep_gallery("dep0",np);
-        @test_throws NEPCore.NoConvergenceException (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),displaylevel=0,maxit=5,tol=eps()*100,errmeasure=ResidualErrmeasure);
+        np=100;
+        dep=nep_gallery("dep0",np);
+        @test_throws NEPCore.NoConvergenceException (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(np),displaylevel=0,maxit=5,tol=eps()*100,errmeasure=ResidualErrmeasure);
     end
 
 end

--- a/test/tiar.jl
+++ b/test/tiar.jl
@@ -26,6 +26,11 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
         verify_lambdas(4, dep, λ, Q, eps()*100)
     end
 
+    @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
+        (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=Inf,v=ones(n),displaylevel=0,maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
+        verify_lambdas(4, dep, λ, Q, eps()*100)
+    end
+
     @testset "orthogonalization" begin
 
     # NOW TEST DIFFERENT ORTHOGONALIZATION METHODS
@@ -73,5 +78,10 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
         @test errmeasure(λ[1],Q[:,1])<sqrt(eps())*10
     end
 
+    @testset "Errors thrown" begin
+        np=1000;
+        depp=nep_gallery("dep0",np);
+        @test_throws NEPCore.NoConvergenceException (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),displaylevel=0,maxit=5,tol=eps()*100,errmeasure=ResidualErrmeasure);
+    end
 
 end


### PR DESCRIPTION
Fixes a bug reported in #178 where `Neig=Inf` gives a type error (fixed in IAR, TIAR, and IAR_CHEB). Also works on a feature requested in #177, where  `Neig=Inf` should be interpreted as running `maxit` iterations and return all converged Ritz pairs.