### PR TITLE
Infinite Bi-Lanczos fix

### DIFF
--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -136,7 +136,7 @@ function iar(
             if (k==m)||(conv_eig>=Neig)
                 nrof_eigs = Int(min(length(λ),Neig))
                 λ=λ[idx[1:nrof_eigs]]
-                Q=Q[:,idx[1:length(λ)]]
+                Q=Q[:,idx[1:nrof_eigs]]
             end
         end
 

--- a/src/method_iar_chebyshev.jl
+++ b/src/method_iar_chebyshev.jl
@@ -170,7 +170,7 @@ function iar_chebyshev(
             if (k==m)||(conv_eig>=Neig)
                 nrof_eigs = Int(min(length(λ),Neig))
                 λ=λ[idx[1:nrof_eigs]]
-                Q=Q[:,idx[1:length(λ)]]
+                Q=Q[:,idx[1:nrof_eigs]]
             end
         end
         k=k+1;

--- a/src/method_infbilanczos.jl
+++ b/src/method_infbilanczos.jl
@@ -10,6 +10,9 @@ and `nept::NEP`. `nep:NEP` is the original nonlinear eigenvalue problem and
 `nept::NEP` is its (hermitian) transpose: ``M(λ^*)^H``.
  `v` and `u` are starting vectors,
 `σ` is the shift and `γ` the scaling.
+The iteration is continued until `Neig` Ritz pairs have converged.
+This function throws a `NoConvergenceException` if the wanted eigenpairs are not computed after `maxit` iterations.
+However, if `Neig` is set to `Inf` the iteration is continued until `maxit` iterations without an error being thrown.
 See [`newton`](@ref) for other parameters.
 
 # Example:

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -216,7 +216,7 @@ function tiar(
             if (k==m)||(conv_eig>=Neig)
                 nrof_eigs = Int(min(length(λ),Neig))
                 λ=λ[idx[1:nrof_eigs]]
-                Q=Q[:,idx[1:length(λ)]]
+                Q=Q[:,idx[1:nrof_eigs]]
             end
             conv_eig_hist[k]=conv_eig
         end

--- a/test/infbilanczos.jl
+++ b/test/infbilanczos.jl
@@ -28,6 +28,22 @@ using LinearAlgebra
         thiserr[i]=norm(compute_Mlincomb(nep,λ[i],V[:,i]));
     end
     @test length(findall(thiserr .< 1e-7)) == 3
+
+
+    @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
+        m=30;
+        λ,V,T = infbilanczos(Float64,nep,nept,maxit=m,Neig=Inf,σ=0,displaylevel=displaylevel,
+                             v=ones(Float64,n),u=ones(Float64,n),check_error_every=3,
+                             tol=1e-7, errmeasure=ResidualErrmeasure);
+        verify_lambdas(3, nep, λ, V, 1e-6)
+    end
+
+
+    @testset "Errors thrown" begin
+        @test_throws NEPCore.NoConvergenceException λ,V,T = infbilanczos(Float64,nep,nept,maxit=9,Neig=8,σ=0,displaylevel=displaylevel,
+                             v=ones(Float64,n),u=ones(Float64,n),check_error_every=3,
+                             tol=1e-7, errmeasure=ResidualErrmeasure);
+    end
 end
 
 # Disabled to improve unit test performance


### PR DESCRIPTION
Fixes some bugs in Infinite Bi-Lanczos:
- `maxit` number of iterations was not possible due to an off-by-one error
- `NoConvergenceException` was not thrown due to how variables were defined

Also adds feature compute as many eigenvalues as possible in `maxit` iterations. As discussed in #177.

 