### PR TITLE
Implementation of Logger 

### DIFF
--- a/docs/src/bemtutorial.md
+++ b/docs/src/bemtutorial.md
@@ -83,7 +83,7 @@ nep=BEM_NEP(mesh,gauss_order);
 After creating the NEP, you can try to solve the problem with methods in the package, e.g.,
 [`MSLP`](methods.md#NonlinearEigenproblems.NEPSolver.mslp) works quite well for this problem:
 ```julia-repl
-julia> (λ,v)=mslp(nep,λ=8,displaylevel=1)
+julia> (λ,v)=mslp(nep,λ=8,logger=1)
 Iteration:1 errmeasure:4.122635537095636e-6 λ=8.128272919317748 + 0.007584851218214716im
 Iteration:2 errmeasure:1.787963303973586e-8 λ=8.132181234599427 - 1.952792817964521e-5im
 Iteration:3 errmeasure:3.2884958163572594e-13 λ=8.132145310156643 - 1.2648247028455485e-5im
@@ -101,7 +101,7 @@ The plotting was done with the following code (by using internals of the BEM-imp
 ```julia
 using NonlinearEigenproblems, PyPlot
 nep=nep_gallery("bem_fichera")
-(λ,v)=mslp(nep,λ=8.1,displaylevel=1)
+(λ,v)=mslp(nep,λ=8.1,logger=1)
 v=v./maximum(abs.(v));
 for k=1:size(nep.mesh,1);
     tri=nep.mesh[k];

--- a/docs/src/errmeasure.md
+++ b/docs/src/errmeasure.md
@@ -65,9 +65,9 @@ we use the result of the first run as a reference.
 ```julia-repl
 julia> nep=nep_gallery("qdep0");
 julia> v0=ones(size(nep,1));
-julia> (λref,v)=resinv(nep,v=v0,λ=230^2+1im,displaylevel=1);
+julia> (λref,v)=resinv(nep,v=v0,λ=230^2+1im,logger=1);
 julia> myerrmeasure = (λ,v) -> abs(λ-λref)/abs(λ);
-julia> (λ,v)=resinv(nep,v=v0,λ=250^2+1im,displaylevel=1,tol=1e-10,errmeasure=myerrmeasure);
+julia> (λ,v)=resinv(nep,v=v0,λ=250^2+1im,logger=1,tol=1e-10,errmeasure=myerrmeasure);
 Iteration:  1 errmeasure:1.274091618457501296e-01
 Iteration:  2 errmeasure:9.535794095609478882e-01
 ...
@@ -90,11 +90,11 @@ The error measure should then provided in the function
 `estimate_error`:
 ```julia-repl
 julia> v0=ones(size(nep,1));
-julia> (λref,v)=resinv(nep,v=v0,λ=230^2+1im,displaylevel=1);
+julia> (λref,v)=resinv(nep,v=v0,λ=230^2+1im,logger=1);
 julia> function NonlinearEigenproblems.estimate_error(e::RefErrmeasure,λ,v)
          return abs(λ-λref)/abs(λ);
        end
-julia> (λ,v)=resinv(nep,v=v0,λ=250^2+1im,displaylevel=1,tol=1e-10,errmeasure=RefErrmeasure);
+julia> (λ,v)=resinv(nep,v=v0,λ=250^2+1im,logger=1,tol=1e-10,errmeasure=RefErrmeasure);
 Iteration:  1 errmeasure:1.274091618457501296e-01
 ...
 Iteration: 49 errmeasure:1.269396691930517923e-10

--- a/docs/src/gallery.md
+++ b/docs/src/gallery.md
@@ -23,7 +23,7 @@ we can access them with the GalleryNLEVP
 ```julia-repl
 julia> using GalleryNLEVP
 julia> nep=nep_gallery(NLEVP_NEP,"hadeler")
-julia> λ,v=quasinewton(nep,λ=0.2,displaylevel=1,maxit=20,tol=1e-10);
+julia> λ,v=quasinewton(nep,λ=0.2,logger=1,maxit=20,tol=1e-10);
 julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
 9.698206079849311e-11
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -158,7 +158,7 @@ gallery.
 julia> nep=nep_gallery("nlevp_native_gun");
 julia> n=size(nep,1)
 julia> S=150^2*[1.0 0; 0 1]; V=[[1 0; 0 1]; zeros(n-2,2)];
-julia> (Z,X)=blocknewton(nep,S=S,X=V,displaylevel=1,armijo_factor=0.5,maxit=20)
+julia> (Z,X)=blocknewton(nep,S=S,X=V,logger=1,armijo_factor=0.5,maxit=20)
 Iteration 1: Error: 6.081316e+03
 Iteration 2: Error: 1.701970e-02 Armijo scaling=0.031250
 Iteration 3: Error: 1.814887e-02 Armijo scaling=0.250000

--- a/docs/src/movebc_tutorial.md
+++ b/docs/src/movebc_tutorial.md
@@ -193,10 +193,10 @@ a NEP-solver:
 ```julia
 using NonlinearEigenproblems
 nep=SPMF_NEP([Dn-Vn,In,G,F],[f1,f2,g,f]);
-(λ1,v1)=quasinewton(Float64,nep,displaylevel=1,λ=-5,v=ones(n),tol=1e-9);
-(λ2,v2)=quasinewton(nep,displaylevel=1,λ=-11,v=ones(n),tol=1e-9)
-(λ3,v3)=quasinewton(nep,displaylevel=1,λ=-20,v=ones(n),tol=1e-9)
-(λ4,v4)=quasinewton(nep,displaylevel=1,λ=-35,v=ones(n),tol=1e-9)
+(λ1,v1)=quasinewton(Float64,nep,logger=1,λ=-5,v=ones(n),tol=1e-9);
+(λ2,v2)=quasinewton(nep,logger=1,λ=-11,v=ones(n),tol=1e-9)
+(λ3,v3)=quasinewton(nep,logger=1,λ=-20,v=ones(n),tol=1e-9)
+(λ4,v4)=quasinewton(nep,logger=1,λ=-35,v=ones(n),tol=1e-9)
 ```
 We can easily do a sanity check of the solution by visualizing it in this way
 ```julia
@@ -230,7 +230,7 @@ error measure is used. With this use of measuring the error other
 methods, e.g., infinite Arnoldi method terminate in a reasonable
 number of iterations:
 ```julia-repl
-julia> (λ,v)=iar(nep,displaylevel=1,σ=-36,v=ones(n),tol=1e-9,
+julia> (λ,v)=iar(nep,logger=1,σ=-36,v=ones(n),tol=1e-9,
                  errmeasure=BackwardErrmeasure,Neig=5,maxit=100);
 Iteration:1 conveig:0
 Iteration:2 conveig:0

--- a/docs/src/tutorial_call_python.md
+++ b/docs/src/tutorial_call_python.md
@@ -126,7 +126,7 @@ we can now use many NEP-solvers to solve this problem.
 Here we use IAR:
 ```julia-repl
 
-julia> (λv,vv)=iar(pnep,v=[1;1],σ=1,displaylevel=1,Neig=3);
+julia> (λv,vv)=iar(pnep,v=[1;1],σ=1,logger=1,Neig=3);
 Iteration:1 conveig:0
 Iteration:2 conveig:0
 Iteration:3 conveig:0

--- a/docs/src/tutorial_fortran1.md
+++ b/docs/src/tutorial_fortran1.md
@@ -153,7 +153,7 @@ julia> function my_Mder(λ::Float64,der::Int=0)
   return sparse(I,J,F);
 end
 julia> nep=Mder_NEP(n,my_Mder)
-julia> quasinewton(Float64,nep,λ=-1.8,v=ones(n), displaylevel=1)
+julia> quasinewton(Float64,nep,λ=-1.8,v=ones(n), logger=1)
 Precomputing linsolver
 Iteration:  1 errmeasure:4.903565024143569095e-01, λ=-1.8
 Iteration:  2 errmeasure:8.776860766232853772e-02, λ=-1.3816406142423465
@@ -225,7 +225,7 @@ end
 Create the `NEP` and call a solver, in this case [`MSLP`](methods.md#NonlinearEigenproblems.NEPSolver.mslp).
 ```julia
 julia> nep=Mder_NEP(n,my_Mder_FD)
-julia> mslp(Float64,nep,λ=-1.8, displaylevel=1)
+julia> mslp(Float64,nep,λ=-1.8, logger=1)
 Iteration:1 errmeasure:5.145479494934554e-6 λ=-1.7941228234498503
 Iteration:2 errmeasure:6.604789080027513e-10 λ=-1.7940561772509709
 Iteration:3 errmeasure:4.3096620402514632e-16 λ=-1.794056168678654
@@ -287,7 +287,7 @@ specify the highest derivative available for the two functions.
 We can now solve it with many methods, e.g.
 [`resinv`](methods.md#NonlinearEigenproblems.NEPSolver.resinv).
 ```julia
-julia> resinv(Float64,nep2,λ=-1.8,v=ones(n),displaylevel=1)
+julia> resinv(Float64,nep2,λ=-1.8,v=ones(n),logger=1)
 Iteration:  1 errmeasure:4.903565024143570761e-01
 Iteration:  2 errmeasure:1.145360525649362360e-01
 ...

--- a/docs/src/tutorial_matlab1.md
+++ b/docs/src/tutorial_matlab1.md
@@ -66,7 +66,7 @@ Now you can instantiate the NEP and use your favorite NEP-solver,
 in this case we use [`newtonqr`](methods.md#NonlinearEigenproblems.NEPSolver.newtonqr).
 ```julia
 julia> nep=MATLABNEP();
-julia> (λ,v)=newtonqr(nep,λ=-3,displaylevel=1,maxit=30,v=ones(10))
+julia> (λ,v)=newtonqr(nep,λ=-3,logger=1,maxit=30,v=ones(10))
 Iteration: 1 errmeasure: 1.0335933094121779
 Iteration: 2 errmeasure: 0.305924622401145
 Iteration: 3 errmeasure: 0.6000405833925101

--- a/src/NEPSolver.jl
+++ b/src/NEPSolver.jl
@@ -28,6 +28,9 @@ Executes z if displaylevel>1.
     end
 
 
+    macro parse_logger_param!(l)
+       return esc(:( if ($l isa Number) ; $l=PrintLogger($l); end ))
+    end
     include("logger.jl");
 
     ## NEP-Methods

--- a/src/NEPSolver.jl
+++ b/src/NEPSolver.jl
@@ -16,6 +16,11 @@ Executes z if displaylevel>0.
         return esc(:( if (displaylevel > 0); $z; end ))
     end
 
+    #
+    macro debug_log(z)
+        return esc(:( push!(logger,z) ))
+    end
+
     export @ifdd
 
     """
@@ -25,6 +30,9 @@ Executes z if displaylevel>1.
     macro ifdd(z)
         return esc(:( if (displaylevel > 1); $z; end ))
     end
+
+
+    include("logger.jl");
 
     ## NEP-Methods
 

--- a/src/NEPSolver.jl
+++ b/src/NEPSolver.jl
@@ -6,31 +6,16 @@ module NEPSolver
     using SparseArrays
     using Random
 
-    export @ifd
 
     """
-    @ifd(z)
-Executes z if displaylevel>0.
+    @parse_logger_param!(l)
+
+If l is a number it canges l to a PrintLogger(l).
 """
-    macro ifd(z)
-        return esc(:( if (displaylevel > 0); $z; end ))
-    end
-
-
-    export @ifdd
-
-    """
-    @ifd(z)
-Executes z if displaylevel>1.
-"""
-    macro ifdd(z)
-        return esc(:( if (displaylevel > 1); $z; end ))
-    end
-
-
     macro parse_logger_param!(l)
        return esc(:( if ($l isa Number) ; $l=PrintLogger($l); end ))
     end
+
     include("logger.jl");
 
     ## NEP-Methods

--- a/src/NEPSolver.jl
+++ b/src/NEPSolver.jl
@@ -16,10 +16,6 @@ Executes z if displaylevel>0.
         return esc(:( if (displaylevel > 0); $z; end ))
     end
 
-    #
-    macro debug_log(z)
-        return esc(:( push!(logger,z) ))
-    end
 
     export @ifdd
 

--- a/src/errmeasure.jl
+++ b/src/errmeasure.jl
@@ -35,7 +35,7 @@ julia> struct EigvalError <: Errmeasure; nep::NEP; end
 julia> function NonlinearEigenproblems.estimate_error(E::EigvalError,λ,v)
 return abs(λref-λ);
 end
-julia> (λ,v)=quasinewton(nep,errmeasure=EigvalError,λ=-1.0 ,displaylevel=1,tol=5e-13)
+julia> (λ,v)=quasinewton(nep,errmeasure=EigvalError,λ=-1.0 ,logger=1,tol=5e-13)
 Precomputing linsolver
 Iteration:  1 errmeasure:2.466988587467300320e-03, λ=-1.0 + 0.0im
 Iteration:  2 errmeasure:4.625160667012763183e-01, λ=-0.539950921886191 + 0.0im
@@ -54,7 +54,7 @@ Iteration: 13 errmeasure:3.352873534367972752e-14, λ=-1.0024669885874338 + 0.0i
 Note that this can also be achieved by providing a function handle:
 ```julia
 julia> myerrmeasure= (λ,v) -> abs(λref-λ);
-julia> (λ,v)=quasinewton(nep,errmeasure=myerrmeasure,λ=-1.0 ,displaylevel=1,tol=5e-13)
+julia> (λ,v)=quasinewton(nep,errmeasure=myerrmeasure,λ=-1.0 ,logger=1,tol=5e-13)
 ...
 Iteration: 12 errmeasure:3.205657961302676995e-12, λ=-1.0024669885842616 + 0.0im
 Iteration: 13 errmeasure:3.352873534367972752e-14, λ=-1.0024669885874338 + 0.0im

--- a/src/inner_solver.jl
+++ b/src/inner_solver.jl
@@ -131,7 +131,8 @@ the kwargs are the following:\\
 `σ`: target specifying where eigenvalues\\
 `λv`, `V`: Vector/matrix of guesses to be used as starting values\\
 `j`: the jth eigenvalue in a min-max characterization\\
-`tol`: Termination tolarance for inner solver
+`tol`: Termination tolarance for inner solver\\
+`inner_logger`: Determines how the inner solves are logged. See [`Logger`](@ref) for further references
 """
 function inner_solve(TT::Type{DefaultInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;kwargs...)
     if (typeof(nep.orgnep)==NEPTypes.PEP)
@@ -152,13 +153,15 @@ function inner_solve(TT::Type{NewtonInnerSolver},T_arit::Type,nep::NEPTypes.Proj
                      λv=zeros(T_arit,1),
                      V=Matrix{T_arit}(rand(size(nep,1),size(λv,1))),
                      tol=sqrt(eps(real(T_arit))),
+                     inner_logger=0,
                      kwargs...)
+    @parse_logger_param!(inner_logger)
     for k=1:size(λv,1)
         try
             v0=V[:,k]; # Starting vector for projected problem
             projerrmeasure=(λ,v) -> norm(compute_Mlincomb(nep,λ,v))/opnorm(compute_Mder(nep,λ));
             # Compute a solution to projected problem with Newton's method
-            λ1,vproj=augnewton(T_arit,nep,logger=0,λ=λv[k],
+            λ1,vproj=augnewton(T_arit,nep,logger=inner_logger,λ=λv[k],
                                v=v0,maxit=50,tol=tol/10,
                                errmeasure=projerrmeasure);
             V[:,k]=vproj;
@@ -186,9 +189,10 @@ end
 
 
 
-function inner_solve(TT::Type{IARInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;σ=0,Neig=10,kwargs...)
+function inner_solve(TT::Type{IARInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;σ=0,Neig=10,inner_logger=0,kwargs...)
+    @parse_logger_param!(inner_logger)
     try
-        λ,V=iar(T_arit,nep,σ=σ,Neig=Neig,tol=1e-13,maxit=50);
+        λ,V=iar(T_arit,nep,σ=σ,Neig=Neig,tol=1e-13,maxit=50,logger=inner_logger);
         return λ,V
     catch e
         if (isa(e, NoConvergenceException))
@@ -203,7 +207,8 @@ end
 
 
 
-function inner_solve(TT::Type{IARChebInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;σ=0,Neig=10,kwargs...)
+function inner_solve(TT::Type{IARChebInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;σ=0,Neig=10,inner_logger=0,kwargs...)
+    @parse_logger_param!(inner_logger)
     if isa(nep.orgnep, NEPTypes.DEP)
         AA = get_Av(nep)
         TT = eltype(AA);
@@ -218,7 +223,7 @@ function inner_solve(TT::Type{IARChebInnerSolver},T_arit::Type,nep::NEPTypes.Pro
     end
 
     try
-        λ,V=iar_chebyshev(T_arit,nep,σ=σ,Neig=Neig,tol=1e-13,maxit=50);
+        λ,V=iar_chebyshev(T_arit,nep,σ=σ,Neig=Neig,tol=1e-13,maxit=50,logger=inner_logger);
         return λ,V
     catch e
         if (isa(e, NoConvergenceException))
@@ -233,17 +238,19 @@ end
 
 
 
-function inner_solve(TT::Type{SGIterInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;λv=[0],j=0,kwargs...)
-    λ,V=sgiter(T_arit,nep,j)
+function inner_solve(TT::Type{SGIterInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;λv=[0],j=0,inner_logger=0,kwargs...)
+    @parse_logger_param!(inner_logger)
+    λ,V=sgiter(T_arit,nep,j,logger=inner_logger)
     return [λ],reshape(V,size(V,1),1);
 end
 
 
 
-function inner_solve(TT::Type{ContourBeynInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;σ=0,λv=[0,1],Neig=10,kwargs...)
+function inner_solve(TT::Type{ContourBeynInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;σ=0,λv=[0,1],Neig=10,inner_logger=0,kwargs...)
+    @parse_logger_param!(inner_logger)
     # Radius  computed as the largest distance σ and λv and a litte more
     radius = maximum(abs.(σ .- λv))*1.5
     Neig = min(Neig,size(nep,1))
-    λ,V = contour_beyn(T_arit,nep,neigs=Neig,σ=σ,radius=radius)
+    λ,V = contour_beyn(T_arit,nep,neigs=Neig,σ=σ,radius=radius,logger=inner_logger)
     return λ,V
 end

--- a/src/inner_solver.jl
+++ b/src/inner_solver.jl
@@ -158,7 +158,7 @@ function inner_solve(TT::Type{NewtonInnerSolver},T_arit::Type,nep::NEPTypes.Proj
             v0=V[:,k]; # Starting vector for projected problem
             projerrmeasure=(λ,v) -> norm(compute_Mlincomb(nep,λ,v))/opnorm(compute_Mder(nep,λ));
             # Compute a solution to projected problem with Newton's method
-            λ1,vproj=augnewton(T_arit,nep,displaylevel=0,λ=λv[k],
+            λ1,vproj=augnewton(T_arit,nep,logger=0,λ=λv[k],
                                v=v0,maxit=50,tol=tol/10,
                                errmeasure=projerrmeasure);
             V[:,k]=vproj;

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -1,6 +1,6 @@
 # Logging functionality
 
-export PrintLogger, Logger, ErrorLogger
+export Logger, PrintLogger, ErrorLogger
 export push_info!, push_iteration_info!
 import Base.push!
 using Printf
@@ -65,7 +65,12 @@ function push_iteration_info!(logger::ErrorLogger,level,iter;
                               continues::Bool=false)
     if (iter<=size(logger.errs,1))
         if (size(err,1)<=size(logger.errs,2))
-            logger.errs[iter,1:size(err,1)]=err;
+            err_vec=err;
+            # Make sure err_vec is a vector
+            if (err_vec isa Number)
+                err_vec=[err_vec]
+            end
+            logger.errs[iter,1:size(err,1)]=err_vec;
         else
             if (logger.printlogger.displaylevel>1)
                 println("Warning: Insufficient space in logger matrix");

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -1,0 +1,36 @@
+# Logging functionality
+
+export PrintLogger, Logger
+import Base.push!
+using Printf
+
+abstract type Logger ; end
+
+function push_info!(logger::Logger,v::String,continues::Bool=false)
+    push_info!(logger,1,v,continues);
+end
+
+
+struct PrintLogger <: Logger ;
+    displaylevel::Int
+end
+
+
+function push_info!(logger::PrintLogger,level,v::String,continues::Bool=false)
+    if (logger.displaylevel>=level)
+        print(v);
+        if (!continues)
+            println();
+        end
+    end
+end
+
+function push_iteration_info!(logger::PrintLogger,iter,continues::Bool=false;
+                              err=Inf,λ=NaN,v=NaN)
+    if (logger.displaylevel>=1)
+        print("iter ",iter, " err:",err, " λ=",λ);
+        if (!continues)
+            println()
+        end
+    end
+end

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -14,6 +14,8 @@ as well as a storage. The most common `Logger`s are `PrintLogger` and
 
 As a method developer you want to use `push_info!` and
 `push_iteration_info!`.
+
+ See also: [`PrintLogger`](@ref) and [`ErrorLogger`](@ref).
 """
 abstract type Logger ; end
 

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -43,16 +43,16 @@ end
    struct PrintLogger <: Logger ;
 
 When you use this logger, you will obtain printouts in stdout,
-no other logging. The displaylevel parameter specified,
+no other logging. The logger parameter specified,
 how much should be printed.
 """
 struct PrintLogger <: Logger ;
-    displaylevel::Int
+    logger::Int
 end
 
 
 function push_info!(logger::PrintLogger,level,v::String;continues::Bool=false)
-    if (logger.displaylevel>=level)
+    if (logger.logger>=level)
         print(v);
         if (!continues)
             println();
@@ -63,7 +63,7 @@ end
 function push_iteration_info!(logger::PrintLogger,level,iter;
                               err=Inf,λ=NaN,v=NaN,
                               continues::Bool=false)
-    if (logger.displaylevel>=level)
+    if (logger.logger>=level)
         print("iter ",iter, " err:",err, " λ=",λ);
         if (!continues)
             println()
@@ -77,7 +77,7 @@ end
 
 When you use this logger, the error of `push_iteration_info!`-calls
 will be stored in `logger.errs`. It can also print to stdout,
-if `displaylevel` is set to a value greater than zero.
+if `logger` is set to a value greater than zero.
 
 """
 struct ErrorLogger{T} <: Logger  where {T};
@@ -86,10 +86,10 @@ struct ErrorLogger{T} <: Logger  where {T};
 end
 
 
-function ErrorLogger(nof_eigvals=100,nof_iters=100,displaylevel=1)
+function ErrorLogger(nof_eigvals=100,nof_iters=100,logger=1)
     s=Matrix{Float64}(undef,nof_iters,nof_eigvals)
     s[:] .= NaN;
-    printlogger=PrintLogger(displaylevel)
+    printlogger=PrintLogger(logger)
     return ErrorLogger{eltype(s)}(s,printlogger);
 end
 
@@ -107,7 +107,7 @@ function push_iteration_info!(logger::ErrorLogger,level,iter;
             end
             logger.errs[iter,1:size(err,1)]=err_vec;
         else
-            if (logger.printlogger.displaylevel>1)
+            if (logger.printlogger.logger>1)
                 println("Warning: Insufficient space in logger matrix");
             end
         end

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -77,7 +77,7 @@ end
 
 When you use this logger, the error of `push_iteration_info!`-calls
 will be stored in `logger.errs`. It can also print to stdout,
-if `logger` is set to a value greater than zero.
+if `displaylevel` is set to a value greater than zero.
 
 """
 struct ErrorLogger{T} <: Logger  where {T};

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -7,7 +7,7 @@ using Printf
 abstract type Logger ; end
 
 function push_info!(logger::Logger,v::String; continues::Bool=false)
-    push_info!(logger,1,v,continues);
+    push_info!(logger,1,v;continues=continues);
 end
 
 
@@ -26,8 +26,10 @@ function push_info!(logger::PrintLogger,level,v::String;continues::Bool=false)
 end
 
 function push_iteration_info!(logger::PrintLogger,iter;
-                              err=Inf,λ=NaN,v=NaN,continues::Bool=false)
-    if (logger.displaylevel>=1)
+                              err=Inf,λ=NaN,v=NaN,
+                              continues::Bool=false,
+                              level=1)
+    if (logger.displaylevel>=level)
         print("iter ",iter, " err:",err, " λ=",λ);
         if (!continues)
             println()

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -6,7 +6,7 @@ using Printf
 
 abstract type Logger ; end
 
-function push_info!(logger::Logger,v::String,continues::Bool=false)
+function push_info!(logger::Logger,v::String; continues::Bool=false)
     push_info!(logger,1,v,continues);
 end
 
@@ -16,7 +16,7 @@ struct PrintLogger <: Logger ;
 end
 
 
-function push_info!(logger::PrintLogger,level,v::String,continues::Bool=false)
+function push_info!(logger::PrintLogger,level,v::String;continues::Bool=false)
     if (logger.displaylevel>=level)
         print(v);
         if (!continues)
@@ -25,8 +25,8 @@ function push_info!(logger::PrintLogger,level,v::String,continues::Bool=false)
     end
 end
 
-function push_iteration_info!(logger::PrintLogger,iter,continues::Bool=false;
-                              err=Inf,λ=NaN,v=NaN)
+function push_iteration_info!(logger::PrintLogger,iter;
+                              err=Inf,λ=NaN,v=NaN,continues::Bool=false)
     if (logger.displaylevel>=1)
         print("iter ",iter, " err:",err, " λ=",λ);
         if (!continues)

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -1,6 +1,7 @@
 # Logging functionality
 
-export PrintLogger, Logger
+export PrintLogger, Logger, ErrorLogger
+export push_info!, push_iteration_info!
 import Base.push!
 using Printf
 
@@ -9,8 +10,13 @@ abstract type Logger ; end
 function push_info!(logger::Logger,v::String; continues::Bool=false)
     push_info!(logger,1,v;continues=continues);
 end
+function push_iteration_info!(logger::Logger,iter; kwargs...)
+    push_iteration_info!(logger,1,iter;kwargs...);
+end
 
 
+
+# PrintLogger: printouts only
 struct PrintLogger <: Logger ;
     displaylevel::Int
 end
@@ -25,14 +31,55 @@ function push_info!(logger::PrintLogger,level,v::String;continues::Bool=false)
     end
 end
 
-function push_iteration_info!(logger::PrintLogger,iter;
+function push_iteration_info!(logger::PrintLogger,level,iter;
                               err=Inf,λ=NaN,v=NaN,
-                              continues::Bool=false,
-                              level=1)
+                              continues::Bool=false)
     if (logger.displaylevel>=level)
         print("iter ",iter, " err:",err, " λ=",λ);
         if (!continues)
             println()
         end
     end
+end
+
+
+
+# PrintLogger: printouts only
+struct ErrorLogger{T} <: Logger  where {T};
+    errs::Matrix{T}
+    printlogger::Logger
+end
+
+
+function ErrorLogger(nof_eigvals=100,nof_iters=100,displaylevel=1)
+    s=Matrix{Float64}(undef,nof_iters,nof_eigvals)
+    s[:] .= NaN;
+    printlogger=PrintLogger(displaylevel)
+    return ErrorLogger{eltype(s)}(s,printlogger);
+end
+
+
+
+function push_iteration_info!(logger::ErrorLogger,level,iter;
+                              err=Inf,λ=NaN,v=NaN,
+                              continues::Bool=false)
+    if (iter<=size(logger.errs,1))
+        if (size(err,1)<=size(logger.errs,2))
+            logger.errs[iter,1:size(err,1)]=err;
+        else
+            if (logger.printlogger.displaylevel>1)
+                println("Warning: Insufficient space in logger matrix");
+            end
+        end
+
+    end
+
+    push_iteration_info!(logger.printlogger,level,iter;
+                              err=err,λ=λ,v=v,
+                              continues=continues)
+
+end
+function push_info!(logger::ErrorLogger,level::Int,
+                    v::String;continues::Bool=false)
+    push_info!(logger.printlogger,level,v,continues=continues)
 end

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -43,16 +43,16 @@ end
    struct PrintLogger <: Logger ;
 
 When you use this logger, you will obtain printouts in stdout,
-no other logging. The logger parameter specified,
+no other logging. The displaylevel parameter specified,
 how much should be printed.
 """
 struct PrintLogger <: Logger ;
-    logger::Int
+    displaylevel::Int
 end
 
 
 function push_info!(logger::PrintLogger,level,v::String;continues::Bool=false)
-    if (logger.logger>=level)
+    if (logger.displaylevel>=level)
         print(v);
         if (!continues)
             println();
@@ -63,7 +63,7 @@ end
 function push_iteration_info!(logger::PrintLogger,level,iter;
                               err=Inf,λ=NaN,v=NaN,
                               continues::Bool=false)
-    if (logger.logger>=level)
+    if (logger.displaylevel>=level)
         print("iter ",iter, " err:",err, " λ=",λ);
         if (!continues)
             println()
@@ -86,10 +86,10 @@ struct ErrorLogger{T} <: Logger  where {T};
 end
 
 
-function ErrorLogger(nof_eigvals=100,nof_iters=100,logger=1)
+function ErrorLogger(nof_eigvals=100,nof_iters=100,displaylevel=1)
     s=Matrix{Float64}(undef,nof_iters,nof_eigvals)
     s[:] .= NaN;
-    printlogger=PrintLogger(logger)
+    printlogger=PrintLogger(displaylevel)
     return ErrorLogger{eltype(s)}(s,printlogger);
 end
 
@@ -107,7 +107,7 @@ function push_iteration_info!(logger::ErrorLogger,level,iter;
             end
             logger.errs[iter,1:size(err,1)]=err_vec;
         else
-            if (logger.printlogger.logger>1)
+            if (logger.printlogger.displaylevel>1)
                 println("Warning: Insufficient space in logger matrix");
             end
         end

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -5,18 +5,47 @@ export push_info!, push_iteration_info!
 import Base.push!
 using Printf
 
+    """
+    abstract type Logger ; end
+
+The type represents a way to log information throughout the algorithms,
+as well as a storage. The most common `Logger`s are `PrintLogger` and
+`ErrorLogger`.
+
+As a method developer you want to use `push_info!` and
+`push_iteration_info!`.
+"""
 abstract type Logger ; end
 
+   """
+    function push_info!(logger, [level,] v; continues::Bool=false)
+
+Pushes a string v to the logger. If continues=true, the next
+`push_info!` (or `push_iteration_info!`) is connected to this,
+e.g. line-feed will be omitted.
+"""
 function push_info!(logger::Logger,v::String; continues::Bool=false)
     push_info!(logger,1,v;continues=continues);
 end
+   """
+    function push_iteration_info!(logger, [level,] iter; kwargs)
+
+Pushes information about a specific iteration `iter`. The supported
+keyword arguments include `λ`, `err` and `v`.
+
+"""
 function push_iteration_info!(logger::Logger,iter; kwargs...)
     push_iteration_info!(logger,1,iter;kwargs...);
 end
 
 
+   """
+   struct PrintLogger <: Logger ;
 
-# PrintLogger: printouts only
+When you use this logger, you will obtain printouts in stdout,
+no other logging. The displaylevel parameter specified,
+how much should be printed.
+"""
 struct PrintLogger <: Logger ;
     displaylevel::Int
 end
@@ -43,8 +72,14 @@ function push_iteration_info!(logger::PrintLogger,level,iter;
 end
 
 
+    """
+    struct ErrorLogger <: Logger
 
-# PrintLogger: printouts only
+When you use this logger, the error of `push_iteration_info!`-calls
+will be stored in `logger.errs`. It can also print to stdout,
+if `displaylevel` is set to a value greater than zero.
+
+"""
 struct ErrorLogger{T} <: Logger  where {T};
     errs::Matrix{T}
     printlogger::Logger

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -8,7 +8,7 @@ using Random
 export contour_beyn
 
 """
-    λv,V=contour_beyn([eltype,] nep;[tol,][displaylevel,][σ,][radius,][linsolvercreator,][quad_method,][N,][neigs,][k])
+    λv,V=contour_beyn([eltype,] nep;[tol,][logger,][σ,][radius,][linsolvercreator,][quad_method,][N,][neigs,][k])
 
 The function computes eigenvalues using Beyn's contour integral approach,
 using an ellipse centered at `σ` with radii given in `radius`, or if only one `radius` is given,

--- a/src/method_beyncontour.jl
+++ b/src/method_beyncontour.jl
@@ -46,7 +46,7 @@ function contour_beyn(::Type{T},
                       nep::NEP;
                       tol::Real=sqrt(eps(real(T))), # Note tol is quite high for this method
                       σ::Number=zero(complex(T)),
-                      displaylevel::Integer=0,
+                      logger=0,
                       linsolvercreator::Function=backslash_linsolvercreator,
                       neigs::Integer=2, # Number of wanted eigvals
                       k::Integer=neigs+1, # Columns in matrix to integrate
@@ -57,6 +57,8 @@ function contour_beyn(::Type{T},
                       sanity_check=true,
                       rank_drop_tol=tol # Used in sanity checking
                       )where{T<:Number}
+
+    @parse_logger_param!(logger)
 
     # Geometry
     length(radius)==1 ? radius=(radius,radius) : nothing
@@ -84,7 +86,7 @@ function contour_beyn(::Type{T},
 
 
     function local_linsolve(λ::TT,V::Matrix{TT}) where {TT<:Number}
-        @ifd(print("."))
+        push_info!(logger,".",continues=true);
         local M0inv::LinSolver = linsolvercreator(nep,λ+σ);
         # This requires that lin_solve can handle rectangular
         # matrices as the RHS
@@ -94,12 +96,12 @@ function contour_beyn(::Type{T},
     # Constructing integrands
     Tv(λ) = local_linsolve(T(λ),Vh)
     f(t) = Tv(g(t))*gp(t)
-    @ifd(print("Computing integrals"))
+    push_info!(logger,"Computing integrals",continues=true)
 
 
     local A0,A1
     if (quad_method == :quadg_parallel)
-        @ifd(print(" using quadg_parallel"))
+        push_info!(logger," using quadg_parallel")
         (A0,A1)=quadg_parallel(f,g,0,2*pi,N);
     elseif (quad_method == :quadg)
         #@ifd(print(" using quadg"))
@@ -107,10 +109,10 @@ function contour_beyn(::Type{T},
         #A1=quadg(f2,0,2*pi,N);
         error("disabled");
     elseif (quad_method == :ptrapz)
-        @ifd(print(" using ptrapz"))
+        push_info!(logger," using ptrapz")
         (A0,A1)=ptrapz(f,g,0,2*pi,N);
     elseif (quad_method == :ptrapz_parallel)
-        @ifd(print(" using ptrapz_parallel"))
+        push_info!(logger," using ptrapz_parallel")
         (A0,A1)=ptrapz_parallel(f,g,0,2*pi,N);
     elseif (quad_method == :quadgk)
         #@ifd(print(" using quadgk"))
@@ -120,15 +122,15 @@ function contour_beyn(::Type{T},
     else
         error("Unknown quadrature method:"*String(quad_method));
     end
-    @ifd(println("."));
+    push_info!(logger,"");
     # Don't forget scaling
     A0[:,:] = A0 ./(2im*pi);
     A1[:,:] = A1 ./(2im*pi);
 
-    @ifd(print("Computing SVD prepare for eigenvalue extraction "))
+    push_info!(logger,"Computing SVD prepare for eigenvalue extraction ",continues=true)
     V,S,W = svd(A0)
     p = count( S/S[1] .> rank_drop_tol);
-    @ifd(println(" p=",p));
+    push_info!(logger," p=$p");
 
     V0 = V[:,1:p]
     W0 = W[:,1:p]
@@ -136,10 +138,10 @@ function contour_beyn(::Type{T},
 
     # Extract eigenval and eigvec approximations according to
     # step 6 on page 3849 in the reference
-    @ifd(println("Computing eigenvalues "))
+    push_info!(logger,"Computing eigenvalues ")
     λ,VB=eigen(B)
     λ[:] = λ .+ σ
-    @ifd(println("Computing eigenvectors "))
+    push_info!(logger,"Computing eigenvectors ")
     V = V0 * VB;
     for i = 1:p
         normalize!(V[:,i]);
@@ -179,7 +181,8 @@ function contour_beyn(::Type{T},
     # and potentially remove eigenvalues if more than neigs.
     local Vgood,λgood
     if( size(sorted_good_index,1) > neigs)
-        @ifd(println("Removing unwanted eigvals: neigs=",neigs,"<",size(sorted_good_index,1),"=found_eigvals"))
+        found_evals=size(sorted_good_index,1);
+        push_info!(logger,"Removing unwanted eigvals: neigs=$neigs<$found_evals=found_eigvals")
         Vgood=V[:,sorted_good_index[sorted_good_inside_perm][1:neigs]];
         λgood=λ[sorted_good_index[sorted_good_inside_perm][1:neigs]];
     else

--- a/src/method_blocknewton.jl
+++ b/src/method_blocknewton.jl
@@ -51,9 +51,12 @@ function blocknewton(nep::AbstractSPMF;
                      errmeasure::Function =  default_block_errmeasure(nep::NEP),
                      tol::Real=eps(real(eltype(S)))*100,
                      maxit::Integer=10,
-                     displaylevel::Integer=0,
+                     logger=0,
                      armijo_factor::Real=1,
                      armijo_max::Integer=5)
+
+    @parse_logger_param!(logger)
+
     T=complex(eltype(S))
     # This implementation is for complex arithmetic only
     # since the original paper is based on the Schur form (not real Schur form)
@@ -77,9 +80,9 @@ function blocknewton(nep::AbstractSPMF;
     # Main loop
     for k=1:maxit
         err0=errmeasure(S,X)
-        @ifd(@printf("Iteration %d: Error: %e",k,err0))
+        push_iteration_info!(logger,k,err=err0,continues=true);
         if (err0<tol)
-            @ifd(println())
+            push_iteration_info!(logger,"");
             return S,X
         end
 
@@ -93,7 +96,7 @@ function blocknewton(nep::AbstractSPMF;
                                     WW,  # Orthogonalization matrix
                                     Res*QQ, # RT
                                     zeros(T,p,p),  #RV=0
-                                    displaylevel);
+                                    logger);
         dX=dXt*QQ';
         dS=QQ*dSt*QQ';
 
@@ -116,9 +119,9 @@ function blocknewton(nep::AbstractSPMF;
 
         end
         if (j>0)
-            @ifd(@printf(" Armijo scaling=%f\n",scaling))
+            push_info!(logger," Armijo scaling=$scaling")
         else
-            @ifd(@printf("\n"))
+            push_info!(logger,"");
         end
 
 
@@ -141,7 +144,7 @@ end
 # (S,X) Schur pair approx
 # W tensor with orthogonalization coeffs
 # RT,RV the right-hand side of linear system
-function newtonstep_linsys(::Type{T},nep::AbstractSPMF,S, X, W, RT, RV, displaylevel) where {T}
+function newtonstep_linsys(::Type{T},nep::AbstractSPMF,S, X, W, RT, RV, logger) where {T}
 
     n = size(nep,1);
     p = size(X,2); l = size(W,3);

--- a/src/method_blocknewton.jl
+++ b/src/method_blocknewton.jl
@@ -5,7 +5,7 @@ export blocknewton
 default_block_errmeasure(nep::NEP) = (S,X) -> opnorm(compute_MM(nep,S,X))
 
 """
-    (S,X)=blocknewton(nep [S,] [X,] [errmeasure,] [tol,] [maxit,] [armijo_factor,] [armijo_max,] [displaylevel])
+    (S,X)=blocknewton(nep [S,] [X,] [errmeasure,] [tol,] [maxit,] [armijo_factor,] [armijo_max,] [logger])
 
 Applies the block Newton method to `nep::AbstractSPMF`. The method computes
 an invariant pair `(S,X)` using the block Newton approach of Kressner.
@@ -33,7 +33,7 @@ This example solves the `gun` problem from the Berlin-Manchester collection
 julia> using NonlinearEigenproblems.Gallery
 julia> nep=nep_gallery("nlevp_native_gun");
 julia> II=[1.0 0; 0 1]; S=150^2*II; V=[II;zeros(size(nep,1)-2,2)];
-julia> (Z,X)=blocknewton(nep,S=S,X=V,displaylevel=1,armijo_factor=0.5,maxit=20)
+julia> (Z,X)=blocknewton(nep,S=S,X=V,logger=1,armijo_factor=0.5,maxit=20)
 Iteration 1: Error: 6.081316e+03
 Iteration 2: Error: 1.701970e-02 Armijo scaling=0.031250
 Iteration 3: Error: 1.814887e-02 Armijo scaling=0.250000

--- a/src/method_broyden.jl
+++ b/src/method_broyden.jl
@@ -551,7 +551,7 @@ julia> λ=S[3,3]
 0.8347353572199486 + 1.5032076225139986e-14im
 julia> minimum(svdvals(compute_Mder(nep,λ)))
 1.296144276122994e-14
-julia> broyden(nep,displaylevel=2,check_error_every=1);  % Prints out a lot more convergence info
+julia> broyden(nep,logger=2,check_error_every=1);  % Prints out a lot more convergence info
 ```
 
 # References

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -6,7 +6,9 @@ using Random
 using Statistics
 
 """
-    iar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tol=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][logger=0,][check_error_every=1,][orthmethod=DGKS])
+    iar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tol=eps()*10000,][Neig=6,][errmeasure,]
+[v=rand(size(nep,1),1),][logger=0,][check_error_every=1,][orthmethod=DGKS,]
+[proj_solve=false,][inner_solver_method=DefaultInnerSolver,][inner_logger=0])
 
 Run the infinite Arnoldi method on the nonlinear eigenvalue problem stored in `nep`.
 
@@ -20,6 +22,9 @@ method, used in contructing the orthogonal basis of the Krylov space, is specifi
 The iteration is continued until `Neig` Ritz pairs have converged.
 This function throws a `NoConvergenceException` if the wanted eigenpairs are not computed after `maxit` iterations.
 However, if `Neig` is set to `Inf` the iteration is continued until `maxit` iterations without an error being thrown.
+The parameter `proj_solve` determines if the Ritz paris are extracted using the Hessenberg matrix (false),
+or as the solution to a projected problem (true). If true, the method is descided by `inner_solver_method`, and the
+logging of the inner solvers are descided by `inner_logger`, which works in the same way as `logger`.
 
 See [`newton`](@ref) for other parameters.
 

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -59,12 +59,8 @@ function iar(
     inner_solver_method=DefaultInnerSolver,
     inner_logger=0)where{T<:Number,T_orth<:IterativeSolvers.OrthogonalizationMethod}
 
-    if (isa(logger,Number))
-        logger=PrintLogger(logger)
-    end
-    if (isa(inner_logger,Number))
-        inner_logger=PrintLogger(inner_logger)
-    end
+    @parse_logger_param!(logger)
+    @parse_logger_param!(inner_logger)
 
     # Ensure types σ and v are of type T
     σ=T(σ)
@@ -96,9 +92,6 @@ function iar(
     while (k <= m) && (conv_eig<Neig)
 
 
-#        if (displaylevel>0) && ((rem(k,check_error_every)==0) || (k==m))
-#            println("Iteration:",k, " conveig:",conv_eig)
-#        end
         VV=view(V,1:1:n*(k+1),1:k); # extact subarrays, memory-CPU efficient
         vv=view(V,1:1:n*(k+1),k+1); # next vector V[:,k+1]
 

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -131,10 +131,12 @@ function iar(
                 λ=λproj;
              end
             conv_eig=0;
+            # compute the errors
             err[k,1:size(λ,1)]=
               map(s-> estimate_error(ermdata,λ[s],Q[:,s]), 1:size(λ,1))
-            push_iteration_info!(logger,k,err=err[k,1:size(λ,1)],
-                                 continues=true, level=2);
+            # Log them and compute the converged
+            push_iteration_info!(logger,2, k,err=err[k,1:size(λ,1)],
+                                 continues=true);
             for s=1:size(λ,1)
                 if err[k,s]<tol;
                     conv_eig=conv_eig+1;

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -6,9 +6,7 @@ using Random
 using Statistics
 
 """
-    iar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tol=eps()*10000,][Neig=6,][errmeasure,]
-[v=rand(size(nep,1),1),][logger=0,][check_error_every=1,][orthmethod=DGKS,]
-[proj_solve=false,][inner_solver_method=DefaultInnerSolver,][inner_logger=0])
+    iar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tol=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][logger=0,][check_error_every=1,][orthmethod=DGKS,][proj_solve=false,][inner_solver_method=DefaultInnerSolver,][inner_logger=0])
 
 Run the infinite Arnoldi method on the nonlinear eigenvalue problem stored in `nep`.
 

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -6,7 +6,7 @@ using Random
 using Statistics
 
 """
-    iar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tol=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][displaylevel=0,][check_error_every=1,][orthmethod=DGKS])
+    iar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tol=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][logger=0,][check_error_every=1,][orthmethod=DGKS])
 
 Run the infinite Arnoldi method on the nonlinear eigenvalue problem stored in `nep`.
 

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -133,7 +133,7 @@ function iar(
             err[k,1:size(λ,1)]=
               map(s-> estimate_error(ermdata,λ[s],Q[:,s]), 1:size(λ,1))
             # Log them and compute the converged
-            push_iteration_info!(logger,2, k,err=err[k,1:size(λ,1)],
+            push_iteration_info!(logger,2, k,err=err[k,1:size(λ,1)], λ=λ,
                                  continues=true);
             for s=1:size(λ,1)
                 if err[k,s]<tol;

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -56,10 +56,14 @@ function iar(
     logger=0,
     check_error_every=1,
     proj_solve=false,
-    inner_solver_method=DefaultInnerSolver)where{T<:Number,T_orth<:IterativeSolvers.OrthogonalizationMethod}
+    inner_solver_method=DefaultInnerSolver,
+    inner_logger=0)where{T<:Number,T_orth<:IterativeSolvers.OrthogonalizationMethod}
 
     if (isa(logger,Number))
         logger=PrintLogger(logger)
+    end
+    if (isa(inner_logger,Number))
+        inner_logger=PrintLogger(inner_logger)
     end
 
     # Ensure types σ and v are of type T
@@ -125,7 +129,8 @@ function iar(
                                         V=RR*Z,λv=copy(λ),
                                         Neig=size(λ,1)+3,
                                         σ=mean(λ),
-                                        tol=tol,displaylevel=displaylevel);
+                                        tol=tol,
+                                        logger=inner_logger);
 
                 Q=QQ*Qproj;
                 λ=λproj;
@@ -148,6 +153,7 @@ function iar(
                 end
             end
             push_info!(logger,"");
+            # Sort the errors
             idx=sortperm(err[k,1:k]); # sort the error
             err[k,1:k]=err[k,idx];
 
@@ -178,5 +184,5 @@ function iar(
     # extract the converged Ritzpairs
     λ=λ[1:min(length(λ),conv_eig)];
     Q=Q[:,1:min(size(Q,2),conv_eig)];
-    return λ,Q,err[1:k,:],V[:,1:k]
+    return λ,Q,V[:,1:k]
 end

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -123,7 +123,7 @@ function iar(
                                         Neig=size(λ,1)+3,
                                         σ=mean(λ),
                                         tol=tol,
-                                        logger=inner_logger);
+                                        inner_logger=inner_logger);
 
                 Q=QQ*Qproj;
                 λ=λproj;

--- a/src/method_iar_chebyshev.jl
+++ b/src/method_iar_chebyshev.jl
@@ -31,7 +31,7 @@ end
 
 
 """
-    iar_chebyshev(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][displaylevel=0,][check_error_every=1,][orthmethod=DGKS][a=-1,][b=1,][compute_y0_method=ComputeY0ChebAuto])
+    iar_chebyshev(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][logger=0,][check_error_every=1,][orthmethod=DGKS][a=-1,][b=1,][compute_y0_method=ComputeY0ChebAuto])
 
 Run the infinite Arnoldi method (Chebyshev version) on the nonlinear eigenvalue problem stored in `nep`.
 

--- a/src/method_ilan.jl
+++ b/src/method_ilan.jl
@@ -72,11 +72,13 @@ function ilan(
     σ=zero(T),
     γ=one(T),
     v=randn(real(T),size(nep,1)),
-    displaylevel=0,
+    logger=0,
     check_error_every=30,
     inner_solver_method=DefaultInnerSolver,
     Compute_Bmul_method::Type{T_y0}=Compute_Bmul_method_Auto,
     )where{T<:Number,T_orth<:IterativeSolvers.OrthogonalizationMethod,T_y0<:Compute_Bmul_method}
+
+    @parse_logger_param!(logger)
 
     # Ensure types σ and v are of type T
     σ=T(σ)
@@ -132,9 +134,6 @@ function ilan(
     ermdata=init_errmeasure(errmeasure,nep);
 
     while (k <= m) && (conv_eig<Neig)
-        if (displaylevel>0) && ((rem(k,check_error_every)==0) || (k==m))
-            println("Iteration:",k, " conveig:",conv_eig)
-        end
 
         broadcast!(/,view(Qn,:,2:k+1),view(Q,:,1:k),(1:k)')
         Qn[:,1] = compute_Mlincomb!(nep,σ,view(Qn,:,1:k+1),a[1:k+1]);
@@ -179,11 +178,13 @@ function ilan(
             err_lifted=(λ,z)->estimate_error(ermdata,λ,VV*z);
 
             # solve the projected NEP
-            if displaylevel>0
-                println("Solving the projected problem")
-            end
+            push_info!(logger,2,"Solving the projected problem",continues=true);
             λ,ZZ=iar(pnep;Neig=Inf,logger=0,maxit=150,tol=tol,check_error_every=Inf,errmeasure=err_lifted)
+            push_info!(logger,2,".");
             W=VV*ZZ;
+
+            push_iteration_info!(logger,2,k,λ=λ);
+            push_info!(logger,"$k:conv_eig=$conv_eig");
 
             conv_eig=length(λ)
             # extract the converged Ritzpairs

--- a/src/method_ilan.jl
+++ b/src/method_ilan.jl
@@ -26,7 +26,7 @@ mutable struct IlanPrecomputeDataDerSPMF <: IlanAbstractPrecomputeData
 end
 
 """
-    ilan(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][displaylevel=0,][check_error_every=30,][orthmethod=DGKS])
+    ilan(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][logger=0,][check_error_every=30,][orthmethod=DGKS])
 
 Run the infinite Lanczos method on the symmetric nonlinear eigenvalue problem stored in `nep`.
 

--- a/src/method_ilan.jl
+++ b/src/method_ilan.jl
@@ -182,7 +182,7 @@ function ilan(
             if displaylevel>0
                 println("Solving the projected problem")
             end
-            λ,ZZ=iar(pnep;Neig=Inf,displaylevel=0,maxit=150,tol=tol,check_error_every=Inf,errmeasure=err_lifted)
+            λ,ZZ=iar(pnep;Neig=Inf,logger=0,maxit=150,tol=tol,check_error_every=Inf,errmeasure=err_lifted)
             W=VV*ZZ;
 
             conv_eig=length(λ)

--- a/src/method_infbilanczos.jl
+++ b/src/method_infbilanczos.jl
@@ -3,7 +3,7 @@ using Random
 
 export infbilanczos
 """
-    λv,V,U=infbilanczos([eltype],nep, nept,[linsolvecreator,][linsolvertcreator,][v,][u,][σ,][γ,][tol,][Neig,][errmeasure,][displaylevel,][maxit,][check_error_every])
+    λv,V,U=infbilanczos([eltype],nep, nept,[linsolvecreator,][linsolvertcreator,][v,][u,][σ,][γ,][tol,][Neig,][errmeasure,][logger,][maxit,][check_error_every])
 
 Executes the Infinite Bi-Lanczos method on the problem defined by `nep::NEP`
 and `nept::NEP`. `nep:NEP` is the original nonlinear eigenvalue problem and

--- a/src/method_jd.jl
+++ b/src/method_jd.jl
@@ -192,6 +192,7 @@ end
 The function computes eigenvalues using the Jacobi-Davidson method, which is a projection method.
 Repreated eigenvalues are avoided by using deflation, as presented in the reference by Effenberger.
 The projected problems are solved using a solver spcified through the type `inner_solver_method`.
+The logging of the inner solvers are descided by `inner_logger`, which works in the same way as `logger`.
 For numerical stability the basis is kept orthogonal, and the method for orthogonalization is specified by `orthmethod`, see the package `IterativeSolvers.jl`.
 The function tries to compute `Neig` number of eigenvalues, and throws a `NoConvergenceException` if it cannot.
 The value `λ` and the vector `v` are initial guesses for an eigenpair. `linsolvercreator` is a function which specifies how the linear system is created and solved.

--- a/src/method_jd.jl
+++ b/src/method_jd.jl
@@ -198,6 +198,9 @@ The function tries to compute `Neig` number of eigenvalues, and throws a `NoConv
 The value `λ` and the vector `v` are initial guesses for an eigenpair. `linsolvercreator` is a function which specifies how the linear system is created and solved.
 The `target` is the center around which eiganvalues are computed. For further specifications on the `deflation_mode`, see the function `deflate_eigpair`.
 
+See [`newton`](@ref) for other parameters.
+
+
 # Example
 ```julia-repl
 julia> nep=nep_gallery("dep0",100);

--- a/src/method_jd.jl
+++ b/src/method_jd.jl
@@ -22,7 +22,7 @@ end
 
 
 """
-    jd_betcke([eltype]], nep::ProjectableNEP; [Neig=1], [tol=eps(real(T))*100], [maxit=100], [λ=zero(T)], [orthmethod=DGKS],  [errmeasure], [linsolvercreator=default_linsolvercreator], [v = randn(size(nep,1))], [displaylevel=0], [inner_solver_method=DefaultInnerSolver], [projtype=:PetrovGalerkin], [target=zero(T)])
+    jd_betcke([eltype]], nep::ProjectableNEP; [Neig=1], [tol=eps(real(T))*100], [maxit=100], [λ=zero(T)], [orthmethod=DGKS],  [errmeasure], [linsolvercreator=default_linsolvercreator], [v = randn(size(nep,1))], [logger=0], [inner_solver_method=DefaultInnerSolver], [projtype=:PetrovGalerkin], [target=zero(T)])
 The function computes eigenvalues using Jacobi-Davidson method, which is a projection method.
 The projected problems are solved using a solver spcified through the type `inner_solver_method`.
 For numerical stability the basis is kept orthogonal, and the method for orthogonalization is specified by `orthmethod`, see the package `IterativeSolvers.jl`.
@@ -184,7 +184,7 @@ end
 
 
 """
-    jd_effenberger([eltype]], nep::ProjectableNEP; [maxit=100], [Neig=1], [inner_solver_method=DefaultInnerSolver], [orthmethod=DGKS], [linsolvercreator=default_linsolvercreator], [tol=eps(real(T))*100], [λ=zero(T)], [v = rand(T,size(nep,1))], [target=zero(T)],  [displaylevel=0])
+    jd_effenberger([eltype]], nep::ProjectableNEP; [maxit=100], [Neig=1], [inner_solver_method=DefaultInnerSolver], [orthmethod=DGKS], [linsolvercreator=default_linsolvercreator], [tol=eps(real(T))*100], [λ=zero(T)], [v = rand(T,size(nep,1))], [target=zero(T)],  [logger=0])
 The function computes eigenvalues using the Jacobi-Davidson method, which is a projection method.
 Repreated eigenvalues are avoided by using deflation, as presented in the reference by Effenberger.
 The projected problems are solved using a solver spcified through the type `inner_solver_method`.

--- a/src/method_mslp.jl
+++ b/src/method_mslp.jl
@@ -40,8 +40,10 @@ function mslp(::Type{T},
                  tol::Real=eps(real(T))*100,
                  maxit::Integer=100,
                  λ::Number=zero(T),
-                 displaylevel::Integer=0,
+                 logger=0,
                  eigsolvertype::Type=DefaultEigSolver) where {T<:Number}
+
+    @parse_logger_param!(logger)
 
     # Ensure types λ is of type T
     λ::T = T(λ)
@@ -73,7 +75,7 @@ function mslp(::Type{T},
 
         # Checck for convergence
         err=estimate_error(ermdata,λ,v)
-        @ifd(println("Iteration:",k," errmeasure:",err, " λ=",λ))
+        push_iteration_info!(logger,k,err=err,λ=λ);
 
         if (err< tol)
             return (λ,v)

--- a/src/method_mslp.jl
+++ b/src/method_mslp.jl
@@ -5,7 +5,7 @@ export mslp
 
 
 """
-     mslp([eltype],nep::NEP;[errmeasure,][tol,][maxit,][λ,][v,][displaylevel,][eigsolvertype::Type][armijo_factor=1,][armijo_max])
+     mslp([eltype],nep::NEP;[errmeasure,][tol,][maxit,][λ,][v,][logger,][eigsolvertype::Type][armijo_factor=1,][armijo_max])
 
 Runs the method of successive linear problems. The  method requires the solution of a
 generalized eigenvalue problem in every iteration. The method used for the eigenvalue

--- a/src/method_newton.jl
+++ b/src/method_newton.jl
@@ -71,9 +71,7 @@ julia> minimum(svdvals(compute_Mder(nep,λ)))
                     armijo_factor::Real=1,
                     armijo_max::Int=5) where {T<:Number}
 
-        if (isa(logger,Number))
-            logger=PrintLogger(logger)
-        end
+        @parse_logger_param!(logger)
 
         # Ensure types λ and v are of type T
         λ=T(λ)
@@ -172,9 +170,8 @@ julia> norm(compute_Mlincomb(nep,λ,v))
                     armijo_factor::Real=1,
                     armijo_max::Int=5) where T
 
-        if (isa(logger,Number))
-            logger=PrintLogger(logger)
-        end
+        @parse_logger_param!(logger)
+
 
         # Ensure types λ and v are of type T
         λ::T=T(λ)
@@ -287,9 +284,8 @@ julia> λ1-λ2
                        armijo_factor::Real=one(real(T)),
                        armijo_max::Int=5) where {T<:Number}
 
-        if (isa(logger,Number))
-            logger=PrintLogger(logger)
-        end
+        @parse_logger_param!(logger)
+
 
         # Ensure types λ and v are of type T
         λ=T(λ)
@@ -390,9 +386,8 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
                          armijo_factor::Real=1,
                          armijo_max::Int=5) where T
 
-        if (isa(logger,Number))
-            logger=PrintLogger(logger)
-        end
+        @parse_logger_param!(logger)
+
 
         # Ensure types λ and v are of type T
         λ=T(λ)
@@ -485,9 +480,8 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
                       c::Vector=v,
                       logger=0) where T
 
-        if (isa(logger,Number))
-            logger=PrintLogger(logger)
-        end
+        @parse_logger_param!(logger)
+
 
         # Ensure types λ and v are of type T
         λ=T(λ)
@@ -568,9 +562,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
                          c=v,
                          logger=0) where T
 
-        if (isa(logger,Number))
-            logger=PrintLogger(logger)
-        end
+        @parse_logger_param!(logger)
 
         n = size(nep,1);
         v = Vector{T}(vcat(v,one(T)))

--- a/src/method_newton.jl
+++ b/src/method_newton.jl
@@ -15,7 +15,7 @@ export implicitdet
 
 #############################################################################
 """
-    λ,v = newton([eltype],nep::NEP;[errmeasure,][tol,][maxit,][λ,][v,][c,][displaylevel,][armijo_factor=1,][armijo_max])
+    λ,v = newton([eltype],nep::NEP;[errmeasure,][tol,][maxit,][λ,][v,][c,][logger,][armijo_factor=1,][armijo_max])
 
 Applies Newton-Raphsons method on the system of
 nonlinear equations with `n+1` unknowns:
@@ -126,7 +126,7 @@ julia> minimum(svdvals(compute_Mder(nep,λ)))
 
     ############################################################################
 """
-    λ,v = resinv([eltype],nep::NEP;[errmeasure,][tol,][maxit,][λ,][v,][c,][displaylevel,][armijo_factor=1,][armijo_max,][linsolvecreator])
+    λ,v = resinv([eltype],nep::NEP;[errmeasure,][tol,][maxit,][λ,][v,][c,][logger,][armijo_factor=1,][armijo_max,][linsolvecreator])
 
 Applies residual inverse iteration method for nonlinear eigenvalue problems.
 The kwarg `linsolvecreator`
@@ -250,7 +250,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))
 
     # New augnewton
 """
-    augnewton([eltype], nep::NEP; [errmeasure,][tol,][maxit,][λ,][v,][c,][displaylevel,][linsolvercreator,][armijo_factor,][armijo_max])
+    augnewton([eltype], nep::NEP; [errmeasure,][tol,][maxit,][λ,][v,][c,][logger,][linsolvercreator,][armijo_factor,][armijo_max])
 
 Run the augmented Newton method. The method is equivalent to `newton()`
 in exact arithmetic,  but works only with operations on vectors of
@@ -351,7 +351,7 @@ julia> λ1-λ2
 
 
 """
-    quasinewton([T=ComplexF64],nep,[errmeasure,][tol,][maxit,][λ,][v][ws][displaylevel][linsolvercreator,][armijo_factor,][armijo_max])
+    quasinewton([T=ComplexF64],nep,[errmeasure,][tol,][maxit,][λ,][v][ws][logger][linsolvercreator,][armijo_factor,][armijo_max])
 
 An implementation of the quasi-Newton approach referred to as quasi-Newton 2 in the reference.
 The method involves one linear system solve per iteration corresponding with the
@@ -449,7 +449,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
 
 
 """
-    λ,v = newtonqr([eltype],nep::NEP;[errmeasure,][tol,][maxit,][λ,][v,][c,][displaylevel])
+    λ,v = newtonqr([eltype],nep::NEP;[errmeasure,][tol,][maxit,][λ,][v,][c,][logger])
 
 This function implements the Newton-QR method as formulated in the reference. The method ivolves the computation of a rank-revealing QR factorization
 of ``M(λ)``, with the idea that on convergence the the last diagonal element ``R[n,n]`` of the upper-triangular matrix ``R`` becomes zero as a result of ``M(λ)``
@@ -530,7 +530,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
 
 
 """
-    λ,v = implicitdet([eltype],nep::NEP;[errmeasure,][tol,][maxit,][λ,][v,][c,][displaylevel])
+    λ,v = implicitdet([eltype],nep::NEP;[errmeasure,][tol,][maxit,][λ,][v,][c,][logger])
 
 This function implements the Implicit determinant method as formulated Algorithm 4.3 in the reference. The method applies Newton-Raphson to the equation
 ``det(M(λ))/det(G(λ)) = 0``, where ``G(λ)`` is a saddle point matrix with ``M(λ)``

--- a/src/method_newton.jl
+++ b/src/method_newton.jl
@@ -89,7 +89,7 @@ julia> minimum(svdvals(compute_Mder(nep,λ)))
         for k=1:maxit
             err=estimate_error(ermdata,λ,v)
 
-            push_iteration_info!(logger,k,true,err=err,λ=λ,v=v);
+            push_iteration_info!(logger,k,err=err,λ=λ,v=v,continues=true);
             if (err< tol)
                 return (λ,v)
             end
@@ -111,7 +111,7 @@ julia> minimum(svdvals(compute_Mder(nep,λ)))
             (Δλ,Δv,j,scaling)=armijo_rule(nep,ermdata,err,
                                           λ,v,Δλ,Δv,real(T(armijo_factor)),armijo_max)
             if (j>0)
-                push_info!(logger," Armijo scaling=$scaling",false)
+                push_info!(logger," Armijo scaling=$scaling")
             else
                 push_info!(logger,"")
             end
@@ -213,7 +213,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))
             end
 
 
-            push_iteration_info!(logger,k,true,err=err,λ=λ,v=v);
+            push_iteration_info!(logger,k,err=err,λ=λ,v=v,continues=true);
 
             if (err< tol)
                 push_info!(logger,"")
@@ -314,7 +314,7 @@ julia> λ1-λ2
 
         for k=1:maxit
             err=estimate_error(ermdata,λ,v)
-            push_iteration_info!(logger,k,true,err=err,λ=λ,v=v);
+            push_iteration_info!(logger,k,err=err,λ=λ,v=v,continues=true);
             if (err< tol)
                 push_info!(logger,"")
                 return (λ,v)
@@ -414,7 +414,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
 
         for k=1:maxit
             err=estimate_error(ermdata,λ,v)
-            push_iteration_info!(logger,k,true,err=err,λ=λ,v=v);
+            push_iteration_info!(logger,k,err=err,λ=λ,v=v,continues=true);
             if (err< tol)
                 push_info!(logger,"")
                 return (λ,v)
@@ -431,7 +431,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
             Δv::Vector{T}=-lin_solve(linsolver, z, tol=tol); # Throws an error if lin_solve returns incorrect type
 
             normΔv=norm(Δv);
-            push_info!(logger,2," norm(Δv)=$normΔv",true)
+            push_info!(logger,2," norm(Δv)=$normΔv",continues=true)
 
             (Δλ,Δv,j,scaling)=armijo_rule(nep,ermdata,err,
                                           λ,v,Δλ,Δv,real(T(armijo_factor)),armijo_max)

--- a/src/method_newton.jl
+++ b/src/method_newton.jl
@@ -30,7 +30,7 @@ orthogonalization vector.  If `c=0` the current approximation will be used for t
 
 The following keyword arguments are in common for many NEP-solvers:
 
-* `displaylevel` specifies how much iteration info should be printed. `displaylevel=0` will not give any printouts.
+* `logger` is eiter a `Logger` object or an `Int`. If it is an `Int`, a `PrintLogger(logger)` will be instantiated. `logger=0` prints nothing, `logger=1` prints more, etc.
 
 * `errmeasure` determines how error is measured. It is either a function handle or a type inheriting from `Errmeasure`. See [`Errmeasure`](@ref) for further description. If it is a function handle, it should take `(λ,v)` as input and return a real scalar (the error).
 

--- a/src/method_nlar.jl
+++ b/src/method_nlar.jl
@@ -10,14 +10,18 @@ export threshold_eigval_sorter
 
 
 """
-    function nlar([eltype],nep::ProjectableNEP,[orthmethod=ModifiedGramSchmidt],[neigs=10],[errmeasure],[tol=eps(real(T))*100],[maxit=100],[λ0=0],[v0=randn(T,size(nep,1))],[logger=0],[linsolvercreator=default_linsolvercreator],[R=0.01],[eigval_sorter=residual_eigval_sorter],[qrfact_orth=false],[max_subspace=100],[num_restart_ritz_vecs=8],[inner_solver_method=DefaultInnerSolver])
+    function nlar([eltype],nep::ProjectableNEP,[orthmethod=ModifiedGramSchmidt],[neigs=10],[errmeasure],[tol=eps(real(T))*100],[maxit=100],[λ0=0],[v0=randn(T,size(nep,1))],[logger=0],[linsolvercreator=default_linsolvercreator],[R=0.01],[eigval_sorter=residual_eigval_sorter],[qrfact_orth=false],[max_subspace=100],[num_restart_ritz_vecs=8],[inner_solver_method=DefaultInnerSolver,][inner_logger=0])
 
 The function implements the Nonlinear Arnoldi method, which finds `neigs` eigenpairs(or throws a `NoConvergenceException`) by projecting the problem to a subspace that is expanded in the course  of the algorithm.
 The basis is orthogonalized either by using the QR method if `qrfact_orth` is `true` or else by an orthogonalization method `orthmethod`).
 This entails solving a smaller projected problem using a method specified by `inner_solver_method`.
+The logging of the inner solvers are descided by `inner_logger`, which works in the same way as `logger`.
 (`λ0`,`v0`) is the initial guess for the eigenpair. `linsolvercreator` specifies how the linear system is created and solved.
 `R` is a parameter used by the function specified by `eigval_sorter` to reject those ritz values that are within a distance `R` from any of the converged eigenvalues, so that repeated convergence to the same eigenpair can be avoided.
 `max_subspace` is the maximum allowable size of the basis befor the algorithm restarts using a basis made of `num_restart_ritz_vecs` ritz vectors and the eigenvectors that the algorithm has converged to.
+
+See [`newton`](@ref) for other parameters.
+
 
 # Example
 ```julia-repl
@@ -48,9 +52,11 @@ function nlar(::Type{T},
             qrfact_orth::Bool = false,
             max_subspace::Int = 100,                           #Maximum subspace size before we implement restarting
             num_restart_ritz_vecs::Int=8,
-            inner_solver_method = DefaultInnerSolver) where {T<:Number,T_orth<:IterativeSolvers.OrthogonalizationMethod}
+            inner_solver_method = DefaultInnerSolver,
+            inner_logger = 0) where {T<:Number,T_orth<:IterativeSolvers.OrthogonalizationMethod}
 
         @parse_logger_param!(logger)
+        @parse_logger_param!(inner_logger)
 
         #Check if maxit is larger than problem size
         if (maxit > size(nep,1))
@@ -110,7 +116,7 @@ function nlar(::Type{T},
 
             #Use inner_solve() to solve the smaller projected problem
             push_info!(logger, 2, "Solving inner problem",continues=true)
-            dd,vv = inner_solve(inner_solver_method,T,proj_nep,Neig=neigs,σ=σ);
+            dd,vv = inner_solve(inner_solver_method,T,proj_nep,Neig=neigs,σ=σ,inner_logger=inner_logger);
             push_info!(logger, 2, ". Done.")
             # Sort the eigenvalues of the projected problem
             nuv,yv = eigval_sorter(nep,dd,vv,σ,D,R,Vk);

--- a/src/method_nlar.jl
+++ b/src/method_nlar.jl
@@ -109,9 +109,9 @@ function nlar(::Type{T},
             expand_projectmatrices!(proj_nep,Vk,Vk);
 
             #Use inner_solve() to solve the smaller projected problem
-            push_info!(logger, "Solving inner problem")
+            push_info!(logger, 2, "Solving inner problem",continues=true)
             dd,vv = inner_solve(inner_solver_method,T,proj_nep,Neig=neigs,σ=σ);
-
+            push_info!(logger, 2, ". Done.")
             # Sort the eigenvalues of the projected problem
             nuv,yv = eigval_sorter(nep,dd,vv,σ,D,R,Vk);
             nu = nuv[1]; y=yv[:,1];

--- a/src/method_nlar.jl
+++ b/src/method_nlar.jl
@@ -10,7 +10,7 @@ export threshold_eigval_sorter
 
 
 """
-    function nlar([eltype],nep::ProjectableNEP,[orthmethod=ModifiedGramSchmidt],[neigs=10],[errmeasure],[tol=eps(real(T))*100],[maxit=100],[λ0=0],[v0=randn(T,size(nep,1))],[displaylevel=0],[linsolvercreator=default_linsolvercreator],[R=0.01],[eigval_sorter=residual_eigval_sorter],[qrfact_orth=false],[max_subspace=100],[num_restart_ritz_vecs=8],[inner_solver_method=DefaultInnerSolver])
+    function nlar([eltype],nep::ProjectableNEP,[orthmethod=ModifiedGramSchmidt],[neigs=10],[errmeasure],[tol=eps(real(T))*100],[maxit=100],[λ0=0],[v0=randn(T,size(nep,1))],[logger=0],[linsolvercreator=default_linsolvercreator],[R=0.01],[eigval_sorter=residual_eigval_sorter],[qrfact_orth=false],[max_subspace=100],[num_restart_ritz_vecs=8],[inner_solver_method=DefaultInnerSolver])
 
 The function implements the Nonlinear Arnoldi method, which finds `neigs` eigenpairs(or throws a `NoConvergenceException`) by projecting the problem to a subspace that is expanded in the course  of the algorithm.
 The basis is orthogonalized either by using the QR method if `qrfact_orth` is `true` or else by an orthogonalization method `orthmethod`).

--- a/src/method_nleigs.jl
+++ b/src/method_nleigs.jl
@@ -58,7 +58,7 @@ function nleigs(
         nep::NEP,
         Σ::AbstractVector{CT}=Vector{CT}([-1.0-1im,-1+1im,+1+1im,1-1im]);
         Ξ::Vector{T} = [T(Inf)],
-        displaylevel::Int = 0,
+        logger = 0,
         maxdgr::Int = 100,
         minit::Int = 20,
         maxit::Int = 200,
@@ -75,6 +75,8 @@ function nleigs(
         blksize::Int = 20,
         return_details::Bool = false,
         check_error_every::Int = 5) where {T<:Real, CT<:Complex{T}}
+
+    @parse_logger_param!(logger)
 
     # The following variables are used when creating the return values, so put them in scope
     D = Vector{Matrix{CT}}()
@@ -253,9 +255,10 @@ function nleigs(
                         V = resize_matrix(V, kn, b+1)
                     end
                     N -= 1
-                    if displaylevel > 0
-                        println("Linearization converged after $kconv iterations")
-                        println(" --> freeze linearization")
+                    push_info!(logger,
+                               "Linearization converged after $kconv iterations")
+                    push_info!(logger,
+                               "--> freeze linearization")
                     end
                 elseif k == maxdgr+1
                     kconv = k
@@ -271,9 +274,8 @@ function nleigs(
                     end
                     N -= 1
                     @warn "NLEIGS: Linearization not converged after $maxdgr iterations"
-                    if displaylevel > 0
-                        println(" --> freeze linearization")
-                    end
+                    push_info!(logger,
+                               "--> freeze linearization")
                 end
             end
         end
@@ -332,10 +334,10 @@ function nleigs(
             end
 
             nbconv = isempty(conv) ? 0 : sum(conv)
-            if displaylevel > 0
-                iteration = static ? k - N : k
-                println("  iteration $iteration: $nbconv of $nblamin < $tol")
-            end
+
+            iteration = static ? k - N : k
+            push_info!(logger,
+                       "  iteration $iteration: $nbconv of $nblamin < $tol")
         end
 
         # Ritz pairs

--- a/src/method_nleigs.jl
+++ b/src/method_nleigs.jl
@@ -13,7 +13,7 @@ Find a few eigenvalues and eigenvectors of a nonlinear eigenvalue problem.
 - `nep`: An instance of a nonlinear eigenvalue problem.
 - `Σ`: A vector containing the points of a polygonal target set in the complex plane.
 - `Ξ`: A vector containing a discretization of the singularity set.
-- `displaylevel`: Level of display (0, 1, 2).
+- `logger`: Level of display (0, 1, 2).
 - `maxdgr`: Max degree of approximation.
 - `minit`: Min number of iterations after linearization is converged.
 - `maxit`: Max number of total iterations.

--- a/src/method_nleigs.jl
+++ b/src/method_nleigs.jl
@@ -259,7 +259,6 @@ function nleigs(
                                "Linearization converged after $kconv iterations")
                     push_info!(logger,
                                "--> freeze linearization")
-                    end
                 elseif k == maxdgr+1
                     kconv = k
                     expand = false

--- a/src/method_rfi.jl
+++ b/src/method_rfi.jl
@@ -78,7 +78,7 @@ function rfi(::Type{T},
 end
 
 """
-    rfi_b(nep,nept,[λ=0,][errmeasure,][tol=eps()*100,][maxit=100,][v=randn,][u=randn,][logger=1,][linsolvecreator=default_linsolvecreator,])
+    rfi_b(nep,nept,[λ=0,][errmeasure,][tol=eps()*100,][maxit=100,][v=randn,][u=randn,][logger=0,][linsolvecreator=default_linsolvecreator,])
 
 This is an implementation of the two-sided Rayleigh functional Iteration(RFI)-Bordered version to compute an eigentriplet of the problem specified by `nep`.
 This method requires the transpose of the NEP, specified in `nept`.

--- a/src/method_rfi.jl
+++ b/src/method_rfi.jl
@@ -37,7 +37,9 @@ function rfi(::Type{T},
             v::Vector = randn(T,size(nep,1)),
             u::Vector = randn(T,size(nep,1)),
             linsolvercreator::Function=default_linsolvercreator,
-            displaylevel=0) where {T <: Number}
+            logger=0) where {T <: Number}
+
+        @parse_logger_param!(logger)
 
         err = Inf
 
@@ -55,7 +57,8 @@ function rfi(::Type{T},
                 return λ,u,v
             end
 
-            @ifd(@printf("Iteration: %2d errmeasure:%.18e \n",k, err))
+            push_iteration_info!(logger,k,err=err,λ=λ,v=v, continues=true);
+            push_info!(logger," u=$u");
 
             local linsolver::LinSolver = linsolvercreator(nep,λ)
             local linsolver_t::LinSolver = linsolvercreator(nept,λ)
@@ -108,7 +111,9 @@ function rfi_b(::Type{T},
             v::Vector = randn(T,size(nep,1)),
             u::Vector = randn(T,size(nep,1)),
             linsolvercreator::Function=default_linsolvercreator,
-            displaylevel=1) where {T <: Number}
+            logger=0) where {T <: Number}
+
+        @parse_logger_param!(logger)
 
         err = Inf
         #Normalize v and u
@@ -125,7 +130,8 @@ function rfi_b(::Type{T},
                 return λ,u,v
             end
 
-            @ifd(@printf("Iteration: %2d errmeasure:%.18e \n",k, err))
+            push_iteration_info!(logger,k,err=err,λ=λ,v=v, continues=true);
+            push_info!(logger," u=$u");
 
             #Construct C_k
             C = [compute_Mder(nep,λ,0) compute_Mlincomb(nep,λ,u,[T(1)],1);v'*compute_Mder(nep,λ,1) T(0.0)]

--- a/src/method_rfi.jl
+++ b/src/method_rfi.jl
@@ -5,7 +5,7 @@ export rfi
 export rfi_b
 
 """
-    rfi(nep,nept,[λ=0,][errmeasure,][tol=eps()*100,][maxit=100,][v=randn,][u=randn,][displaylevel=0,][linsolvecreator=default_linsolvecreator,])
+    rfi(nep,nept,[λ=0,][errmeasure,][tol=eps()*100,][maxit=100,][v=randn,][u=randn,][logger=0,][linsolvecreator=default_linsolvecreator,])
 
 
 This is an implementation of the two-sided Rayleigh functional Iteration (RFI) to compute an eigentriplet of the problem specified by `nep`.
@@ -78,7 +78,7 @@ function rfi(::Type{T},
 end
 
 """
-    rfi_b(nep,nept,[λ=0,][errmeasure,][tol=eps()*100,][maxit=100,][v=randn,][u=randn,][displaylevel=1,][linsolvecreator=default_linsolvecreator,])
+    rfi_b(nep,nept,[λ=0,][errmeasure,][tol=eps()*100,][maxit=100,][v=randn,][u=randn,][logger=1,][linsolvecreator=default_linsolvecreator,])
 
 This is an implementation of the two-sided Rayleigh functional Iteration(RFI)-Bordered version to compute an eigentriplet of the problem specified by `nep`.
 This method requires the transpose of the NEP, specified in `nept`.

--- a/src/method_sgiter.jl
+++ b/src/method_sgiter.jl
@@ -39,9 +39,11 @@ function sgiter(::Type{T},
                    errmeasure::ErrmeasureType = DefaultErrmeasure,
                    tol::Real = eps(real(T)) * 100,
                    maxit::Integer = 100,
-                   displaylevel::Integer = 0,
+                   logger::Integer = 0,
                    eigsolvertype::Type = DefaultEigSolver
                    ) where {T<:Number}
+
+    @parse_logger_param!(logger)
 
     n = size(nep,1)
     if (j > n) || (j <= 0)
@@ -71,11 +73,10 @@ function sgiter(::Type{T},
        eig_solver = eigsolvertype(compute_Mder(nep, λ, 0))
        v[:] = compute_jth_eigenvector(eig_solver, nep, λ, j)
        λ_vec = compute_rf(real_T, nep, v, TOL = tol/10)
-       @ifd(println("compute_rf: ", λ_vec))
+       push_info!(logger,2,"compute_rf: ", λ_vec)
        λ = choose_correct_eigenvalue_from_rf(λ_vec, λ_min, λ_max)
-       @ifd(println(" λ = ", λ))
        err = estimate_error(ermdata,λ, v)
-       @ifd(print("Iteration:", k, " errmeasure:", err, "\n"))
+       push_iteration_info!(logger,k,err=err,λ=λ);
        if (err < tol)
            return (λ, v)
        end

--- a/src/method_sgiter.jl
+++ b/src/method_sgiter.jl
@@ -39,7 +39,7 @@ function sgiter(::Type{T},
                    errmeasure::ErrmeasureType = DefaultErrmeasure,
                    tol::Real = eps(real(T)) * 100,
                    maxit::Integer = 100,
-                   logger::Integer = 0,
+                   logger = 0,
                    eigsolvertype::Type = DefaultEigSolver
                    ) where {T<:Number}
 

--- a/src/method_sgiter.jl
+++ b/src/method_sgiter.jl
@@ -73,7 +73,7 @@ function sgiter(::Type{T},
        eig_solver = eigsolvertype(compute_Mder(nep, λ, 0))
        v[:] = compute_jth_eigenvector(eig_solver, nep, λ, j)
        λ_vec = compute_rf(real_T, nep, v, TOL = tol/10)
-       push_info!(logger,2,"compute_rf: ", λ_vec)
+       push_info!(logger,2,"compute_rf: $λ_vec")
        λ = choose_correct_eigenvalue_from_rf(λ_vec, λ_min, λ_max)
        err = estimate_error(ermdata,λ, v)
        push_iteration_info!(logger,k,err=err,λ=λ);

--- a/src/method_sgiter.jl
+++ b/src/method_sgiter.jl
@@ -1,7 +1,7 @@
 export sgiter
 
 """
-    λ,v = sgiter([eltype],nep::NEP,j::Integer;[λ_min,][λ_max,][λ,][errmeasure,][tol,][maxit,][displaylevel,][eigsolvertype::Type,])
+    λ,v = sgiter([eltype],nep::NEP,j::Integer;[λ_min,][λ_max,][λ,][errmeasure,][tol,][maxit,][logger,][eigsolvertype::Type,])
 
 Finds the `j`-th eigenvalue of the NEP using safeguarded iteration, with eigenvalue numbering
 according to min-max theory. The method only works for Hermitian problems, and the eigenvalues

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -5,9 +5,7 @@ using LinearAlgebra
 using Random
 
 """
-    tiar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure,]
-[v=rand(size(nep,1),1),][logger=0,][check_error_every=1,][orthmethod=DGKS,]
-[proj_solve=false,][inner_solver_method=DefaultInnerSolver,][inner_logger=0])
+    tiar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][logger=0,][check_error_every=1,][orthmethod=DGKS,][proj_solve=false,][inner_solver_method=DefaultInnerSolver,][inner_logger=0])
 
 Run the tensor infinite Arnoldi method on the nonlinear eigenvalue problem stored in `nep`. This is equivalent to `iar`, but handles orthogonalization with
 a tensor representation.

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -66,12 +66,9 @@ function tiar(
     inner_solver_method=DefaultInnerSolver,
     inner_logger=0    )where{T,T_orth<:IterativeSolvers.OrthogonalizationMethod}
 
-    if (isa(logger,Number))
-        logger=PrintLogger(logger)
-    end
-    if (isa(inner_logger,Number))
-        inner_logger=PrintLogger(inner_logger)
-    end
+    @parse_logger_param!(logger)
+    @parse_logger_param!(inner_logger)
+
 
     # Ensure types σ and v are of type T
     σ=T(σ)

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -5,7 +5,9 @@ using LinearAlgebra
 using Random
 
 """
-    tiar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][logger=0,][check_error_every=1,][orthmethod=DGKS])
+    tiar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure,]
+[v=rand(size(nep,1),1),][logger=0,][check_error_every=1,][orthmethod=DGKS,]
+[proj_solve=false,][inner_solver_method=DefaultInnerSolver,][inner_logger=0])
 
 Run the tensor infinite Arnoldi method on the nonlinear eigenvalue problem stored in `nep`. This is equivalent to `iar`, but handles orthogonalization with
 a tensor representation.
@@ -23,6 +25,9 @@ method, used in contructing the orthogonal basis of the Krylov space, is specifi
 The iteration is continued until `Neig` Ritz pairs have converged.
 This function throws a `NoConvergenceException` if the wanted eigenpairs are not computed after `maxit` iterations.
 However, if `Neig` is set to `Inf` the iteration is continued until `maxit` iterations without an error being thrown.
+The parameter `proj_solve` determines if the Ritz paris are extracted using the Hessenberg matrix (false),
+or as the solution to a projected problem (true). If true, the method is descided by `inner_solver_method`, and the
+logging of the inner solvers are descided by `inner_logger`, which works in the same way as `logger`.
 
 See [`newton`](@ref) for other parameters.
 
@@ -64,7 +69,7 @@ function tiar(
     check_error_every=1,
     proj_solve=false,
     inner_solver_method=DefaultInnerSolver,
-    inner_logger=0    )where{T,T_orth<:IterativeSolvers.OrthogonalizationMethod}
+    inner_logger=0)where{T,T_orth<:IterativeSolvers.OrthogonalizationMethod}
 
     @parse_logger_param!(logger)
     @parse_logger_param!(inner_logger)

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -60,11 +60,18 @@ function tiar(
     σ=zero(T),
     γ=one(T),
     v=randn(real(T),size(nep,1)),
-    displaylevel=0,
+    logger=0,
     check_error_every=1,
     proj_solve=false,
-    inner_solver_method=DefaultInnerSolver
-    )where{T,T_orth<:IterativeSolvers.OrthogonalizationMethod}
+    inner_solver_method=DefaultInnerSolver,
+    inner_logger=0    )where{T,T_orth<:IterativeSolvers.OrthogonalizationMethod}
+
+    if (isa(logger,Number))
+        logger=PrintLogger(logger)
+    end
+    if (isa(inner_logger,Number))
+        inner_logger=PrintLogger(inner_logger)
+    end
 
     # Ensure types σ and v are of type T
     σ=T(σ)
@@ -110,9 +117,6 @@ function tiar(
 
     k=1; conv_eig=0;
     while (k <= m)&(conv_eig<Neig)
-        if (displaylevel>0) && ((rem(k,check_error_every)==0) || (k==m))
-            println("Iteration:",k, " conveig:",conv_eig)
-        end
 
         # computation of y[:,2], ..., y[:,k+1]
         y[:,2:k+1]=Z[:,1:k]*transpose(a[1:k,k,1:k])
@@ -195,7 +199,8 @@ function tiar(
                                         λv=copy(λ),
                                         Neig=size(λ,1)+3,
                                         σ=σ,
-                                        tol=tol/10,displaylevel=displaylevel);
+                                        tol=tol/10,
+                                        logger=inner_logger);
 
 
                 II=sortperm(abs.(λproj .- σ));
@@ -206,10 +211,23 @@ function tiar(
 
 
             conv_eig=0;
-            for s=1:min(size(λ,1),size(err,2))
-                err[k,s]=estimate_error(ermdata,λ[s],Q[:,s]);
-                if err[k,s]<tol; conv_eig=conv_eig+1; end
+            err[k,1:size(λ,1)]=
+              map(s-> estimate_error(ermdata,λ[s],Q[:,s]), 1:size(λ,1))
+            # Log them and compute the converged
+            push_iteration_info!(logger,2, k,err=err[k,1:size(λ,1)],
+                                 continues=true);
+            for s=1:size(λ,1)
+                if err[k,s]<tol;
+                    conv_eig=conv_eig+1;
+                    push_info!(logger,"+", continues=true);
+                elseif err[k,s]<tol*10
+                    push_info!(logger,"=", continues=true);
+                else
+                    push_info!(logger,"-", continues=true);
+                end
             end
+            push_info!(logger,"");
+
             idx=sortperm(err[k,1:k]); # sort the error
             err[k,1:k]=err[k,idx];
             # extract the converged Ritzpairs
@@ -238,5 +256,5 @@ function tiar(
     # extract the converged Ritzpairs
     λ=λ[1:min(length(λ),conv_eig)];
     Q=Q[:,1:min(size(Q,2),conv_eig)];
-    return λ,Q,err[1:k,:],Z[:,1:k],conv_eig_hist
+    return λ,Q,Z[:,1:k],conv_eig_hist
 end

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -211,7 +211,7 @@ function tiar(
             err[k,1:size(λ,1)]=
               map(s-> estimate_error(ermdata,λ[s],Q[:,s]), 1:size(λ,1))
             # Log them and compute the converged
-            push_iteration_info!(logger,2, k,err=err[k,1:size(λ,1)],
+            push_iteration_info!(logger,2, k,err=err[k,1:size(λ,1)], λ=λ,
                                  continues=true);
             for s=1:size(λ,1)
                 if err[k,s]<tol;

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -197,7 +197,7 @@ function tiar(
                                         Neig=size(λ,1)+3,
                                         σ=σ,
                                         tol=tol/10,
-                                        logger=inner_logger);
+                                        innerlogger=inner_logger);
 
 
                 II=sortperm(abs.(λproj .- σ));

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -5,7 +5,7 @@ using LinearAlgebra
 using Random
 
 """
-    tiar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][displaylevel=0,][check_error_every=1,][orthmethod=DGKS])
+    tiar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][logger=0,][check_error_every=1,][orthmethod=DGKS])
 
 Run the tensor infinite Arnoldi method on the nonlinear eigenvalue problem stored in `nep`. This is equivalent to `iar`, but handles orthogonalization with
 a tensor representation.

--- a/test/beyn.jl
+++ b/test/beyn.jl
@@ -10,7 +10,7 @@ using LinearAlgebra
     nep=nep_gallery("dep0")
     @bench @testset "disk at origin" begin
 
-        λ,v=contour_beyn(nep,displaylevel=displaylevel,radius=1,neigs=2,quad_method=:ptrapz,sanity_check=false)
+        λ,v=contour_beyn(nep,logger=displaylevel,radius=1,neigs=2,quad_method=:ptrapz,sanity_check=false)
 
         for i = 1:2
             @info "$i: $(λ[i])"
@@ -21,7 +21,7 @@ using LinearAlgebra
         end
 
 
-        λ,v=contour_beyn(nep,displaylevel=displaylevel,radius=1,k=2,quad_method=:ptrapz,N=100,sanity_check=false)
+        λ,v=contour_beyn(nep,logger=displaylevel,radius=1,k=2,quad_method=:ptrapz,N=100,sanity_check=false)
         M=compute_Mder(nep,λ[1])
         minimum(svdvals(M))
         @test minimum(svdvals(M))<eps()*1000
@@ -29,7 +29,7 @@ using LinearAlgebra
     end
     @bench @testset "shifted disk" begin
 
-        λ,v=contour_beyn(nep,displaylevel=displaylevel,σ=-0.2,radius=1.5,
+        λ,v=contour_beyn(nep,logger=displaylevel,σ=-0.2,radius=1.5,
                          neigs=4,quad_method=:ptrapz,sanity_check=false)
 
         @test size(λ,1)==4

--- a/test/blocknewton.jl
+++ b/test/blocknewton.jl
@@ -9,7 +9,7 @@ using LinearAlgebra
     nep=nep_gallery("dep0",4);
     V = Matrix(1.0I, size(nep,1), 3)
     S0=zeros(3,3);
-    S,V=blocknewton(nep,S=S0,X=V,displaylevel=displaylevel,
+    S,V=blocknewton(nep,S=S0,X=V,logger=displaylevel,
                     armijo_factor=0.5,
                     maxit=20)
 

--- a/test/cd_player_native.jl
+++ b/test/cd_player_native.jl
@@ -10,10 +10,10 @@ using LinearAlgebra
 
     (Λ,V)=polyeig(nep)
 
-    (λ,v)=quasinewton(nep,λ=Λ[1],v=V[:,1],displaylevel=displaylevel, armijo_factor=0.5,armijo_max=10, tol=1e-10)
+    (λ,v)=quasinewton(nep,λ=Λ[1],v=V[:,1],logger=displaylevel, armijo_factor=0.5,armijo_max=10, tol=1e-10)
     verify_lambdas(1, nep, λ, v, 1e-10)
 
-    (λ,v)=resinv(nep,λ=Λ[2],v=V[:,2],displaylevel=displaylevel, armijo_factor=0.5,armijo_max=10, tol=1e-10)
+    (λ,v)=resinv(nep,λ=Λ[2],v=V[:,2],logger=displaylevel, armijo_factor=0.5,armijo_max=10, tol=1e-10)
     verify_lambdas(1, nep, λ, v, 1e-10)
 
     @testset "Errors thrown" begin

--- a/test/compan.jl
+++ b/test/compan.jl
@@ -79,7 +79,7 @@ while abs(d) > tolerance
 end
 
 @info "Solving same problem with resinv"
-λ,v = resinv(BigFloat, pep, λ = (BigFloat(evp)+0.1), v = z[1:size(pep,1)], displaylevel=0, tol = tolerance, errmeasure=ResidualErrmeasure)
+λ,v = resinv(BigFloat, pep, λ = (BigFloat(evp)+0.1), v = z[1:size(pep,1)], logger=0, tol = tolerance, errmeasure=ResidualErrmeasure)
 
 @test (abs(λ-evp)/abs(λ) < tolerance*10)
 

--- a/test/compan.jl
+++ b/test/compan.jl
@@ -15,7 +15,7 @@ deg = size(get_fv(pep),1) -1;
 n = size(pep,1);
 tolerance = 1e-14;
 
-λa,xa = newton(pep, maxit=30, displaylevel=0, tol = tolerance);
+λa,xa = newton(pep, maxit=30, logger=0, tol = tolerance);
 Dc,Vc = polyeig(pep, DefaultEigSolver);
 
 ind = 1;
@@ -36,7 +36,7 @@ deg = size(get_fv(pep),1) -1;
 n = size(pep,1);
 tolerance = 1e-14;
 
-λa,xa =newton(pep, maxit=30, λ=-0.75, v=ones(n), displaylevel=0, tol = tolerance);
+λa,xa =newton(pep, maxit=30, λ=-0.75, v=ones(n), logger=0, tol = tolerance);
 Dc,Vc = polyeig(pep,DefaultEigSolver);
 
 ind = 1;

--- a/test/deflation.jl
+++ b/test/deflation.jl
@@ -22,7 +22,7 @@ using LinearAlgebra
 
         (λ2,v2)=mslp(dnep,maxit=1000,
                      λ=λ0,
-                     displaylevel=0
+                     logger=0
                      );
         @info "Computing eigenvalue k=$k"
         v2=v2/norm(v2);

--- a/test/deflation2.jl
+++ b/test/deflation2.jl
@@ -227,7 +227,7 @@ dnep1_new=create_spmf_dnep(nep,S0,V0)
 #Z=randn(3,3);
 #@show norm(compute_MM(dnep,Z,W)-compute_MM(dnep2,Z,W))
 
-(λ2,v2)=resinv(dnep1_new,λ=290^2,armijo_factor=0.9,displaylevel=1,maxit=100,v=ones(n+1),tol=1e-12)
+(λ2,v2)=resinv(dnep1_new,λ=290^2,armijo_factor=0.9,logger=1,maxit=100,v=ones(n+1),tol=1e-12)
 v2=v2/norm(v2);
 
 

--- a/test/deflation2.jl
+++ b/test/deflation2.jl
@@ -31,7 +31,7 @@ using BenchmarkTools;
 nep=nep_gallery("dep0_sparse",100);
 n=size(nep,1);
 local λ,v;
-(λ,v)=quasinewton(nep,v=ones(n),λ=2,tol=1e-11,displaylevel=1,maxit=200)
+(λ,v)=quasinewton(nep,v=ones(n),λ=2,tol=1e-11,logger=1,maxit=200)
 dnep1=deflate_eigpair(nep,λ,v,mode=:Generic);
 @btime mslp(dnep1,λ=1im,tol=1e-11)
 dnep2=deflate_eigpair(nep,λ,v,mode=:SPMF);
@@ -50,7 +50,7 @@ begin
   dnep=deflate_eigpair(nep,λ,v,mode=:Generic);
   for k=1:4
       (λ,v)=augnewton(dnep,v=ones(size(dnep,1)),λ=-1+0.1im,
-                      tol=1e-11,displaylevel=1,maxit=300,armijo_factor=0.5)
+                      tol=1e-11,logger=1,maxit=300,armijo_factor=0.5)
 
       (λ2,V2)=get_deflated_eigpairs(dnep,λ,v)
       @show norm(compute_Mlincomb(nep,λ2[end],V2[:,end]))
@@ -70,7 +70,7 @@ begin
   dnep=deflate_eigpair(nep,λ,v,mode=:Generic);
   for k=1:2
       (λ,v)=augnewton(dnep,v=ones(size(dnep,1)),λ=200^2,
-                      tol=1e-11,displaylevel=1,maxit=300,armijo_factor=0.5)
+                      tol=1e-11,logger=1,maxit=300,armijo_factor=0.5)
 
       (λ2,V2)=get_deflated_eigpairs(dnep,λ,v)
       @show norm(compute_Mlincomb(nep,λ2[end],V2[:,end]))
@@ -94,7 +94,7 @@ begin
   dnep=deflate_eigpair(nep,λ,v,mode=:MM);
   for k=1:4
       (λ,v)=augnewton(dnep,v=ones(size(dnep,1)),λ=-1+0.1im,
-                      tol=1e-11,displaylevel=1,maxit=300,armijo_factor=0.5)
+                      tol=1e-11,logger=1,maxit=300,armijo_factor=0.5)
 
       (λ2,V2)=get_deflated_eigpairs(dnep,λ,v)
       @show norm(compute_Mlincomb(nep,λ2[end],V2[:,end]))
@@ -124,14 +124,14 @@ dnep=deflate_eigpair(nep,λ,v,mode=:Generic);
 
 asd()
 (λ,v)=augnewton(dnep,v=ones(size(dnep,1)),λ=300^2,
-                tol=1e-11,displaylevel=1,maxit=300,armijo_factor=0.5)
+                tol=1e-11,logger=1,maxit=300,armijo_factor=0.5)
 
 dnep=deflate_eigpair(dnep,λ,v);
 (λ,v)=augnewton(dnep,v=ones(size(dnep,1)),λ=300^2,
-                tol=1e-11,displaylevel=1,maxit=300,armijo_factor=0.5)
+                tol=1e-11,logger=1,maxit=300,armijo_factor=0.5)
 dnep=deflate_eigpair(dnep,λ,v);
 (λ,v)=augnewton(dnep,v=ones(size(dnep,1)),λ=300^2,
-                tol=1e-11,displaylevel=1,maxit=300,armijo_factor=0.5)
+                tol=1e-11,logger=1,maxit=300,armijo_factor=0.5)
 
 (λ,V)=get_deflated_eigpairs(dnep)
 
@@ -144,11 +144,11 @@ n=size(nep,1);
 dnep=deflate(dnep,λ,v)
 
 (λ,v)=augnewton(dnep,v=ones(size(dnep,1)),λ=300^2,
-                tol=1e-11,displaylevel=1,maxit=300,armijo_factor=0.5)
+                tol=1e-11,logger=1,maxit=300,armijo_factor=0.5)
 dnep=deflate(dnep,λ,v)
 
 (λ,v)=augnewton(dnep,v=ones(size(dnep,1)),λ=300^2,
-                tol=1e-11,displaylevel=1,maxit=300,armijo_factor=0.5)
+                tol=1e-11,logger=1,maxit=300,armijo_factor=0.5)
 
 
 
@@ -197,7 +197,7 @@ begin
         #λ,V=get_deflated_eigpairs(dnep);
         @show norm(compute_Mlincomb(nep,λ[end],V[:,end]))
         (λ,v)=augnewton(dnep,v=ones(size(dnep,1)),λ=300^2,
-                        tol=1e-11,displaylevel=1,maxit=300,armijo_factor=0.5)
+                        tol=1e-11,logger=1,maxit=300,armijo_factor=0.5)
 
         V=V1;
         S=S1;
@@ -259,7 +259,7 @@ dnep2_new=create_spmf_dnep(nep,S1,V1)
 #compute_MM(dnep3b,Z,X)-compute_MM(dnep3,Z,X)
 
 (λ3,v3)=quasinewton(dnep2_new,λ=300^2,armijo_factor=0.9,
-                    displaylevel=1,maxit=100,v=ones(n+2),tol=1e-12)
+                    logger=1,maxit=100,v=ones(n+2),tol=1e-12)
 
 V=V1;
 S=S1;
@@ -282,7 +282,7 @@ dnep3_new=create_spmf_dnep(nep,S1,V1)
 #compute_MM(dnep3b,Z,X)-compute_MM(dnep3,Z,X)
 
 (λ4,v4)=quasinewton(dnep3_new,λ=295^2,armijo_factor=0.9,
-                    displaylevel=1,maxit=200,v=ones(n+3),tol=1e-12)
+                    logger=1,maxit=200,v=ones(n+3),tol=1e-12)
 
 normalize!(v4)
 
@@ -307,7 +307,7 @@ normalize_schur_pair!(S1,V1);
 dnep4_new=create_spmf_dnep(nep,S1,V1)
 
 (λ5,v5)=quasinewton(dnep4_new,λ=295^2,armijo_factor=0.9,
-                    displaylevel=1,maxit=200,v=ones(n+4),tol=1e-12)
+                    logger=1,maxit=200,v=ones(n+4),tol=1e-12)
 
 V=V1;
 S=S1;

--- a/test/dep_distributed.jl
+++ b/test/dep_distributed.jl
@@ -48,7 +48,7 @@ end
 
 
     (λ,V)=iar(dep,σ=3,Neig=5,errmeasure=MyErrmeasure, v=ones(n),
-              displaylevel=displaylevel,maxit=100,tol=eps()*100)
+              logger=displaylevel,maxit=100,tol=eps()*100)
 
     @info λ
 

--- a/test/dtn_dimer.jl
+++ b/test/dtn_dimer.jl
@@ -18,8 +18,8 @@ using Test
 
 
     # Solve it:
-    (λs,vs)=quasinewton(nep,λ=1.099+1.006im,v=ones(n),displaylevel=displaylevel,tol=1e-5)
-    (λss,vss)=quasinewton(nep,λ=λs,v=vs,displaylevel=displaylevel)
+    (λs,vs)=quasinewton(nep,λ=1.099+1.006im,v=ones(n),logger=displaylevel,tol=1e-5)
+    (λss,vss)=quasinewton(nep,λ=λs,v=vs,logger=displaylevel)
 
     @test minimum(abs.(λss.-λv))<1e-10 # gives 1.4512316607747323e-12
 

--- a/test/fiber.jl
+++ b/test/fiber.jl
@@ -73,7 +73,7 @@ using GalleryNLEVP
         @info "Running MSLP"
 
         (λ,v)=mslp(Float64,nep_org,λ=7e-7,
-                   displaylevel=displaylevel,errmeasure=myerrmeasure,
+                   logger=displaylevel,errmeasure=myerrmeasure,
                    tol=tol)
         @test abs(sol_val-λ)/abs(λ) < tol
         if imag(λ) != 0

--- a/test/fiber.jl
+++ b/test/fiber.jl
@@ -63,7 +63,7 @@ using GalleryNLEVP
         @info "Running resinv"
         tol=1e-8
         (λ,v)=resinv(nep_org,λ=7e-7,v=ones(n),
-                     displaylevel=displaylevel,errmeasure=myerrmeasure,
+                     logger=displaylevel,errmeasure=myerrmeasure,
                      tol=tol)
         @test abs(sol_val-λ)/abs(λ) < tol
         if imag(λ) != 0

--- a/test/fiber.jl
+++ b/test/fiber.jl
@@ -37,7 +37,7 @@ using GalleryNLEVP
 
 
         @info "Running Newton"
-        (λstar,v)=newton(Float64,nep_org,λ=7e-7,v=ones(n),displaylevel=displaylevel,
+        (λstar,v)=newton(Float64,nep_org,λ=7e-7,v=ones(n),logger=displaylevel,
                          tol=1e-14)
 
         @test abs(sol_val-λstar)/abs(λ) < 1e-10
@@ -52,7 +52,7 @@ using GalleryNLEVP
 
         tol=1e-11
         (λ,v)=quasinewton(nep_org,λ=7.1e-7,v=ones(n),
-                          displaylevel=displaylevel,errmeasure=myerrmeasure,
+                          logger=displaylevel,errmeasure=myerrmeasure,
                           tol=tol,armijo_factor=0.5,armijo_max=10)
 
         @test abs(sol_val-λ)/abs(λ) < tol

--- a/test/fiber.jl
+++ b/test/fiber.jl
@@ -90,7 +90,7 @@ using GalleryNLEVP
         @info "Interpolating: $intpoints"
         pep=interpolate(nep_org,intpoints);
         @info "Running IAR"
-        λ,v=iar(pep,σ=7e-7,maxit=100,displaylevel=displaylevel,Neig=2)
+        λ,v=iar(pep,σ=7e-7,maxit=100,logger=displaylevel,Neig=2)
         minerr1=minimum(abs.(sol_val.-λ)) ./ abs(sol_val)
         @info "Error: $minerr1"
         @test minerr1<1e-4
@@ -102,7 +102,7 @@ using GalleryNLEVP
         @info "Interpolating: $intpoints"
         pep=interpolate(nep_org,intpoints);
         @info "Running IAR"
-        λ,v=iar(pep,σ=7e-7,maxit=100,displaylevel=displaylevel,Neig=2)
+        λ,v=iar(pep,σ=7e-7,maxit=100,logger=displaylevel,Neig=2)
         minerr2=minimum(abs.(sol_val.-λ)) ./ abs(sol_val)
         @info "Error: $minerr2"
         @test minerr2<minerr1

--- a/test/fiber_native.jl
+++ b/test/fiber_native.jl
@@ -19,7 +19,7 @@ using LinearAlgebra
     # check that we "maintain" real arithmetic
     vv=real(v/v[1]);
     (λ1,v)=resinv(Float64,nep,λ=7.14e-7,v=vv,
-                      displaylevel=displaylevel)
+                      logger=displaylevel)
     @test abs(λ-sol_val)<1e-10;
 
     @test eltype(v)==Float64

--- a/test/fiber_native.jl
+++ b/test/fiber_native.jl
@@ -12,7 +12,7 @@ using LinearAlgebra
     sol_val= 7.139494306065948e-07;
 
     (λ,v)=quasinewton(nep,λ=7.14e-7,v=ones(n),
-                      displaylevel=displaylevel, armijo_factor=0.5,armijo_max=10)
+                      logger=displaylevel, armijo_factor=0.5,armijo_max=10)
 
     @test abs(λ-sol_val)<1e-10;
 

--- a/test/gallery.jl
+++ b/test/gallery.jl
@@ -111,7 +111,7 @@ using Test
     v0=normalize!(compute_Mder(nep,λ0)\ones(size(nep,1)))
     λ,v=quasinewton(Float64,nep,λ=-1.4566,v=v0,tol=tol,
                     errmeasure=ResidualErrmeasure,
-                    displaylevel=displaylevel,armijo_factor=0.5,armijo_max=3)
+                    logger=displaylevel,armijo_factor=0.5,armijo_max=3)
     normalize!(v)
     @test norm(compute_Mlincomb(nep,λ,v))<sqrt(tol)
     @test isa(nep,SPMFSumNEP)

--- a/test/gallery.jl
+++ b/test/gallery.jl
@@ -184,7 +184,7 @@ using Test
     @test rank(M)<size(M,1)
     @onlybench @testset "bem_fichera + IAR" begin
        v=ones(size(nep,1));
-       (λ,vv)=iar(nep,σ=9,v=v,displaylevel=displaylevel,Neig=4,maxit=50,tol=1e-6) # normally takes 30 iterations
+       (λ,vv)=iar(nep,σ=9,v=v,logger=displaylevel,Neig=4,maxit=50,tol=1e-6) # normally takes 30 iterations
        @test norm(compute_Mlincomb(nep,λ[1],vv[:,1]))<sqrt(eps());
     end
     @info "non-existing example"

--- a/test/gun.jl
+++ b/test/gun.jl
@@ -15,7 +15,7 @@ using GalleryNLEVP
     n=size(nep1,1);
     tol=1e-11;
     @bench @testset "Running alg" begin
-        λ1,v1=quasinewton(nep1,λ=150^2+1im,v=ones(n),displaylevel=displaylevel,tol=tol,maxit=500);
+        λ1,v1=quasinewton(nep1,λ=150^2+1im,v=ones(n),logger=displaylevel,tol=tol,maxit=500);
         λ1 = λ1[1]
         v1 = vec(v1)
         normalize!(v1)
@@ -47,7 +47,7 @@ using GalleryNLEVP
         # Check that two steps of quasinewton always gives the same result
         λ_org=0
         try
-            quasinewton(nep_org,maxit=2,λ=150^2+1im,v=ones(n),displaylevel=displaylevel)
+            quasinewton(nep_org,maxit=2,λ=150^2+1im,v=ones(n),logger=displaylevel)
         catch e
             λ_org=e.λ
         end
@@ -55,7 +55,7 @@ using GalleryNLEVP
 
         λ1=0
         try
-            quasinewton(nep1,maxit=2,λ=150^2+1im,v=ones(n),displaylevel=displaylevel)
+            quasinewton(nep1,maxit=2,λ=150^2+1im,v=ones(n),logger=displaylevel)
         catch e
             λ1=e.λ
         end

--- a/test/gun_native.jl
+++ b/test/gun_native.jl
@@ -10,7 +10,7 @@ using LinearAlgebra
     ref_eigenvalue = 22345.116783765 + 0.644998598im # from NLEIGS
 
     @bench @testset "Running algorithm" begin
-        λ1,v1 = quasinewton(nep, λ = 150^2+1im, v = ones(n), displaylevel = displaylevel, tol = tol, maxit = 500)
+        λ1,v1 = quasinewton(nep, λ = 150^2+1im, v = ones(n), logger = displaylevel, tol = tol, maxit = 500)
 
         v1 = v1 / norm(v1)
 

--- a/test/iar.jl
+++ b/test/iar.jl
@@ -23,13 +23,13 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
 
     @bench @testset "accuracy eigenpairs" begin
         (λ,Q)=iar(dep,σ=3,Neig=5,v=ones(n),
-                  displaylevel=0,maxit=100,tol=eps()*100,errmeasure=ResidualErrmeasure);
+                  maxit=100,tol=eps()*100,errmeasure=ResidualErrmeasure);
         verify_lambdas(5, dep, λ, Q, eps()*100)
     end
 
     @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
         (λ,Q)=iar(dep,σ=3,Neig=Inf,v=ones(n),
-                  displaylevel=0,maxit=38,tol=eps()*100);
+                  maxit=38,tol=eps()*100);
         verify_lambdas(3, dep, λ, Q, eps()*100)
     end
 
@@ -37,22 +37,22 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
         # NOW TEST DIFFERENT ORTHOGONALIZATION METHODS
 
         @bench @testset "DGKS" begin
-            (λ,Q,err,V)=iar(dep,orthmethod=DGKS,σ=3,Neig=5,v=ones(n),displaylevel=0,maxit=100,tol=eps()*100)
+            (λ,Q,err,V)=iar(dep,orthmethod=DGKS,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
             @test opnorm(V'*V - I) < 1e-6
         end
 
         @bench @testset "User provided doubleGS" begin
-            (λ,Q,err,V)=iar(dep,orthmethod=DoubleGS,σ=3,Neig=5,v=ones(n),displaylevel=0,maxit=100,tol=eps()*100)
+            (λ,Q,err,V)=iar(dep,orthmethod=DoubleGS,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
             @test opnorm(V'*V - I) < 1e-6
         end
 
         @bench @testset "ModifiedGramSchmidt" begin
-            (λ,Q,err,V)=iar(dep,orthmethod=ModifiedGramSchmidt,σ=3,Neig=5,v=ones(n),displaylevel=0,maxit=100,tol=eps()*100)
+            (λ,Q,err,V)=iar(dep,orthmethod=ModifiedGramSchmidt,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
             @test opnorm(V'*V - I) < 1e-6
         end
 
         @bench @testset "ClassicalGramSchmidt" begin
-            (λ,Q,err,V)=iar(dep,orthmethod=ClassicalGramSchmidt,σ=3,Neig=5,v=ones(n),displaylevel=0,maxit=100,tol=eps()*100)
+            (λ,Q,err,V)=iar(dep,orthmethod=ClassicalGramSchmidt,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
             @test opnorm(V'*V - I) < 1e-6
         end
     end
@@ -61,7 +61,7 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
         np=100;
         dep=nep_gallery("dep0",np);
         @test_throws NEPCore.NoConvergenceException (λ,Q)=iar(dep,σ=3,Neig=6,v=ones(np),
-                  displaylevel=0,maxit=7,tol=eps()*100);
+                  maxit=7,tol=eps()*100);
     end
 
 end

--- a/test/iar.jl
+++ b/test/iar.jl
@@ -27,6 +27,12 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
         verify_lambdas(5, dep, λ, Q, eps()*100)
     end
 
+    @bench @testset "Solve by projection" begin
+        (λ,Q)=iar(dep,σ=3,Neig=5,v=ones(n),
+                  maxit=100,tol=eps()*100,errmeasure=ResidualErrmeasure, proj_solve=true);
+        verify_lambdas(5, dep, λ, Q, eps()*100)
+    end
+
     @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
         (λ,Q)=iar(dep,σ=3,Neig=Inf,v=ones(n),
                   maxit=38,tol=eps()*100);

--- a/test/iar.jl
+++ b/test/iar.jl
@@ -37,22 +37,22 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
         # NOW TEST DIFFERENT ORTHOGONALIZATION METHODS
 
         @bench @testset "DGKS" begin
-            (λ,Q,err,V)=iar(dep,orthmethod=DGKS,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
+            (λ,Q,V)=iar(dep,orthmethod=DGKS,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
             @test opnorm(V'*V - I) < 1e-6
         end
 
         @bench @testset "User provided doubleGS" begin
-            (λ,Q,err,V)=iar(dep,orthmethod=DoubleGS,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
+            (λ,Q,V)=iar(dep,orthmethod=DoubleGS,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
             @test opnorm(V'*V - I) < 1e-6
         end
 
         @bench @testset "ModifiedGramSchmidt" begin
-            (λ,Q,err,V)=iar(dep,orthmethod=ModifiedGramSchmidt,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
+            (λ,Q,V)=iar(dep,orthmethod=ModifiedGramSchmidt,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
             @test opnorm(V'*V - I) < 1e-6
         end
 
         @bench @testset "ClassicalGramSchmidt" begin
-            (λ,Q,err,V)=iar(dep,orthmethod=ClassicalGramSchmidt,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
+            (λ,Q,V)=iar(dep,orthmethod=ClassicalGramSchmidt,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
             @test opnorm(V'*V - I) < 1e-6
         end
     end

--- a/test/iar_chebyshev.jl
+++ b/test/iar_chebyshev.jl
@@ -86,12 +86,12 @@ end
 
     dep=nep_gallery("dep0"); n=size(dep,1);
     @bench @testset "accuracy eigenpairs" begin
-        (λ,Q)=iar_chebyshev(dep,σ=0,Neig=5,displaylevel=0,maxit=100,tol=eps()*100);
+        (λ,Q)=iar_chebyshev(dep,σ=0,Neig=5,logger=0,maxit=100,tol=eps()*100);
         verify_lambdas(5, dep, λ, Q, n*sqrt(eps()))
     end
 
     @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
-        (λ,Q)=iar_chebyshev(dep,σ=0,Neig=Inf,displaylevel=0,maxit=30,tol=eps()*100);
+        (λ,Q)=iar_chebyshev(dep,σ=0,Neig=Inf,logger=0,maxit=30,tol=eps()*100);
         verify_lambdas(8, dep, λ, Q, n*sqrt(eps()))
     end
 
@@ -101,22 +101,22 @@ end
 
     # NOW TEST DIFFERENT ORTHOGONALIZATION METHODS
     @bench @testset "DGKS" begin
-        (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=DGKS,σ=0,Neig=5,displaylevel=0,maxit=100,tol=eps()*100)
+        (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=DGKS,σ=0,Neig=5,logger=0,maxit=100,tol=eps()*100)
         @test opnorm(V'*V - Matrix(1.0I, size(V,2), size(V,2))) < n*sqrt(eps())
      end
 
      @bench @testset "User provided doubleGS" begin
-         (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=DoubleGS,σ=0,Neig=5,displaylevel=0,maxit=100,tol=eps()*100)
+         (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=DoubleGS,σ=0,Neig=5,logger=0,maxit=100,tol=eps()*100)
          @test opnorm(V'*V - Matrix(1.0I, size(V,2), size(V,2))) < n*sqrt(eps())
       end
 
       @bench @testset "ModifiedGramSchmidt" begin
-          (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=ModifiedGramSchmidt,σ=0,Neig=5,displaylevel=0,maxit=100,tol=eps()*100)
+          (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=ModifiedGramSchmidt,σ=0,Neig=5,logger=0,maxit=100,tol=eps()*100)
           @test opnorm(V'*V - Matrix(1.0I, size(V,2), size(V,2))) < n*sqrt(eps())
       end
 
        @bench @testset "ClassicalGramSchmidt" begin
-           (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=ClassicalGramSchmidt,σ=0,Neig=5,displaylevel=0,maxit=100,tol=eps()*100)
+           (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=ClassicalGramSchmidt,σ=0,Neig=5,logger=0,maxit=100,tol=eps()*100)
            @test opnorm(V'*V - Matrix(1.0I, size(V,2), size(V,2))) < n*sqrt(eps())
        end
     end
@@ -130,7 +130,7 @@ end
                 A[j+1]=rand(n,n)
             end
             nep=PEP(A)
-            (λ,Q)=iar_chebyshev(nep,σ=0,Neig=5,displaylevel=0,maxit=100,tol=eps()*100)
+            (λ,Q)=iar_chebyshev(nep,σ=0,Neig=5,logger=0,maxit=100,tol=eps()*100)
 
             verify_lambdas(5, nep, λ, Q, n*sqrt(eps()))
         end
@@ -141,7 +141,7 @@ end
             nep = SPMF_NEP([sparse(1.0I, n, n), A0, A1], [λ -> -λ, λ -> one(λ), λ -> exp(-λ)])
 
             compute_Mlincomb(nep::DEP,λ::Number,V;a=ones(size(V,2)))=compute_Mlincomb_from_MM!(nep,λ,V,a)
-            (λ,Q,err)=iar_chebyshev(nep,σ=0,γ=1,Neig=7,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=1,a=-1,b=2)
+            (λ,Q,err)=iar_chebyshev(nep,σ=0,γ=1,Neig=7,logger=0,maxit=100,tol=eps()*100,check_error_every=1,a=-1,b=2)
 
             verify_lambdas(7, nep, λ, Q, n*sqrt(eps()))
         end
@@ -150,14 +150,14 @@ end
             n=100; A1=rand(n,n); A2=rand(n,n); A3=rand(n,n);
             tau1=0; tau2=1.1; tau3=.2;
             nep=DEP([A1,A2,A3],[tau1,tau2,tau3])
-            (λ,Q)=iar_chebyshev(nep,σ=0,Neig=3,displaylevel=0,maxit=90,tol=eps()*100)
+            (λ,Q)=iar_chebyshev(nep,σ=0,Neig=3,logger=0,maxit=90,tol=eps()*100)
 
             verify_lambdas(3, nep, λ, Q, n*sqrt(eps()))
         end
 
         @bench @testset "DEP SHIFTED AND SCALED" begin
             nep=nep_gallery("dep0_tridiag",1000)
-            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2;Neig=5,displaylevel=0,maxit=100,tol=eps()*100)
+            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2;Neig=5,logger=0,maxit=100,tol=eps()*100)
             verify_lambdas(5, nep, λ, Q, n*sqrt(eps()))
         end
 
@@ -168,7 +168,7 @@ end
                 A[j+1]=rand(n,n)
             end
             nep=PEP(A)
-            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2;Neig=5,displaylevel=0,maxit=100,tol=eps()*100)
+            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2;Neig=5,logger=0,maxit=100,tol=eps()*100)
 
             verify_lambdas(5, nep, λ, Q, n*sqrt(eps()))
         end
@@ -176,17 +176,17 @@ end
         @bench @testset "compute_y0 AS INPUT FOR QEP (naive)" begin
             A0=rand(n,n); A1=rand(n,n); A2=rand(n,n);
             nep = SPMF_NEP([A0, A1, A2], [λ -> one(λ), λ -> λ, λ -> λ^2])
-            λ,Q,err,V = iar_chebyshev(nep,compute_y0_method=ComputeY0Cheb_QEP,maxit=100,Neig=10,σ=0.0,γ=1,displaylevel=0,check_error_every=1);
+            λ,Q,err,V = iar_chebyshev(nep,compute_y0_method=ComputeY0Cheb_QEP,maxit=100,Neig=10,σ=0.0,γ=1,logger=0,check_error_every=1);
 
             verify_lambdas(10, nep, λ, Q, n*sqrt(eps()))
         end
 
         @bench @testset "QDEP IN SPMF format" begin
             nep=nep_gallery("qdep1")
-            λ,Q,err,V = iar_chebyshev(nep,maxit=100,Neig=8,σ=0.0,γ=1,displaylevel=0,check_error_every=1);
+            λ,Q,err,V = iar_chebyshev(nep,maxit=100,Neig=8,σ=0.0,γ=1,logger=0,check_error_every=1);
             verify_lambdas(8, nep, λ, Q, n*sqrt(eps()))
             # with scaling
-            λ,Q,err,V = iar_chebyshev(nep,maxit=100,Neig=8,σ=0.0,γ=0.9,displaylevel=0,check_error_every=1);
+            λ,Q,err,V = iar_chebyshev(nep,maxit=100,Neig=8,σ=0.0,γ=0.9,logger=0,check_error_every=1);
             verify_lambdas(8, nep, λ, Q, n*sqrt(eps()))
         end
 
@@ -194,16 +194,16 @@ end
             A0=rand(n,n); A1=rand(n,n); A2=rand(n,n);
             nep = SPMF_NEP([A0, A1, A2], [λ -> one(λ), λ -> λ, λ -> λ^2])
 
-            λ,Q,err,V = iar_chebyshev(nep,maxit=100,Neig=10,σ=0.0,γ=1,displaylevel=0,check_error_every=1,v=ones(n));
+            λ,Q,err,V = iar_chebyshev(nep,maxit=100,Neig=10,σ=0.0,γ=1,logger=0,check_error_every=1,v=ones(n));
             verify_lambdas(10, nep, λ, Q, n*sqrt(eps()))
 
-            λ2,Q2,err2,V2, H2 = iar_chebyshev(nep,maxit=100,Neig=20,σ=0.0,γ=1,displaylevel=0,check_error_every=1,compute_y0_method=ComputeY0Cheb,v=ones(n));
+            λ2,Q2,err2,V2, H2 = iar_chebyshev(nep,maxit=100,Neig=20,σ=0.0,γ=1,logger=0,check_error_every=1,compute_y0_method=ComputeY0Cheb,v=ones(n));
             @test opnorm(V[:,1:10]-V2[:,1:10])<n*sqrt(eps());
         end
 
         @bench @testset "DEP format with ComputeY0ChebSPMF_NEP" begin
             nep=nep_gallery("dep0_tridiag",1000)
-            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2;Neig=5,displaylevel=0,maxit=100,tol=eps()*100,compute_y0_method=NEPSolver.ComputeY0ChebSPMF_NEP)
+            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2;Neig=5,logger=0,maxit=100,tol=eps()*100,compute_y0_method=NEPSolver.ComputeY0ChebSPMF_NEP)
             verify_lambdas(5, nep, λ, Q, 1e-10)
         end
 
@@ -214,18 +214,18 @@ end
                 A[j+1]=rand(n,n)
             end
             nep=PEP(A)
-            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2,Neig=5,displaylevel=0,maxit=100,tol=eps()*100,compute_y0_method=NEPSolver.ComputeY0ChebSPMF_NEP)
+            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2,Neig=5,logger=0,maxit=100,tol=eps()*100,compute_y0_method=NEPSolver.ComputeY0ChebSPMF_NEP)
 
             verify_lambdas(5, nep, λ, Q, 1e-10)
         end
 
         @bench @testset "compute_y0 AS INPUT FOR QDEP (combine DEP and PEP)" begin
             nep=nep_gallery("qdep1")
-            λ,Q,err,V,H = iar_chebyshev(nep,compute_y0_method=ComputeY0Cheb_QDEP,maxit=100,Neig=10,displaylevel=0,
+            λ,Q,err,V,H = iar_chebyshev(nep,compute_y0_method=ComputeY0Cheb_QDEP,maxit=100,Neig=10,logger=0,
                                         check_error_every=1,v=ones(size(nep,1)));
             verify_lambdas(10, nep, λ, Q, 1e-10)
 
-            λ2,Q2,err2,V2,H2 = iar_chebyshev(nep,compute_y0_method=ComputeY0Cheb_QDEP,maxit=100,Neig=10,displaylevel=0,
+            λ2,Q2,err2,V2,H2 = iar_chebyshev(nep,compute_y0_method=ComputeY0Cheb_QDEP,maxit=100,Neig=10,logger=0,
                                         check_error_every=1,v=ones(size(nep,1)));
             verify_lambdas(10, nep, λ, Q, 1e-10)
 
@@ -236,6 +236,6 @@ end
     @testset "Errors thrown" begin
         np=100;
         dep=nep_gallery("dep0",np);
-        @test_throws NEPCore.NoConvergenceException (λ,Q)=iar_chebyshev(dep,σ=0,Neig=8,displaylevel=0,maxit=10,tol=eps()*100);
+        @test_throws NEPCore.NoConvergenceException (λ,Q)=iar_chebyshev(dep,σ=0,Neig=8,logger=0,maxit=10,tol=eps()*100);
     end
 end

--- a/test/ilan.jl
+++ b/test/ilan.jl
@@ -20,7 +20,7 @@ using SparseArrays
         nep=DEP([A1,A2,A3],[0,1,0.8])
         v0=rand(n)
         V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0,errmeasure=ResidualErrmeasure)
-        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=Inf,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0,errmeasure=ResidualErrmeasure)
+        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=Inf,logger=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0,errmeasure=ResidualErrmeasure)
 
         # Disabled. This unit test requires rewriting (and ilan_benchmark can be removed)
         @test norm(V-V2)<sqrt(eps())
@@ -44,7 +44,7 @@ using SparseArrays
 
         f1= S -> -S; f2= S -> one(S); f3= S -> exp(-S); f4= S -> exp(-0.8*S)
         nep=SPMF_NEP([one(A1),A1,A2,A3],[f1,f2,f3,f4])
-        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=Inf,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
+        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=Inf,logger=0,maxit=10,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
 
         @test norm(V-V2)<sqrt(eps())
         @test norm(H-H2)<sqrt(eps())
@@ -61,7 +61,7 @@ using SparseArrays
         A3 = sparse(K, J, rand(3*n-2)); A3 = A3+A3';
         nep=DEP([A1,A2,A3],[0,1,0.8])
         v0=rand(n)
-        λ,W,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=Inf,displaylevel=0,maxit=30,tol=eps()*100,check_error_every=5,v=v0,errmeasure=ResidualErrmeasure)
+        λ,W,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=Inf,logger=0,maxit=30,tol=eps()*100,check_error_every=5,v=v0,errmeasure=ResidualErrmeasure)
         verify_lambdas(2, nep, λ, W, eps()*100)
     end
 
@@ -74,7 +74,7 @@ using SparseArrays
         A3 = sparse(K, J, rand(3*n-2)); A3 = A3+A3';
         nep=DEP([A1,A2,A3],[0,1,0.8])
         v0=rand(n)
-        @test_throws NEPCore.NoConvergenceException λ,W,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=2,displaylevel=0,maxit=3,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
+        @test_throws NEPCore.NoConvergenceException λ,W,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=2,logger=0,maxit=3,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
     end
 
 end

--- a/test/infbilanczos.jl
+++ b/test/infbilanczos.jl
@@ -11,7 +11,7 @@ using LinearAlgebra
     n=size(nep,1);
 
     m=40;
-    λ,V,T = infbilanczos(Float64,nep,nept,maxit=m,Neig=3,σ=0,displaylevel=displaylevel,
+    λ,V,T = infbilanczos(Float64,nep,nept,maxit=m,Neig=3,σ=0,logger=displaylevel,
                          v=ones(Float64,n),u=ones(Float64,n),check_error_every=3,
                          tol=1e-7, errmeasure=ResidualErrmeasure);
 
@@ -32,7 +32,7 @@ using LinearAlgebra
 
     @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
         m=30;
-        λ,V,T = infbilanczos(Float64,nep,nept,maxit=m,Neig=Inf,σ=0,displaylevel=displaylevel,
+        λ,V,T = infbilanczos(Float64,nep,nept,maxit=m,Neig=Inf,σ=0,logger=displaylevel,
                              v=ones(Float64,n),u=ones(Float64,n),check_error_every=3,
                              tol=1e-7, errmeasure=ResidualErrmeasure);
         verify_lambdas(3, nep, λ, V, 1e-6)
@@ -40,7 +40,7 @@ using LinearAlgebra
 
 
     @testset "Errors thrown" begin
-        @test_throws NEPCore.NoConvergenceException λ,V,T = infbilanczos(Float64,nep,nept,maxit=9,Neig=8,σ=0,displaylevel=displaylevel,
+        @test_throws NEPCore.NoConvergenceException λ,V,T = infbilanczos(Float64,nep,nept,maxit=9,Neig=8,σ=0,logger=displaylevel,
                              v=ones(Float64,n),u=ones(Float64,n),check_error_every=3,
                              tol=1e-7, errmeasure=ResidualErrmeasure);
     end

--- a/test/inner_solves.jl
+++ b/test/inner_solves.jl
@@ -19,11 +19,19 @@ using LinearAlgebra
     Q = Matrix(Q)
     set_projectmatrices!(pnep,Q,Q)
 
-    λv,V = inner_solve(DefaultInnerSolver, ComplexF64, pnep; λv=[0.0,1.0] .+ 0im, Neig=3, V=ones(k, 2), tol=eps()*100)
+    logger=ErrorLogger(1,100,0);
+    λv,V = inner_solve(DefaultInnerSolver, ComplexF64, pnep; λv=[0.0,1.0] .+ 0im, Neig=3, V=ones(k, 2), tol=eps()*100, inner_logger=logger)
     verify_lambdas(2, pnep, λv, V, eps()*500)
+    E=logger.errs[:,1]; E=E[(!isnan).(E)];
+    @test length(E) > 5 #Has done more than 5 iterations
+    @test E[end] < eps()*100 # Error measure fulfills stopping criteria
 
-    λv,V = inner_solve(NewtonInnerSolver, ComplexF64, pnep; λv=[0.0,1.0] .+ 0im, V=ones(k, 2), tol=eps()*100)
+    logger=ErrorLogger(1,100,0);
+    λv,V = inner_solve(NewtonInnerSolver, ComplexF64, pnep; λv=[0.0,1.0] .+ 0im, V=ones(k, 2), tol=eps()*100, inner_logger=logger)
     verify_lambdas(2, pnep, λv, V, eps()*500)
+    E=logger.errs[:,1]; E=E[(!isnan).(E)];
+    @test length(E) > 5 #Has done more than 5 iterations
+    @test E[end] < eps()*100 # Error measure fulfills stopping criteria
 
     #λv,V=inner_solve(SGIterInnerSolver,pnep,λv=[0.0],j=1);
     #verify_lambdas(2, pnep, λv, V, eps()*500)

--- a/test/interpolation.jl
+++ b/test/interpolation.jl
@@ -10,20 +10,20 @@ using LinearAlgebra
 #########################################################################################
 @bench @testset "Random dep" begin
 nep = nep_gallery("dep0")
-λ1,x1 = newton(nep,displaylevel=displaylevel,maxit=40, λ=-0.75, v=ones(size(nep,1)));
+λ1,x1 = newton(nep,logger=displaylevel,maxit=40, λ=-0.75, v=ones(size(nep,1)));
 @test compute_resnorm(nep,λ1,x1) < eps()*100
 
 # Newton on interpolated dep (interpolating pep of degree 2)
 intpoints = [λ1-1, λ1, λ1+1.5]
 pep = interpolate(nep, intpoints)
-λ2,x2 = newton(pep,displaylevel=displaylevel,maxit=40, λ=-0.75, v=ones(size(nep,1)));
+λ2,x2 = newton(pep,logger=displaylevel,maxit=40, λ=-0.75, v=ones(size(nep,1)));
 @test compute_resnorm(pep,λ2,x2) < eps()*100
 @test abs(λ1-λ2)/abs(λ1) < eps()*1000
 
 # Newton on interpolated dep (interpolating pep of degree 8)
 intpoints = [λ1-5, λ1-1, λ1, λ1+5, λ1+1, λ1+5im, λ1+1im, λ1-5im, λ1-1im]
 pep = interpolate(nep, intpoints)
-λ2,x2 = newton(pep,displaylevel=displaylevel,maxit=40, λ=-0.75, v=ones(size(nep,1)));
+λ2,x2 = newton(pep,logger=displaylevel,maxit=40, λ=-0.75, v=ones(size(nep,1)));
 @test compute_resnorm(pep,λ2,x2) < eps()*100
 @test abs(λ1-λ2)/abs(λ1) < eps()*1000
 end
@@ -32,13 +32,13 @@ end
 @bench @testset "Random sparse dep" begin
 nep = nep_gallery("dep0_sparse", 30)
 
-λ1,x1 = newton(nep,displaylevel=displaylevel,maxit=40, λ=-0.75, v=ones(size(nep,1)));
+λ1,x1 = newton(nep,logger=displaylevel,maxit=40, λ=-0.75, v=ones(size(nep,1)));
 @test compute_resnorm(nep,λ1,x1) < eps()*100
 
 # Newton on interpolated sparse dep
 intpoints = [λ1-1, λ1, λ1+1.5]
 pep = interpolate(nep, intpoints)
-λ2,x2 = newton(pep,displaylevel=displaylevel,maxit=40, λ=-0.75, v=ones(size(nep,1)));
+λ2,x2 = newton(pep,logger=displaylevel,maxit=40, λ=-0.75, v=ones(size(nep,1)));
 @test compute_resnorm(pep,λ2,x2) < eps()*100
 @test abs(λ1-λ2)/abs(λ1) < eps()*1000
 
@@ -47,14 +47,14 @@ end
 #########################################################################################
 @bench @testset "Random pep (original pep of degree 2)" begin
 nep = nep_gallery("pep0")
-λ1,x1 = newton(nep,displaylevel=displaylevel,maxit=40, λ=1, v=ones(size(nep,1)));
+λ1,x1 = newton(nep,logger=displaylevel,maxit=40, λ=1, v=ones(size(nep,1)));
 @test compute_resnorm(nep,λ1,x1) < eps()*100
 
 
 #Newton on interpolated pep (interpolation of degree 2)
 intpoints = [λ1-1, λ1, λ1+1]
 pep = interpolate(nep, intpoints)
-λ2,x2 = newton(pep,displaylevel=displaylevel,maxit=40, λ=1, v=ones(size(nep,1)));
+λ2,x2 = newton(pep,logger=displaylevel,maxit=40, λ=1, v=ones(size(nep,1)));
 @test compute_resnorm(pep,λ2,x2) < eps()*100
 @test abs(λ1-λ2)/abs(λ1) < eps()*100
 
@@ -69,7 +69,7 @@ end
 intpoints = [λ1-3, λ1-1, λ1, λ1+1, λ1+3]
 
 pep = interpolate(Float64, nep, intpoints)
-λ2,x2 = newton(pep,displaylevel=displaylevel,maxit=40, λ=1, v=ones(size(nep,1)));
+λ2,x2 = newton(pep,logger=displaylevel,maxit=40, λ=1, v=ones(size(nep,1)));
 @test compute_resnorm(pep,λ2,x2) < eps()*100
 @test abs(λ1-λ2)/abs(λ1) < eps()*100
 
@@ -87,14 +87,14 @@ end
 #########################################################################################
 @bench @testset "Random sparse pep (original pep of degree 2)" begin
 nep=nep_gallery("pep0_sparse")
-λ1,x1 =newton(nep,displaylevel=displaylevel,maxit=40, λ=-0.75, v=ones(size(nep,1)));
+λ1,x1 =newton(nep,logger=displaylevel,maxit=40, λ=-0.75, v=ones(size(nep,1)));
 @test compute_resnorm(nep,λ1,x1) < eps()*100
 
 
 #Newton on interpolated sparse pep
 intpoints = [λ1-1, λ1, λ1+1.5]
 pep = interpolate(nep, intpoints)
-λ2,x2 =newton(pep,displaylevel=displaylevel,maxit=40, λ=-0.75, v=ones(size(nep,1)));
+λ2,x2 =newton(pep,logger=displaylevel,maxit=40, λ=-0.75, v=ones(size(nep,1)));
 @test compute_resnorm(pep,λ2,x2) < eps()*100
 @test abs(λ1-λ2)/abs(λ1) < eps()*100
 

--- a/test/jd.jl
+++ b/test/jd.jl
@@ -15,7 +15,7 @@ using LinearAlgebra
 @info "Testing a PEP"
 nep = nep_gallery("pep0",60)
 TOL = 1e-11;
-λ,u = jd_betcke(nep, tol=TOL, maxit=55, Neig = 3, displaylevel=displaylevel, v=ones(size(nep,1)),errmeasure=ResidualErrmeasure)
+λ,u = jd_betcke(nep, tol=TOL, maxit=55, Neig = 3, logger=displaylevel, v=ones(size(nep,1)),errmeasure=ResidualErrmeasure)
 @info " Smallest eigenvalue found: $λ"
 Dc,Vc = polyeig(nep,DefaultEigSolver)
 c = sortperm(abs.(Dc))
@@ -27,27 +27,27 @@ verify_lambdas(3, nep, λ, u, TOL)
 nep = nep_gallery("real_quadratic")
 nep = SPMF_NEP(get_Av(nep), get_fv(nep))
 TOL = 1e-10;
-λ,u=jd_betcke(Float64, nep, tol=TOL, maxit=4, displaylevel = displaylevel, projtype = :Galerkin, inner_solver_method = SGIterInnerSolver, v=ones(size(nep,1)))
+λ,u=jd_betcke(Float64, nep, tol=TOL, maxit=4, logger = displaylevel, projtype = :Galerkin, inner_solver_method = SGIterInnerSolver, v=ones(size(nep,1)))
 verify_lambdas(1, nep, λ, u, TOL)
 
 
 @info "Testing IAR Cheb as projected solver"
 nep = nep_gallery("dep0_sparse",40)
 TOL = 1e-10;
-λ,u = jd_betcke(ComplexF64, nep, tol=TOL, maxit=30, displaylevel = displaylevel, inner_solver_method = IARChebInnerSolver, v=ones(size(nep,1)))
+λ,u = jd_betcke(ComplexF64, nep, tol=TOL, maxit=30, logger = displaylevel, inner_solver_method = IARChebInnerSolver, v=ones(size(nep,1)))
 verify_lambdas(1, nep, λ, u, TOL)
 λ0 = λ[1] # store these for the next test
 v0 = vec(u)
 
 @info "Testing convergence before starting"
-λ,u=jd_betcke(nep, tol=TOL, maxit=25, Neig=1, displaylevel=displaylevel, λ=λ0, v=v0)
+λ,u=jd_betcke(nep, tol=TOL, maxit=25, Neig=1, logger=displaylevel, λ=λ0, v=v0)
 verify_lambdas(1, nep, λ, u, TOL)
 
 
 @info "Testing errors thrown"
 nep = nep_gallery("pep0",4)
 # Throw error if iterating more than the size of the NEP
-@test_throws ErrorException λ,u=jd_betcke(nep, tol=TOL, maxit=60, displaylevel = displaylevel, v=ones(size(nep,1)))
+@test_throws ErrorException λ,u=jd_betcke(nep, tol=TOL, maxit=60, logger = displaylevel, v=ones(size(nep,1)))
 # SG requires Galerkin projection type to keep Hermitian
 @test_throws ErrorException λ,u=jd_betcke(Float64, nep, tol=TOL, maxit=4, projtype = :PetrovGalerkin, inner_solver_method = SGIterInnerSolver, v=ones(size(nep,1)))
 # An undefined projection type
@@ -64,16 +64,16 @@ end
 
 TOL = 1e-10
 nep = nep_gallery("pep0",250)
-λ, u = jd_effenberger(nep, Neig=5, displaylevel=displaylevel, tol=TOL, maxit=80, λ=0.82+0.9im, v=ones(ComplexF64,size(nep,1)))
+λ, u = jd_effenberger(nep, Neig=5, logger=displaylevel, tol=TOL, maxit=80, λ=0.82+0.9im, v=ones(ComplexF64,size(nep,1)))
 verify_lambdas(5, nep, λ, u, TOL)
 
 TOL = 1e-10
 nep = nep_gallery("dep0",60)
-λ, u = jd_effenberger(nep, Neig=3, displaylevel=displaylevel, tol=TOL, maxit=55, λ=0.6+0im, v=ones(ComplexF64,size(nep,1)))#, inner_solver_method = IARChebInnerSolver)
+λ, u = jd_effenberger(nep, Neig=3, logger=displaylevel, tol=TOL, maxit=55, λ=0.6+0im, v=ones(ComplexF64,size(nep,1)))#, inner_solver_method = IARChebInnerSolver)
 verify_lambdas(3, nep, λ, u, TOL)
 
 @info "Testing convergence before starting"
-λ,u=jd_effenberger(nep, Neig=1, displaylevel=displaylevel, tol=TOL, maxit=55, λ=λ[1], v=vec(u[:,1]))
+λ,u=jd_effenberger(nep, Neig=1, logger=displaylevel, tol=TOL, maxit=55, λ=λ[1], v=vec(u[:,1]))
 verify_lambdas(1, nep, λ, u, TOL)
 
 

--- a/test/logger.jl
+++ b/test/logger.jl
@@ -1,0 +1,17 @@
+# Tests for NEP types functionality
+
+using NonlinearEigenproblemsTest
+using NonlinearEigenproblems
+using Test
+
+@bench @testset "logger (ErrorLogger)" begin
+    nep=nep_gallery("dep0")
+    logger=ErrorLogger(1,100,0);
+    λ1,x1 = newton(nep,logger=logger,v=ones(size(nep,1)),λ=0,tol=eps()*10)
+    E=logger.errs[:,1];
+    EE=E[(!isnan).(E)];
+    # Check "essentially" quad convergence
+    @test abs(log10(EE[end-1]^2)-log10(EE[end]))<2
+
+
+end

--- a/test/logger.jl
+++ b/test/logger.jl
@@ -12,6 +12,8 @@ using Test
     EE=E[(!isnan).(E)];
     # Check "essentially" quad convergence
     @test abs(log10(EE[end-1]^2)-log10(EE[end]))<2
+    @test length(EE) > 5 #Has done more than 5 iterations
+    @test EE[end] < eps()*10 # Error measure fulfills stopping criteria
 
 
 end

--- a/test/newton.jl
+++ b/test/newton.jl
@@ -14,8 +14,8 @@ using LinearAlgebra
 
         # newton and augnewton are equivalent, therefore I expect them
         # to generate identical results
-        λ1,x1 = newton(nep,displaylevel=displaylevel,v=ones(size(nep,1)),λ=0,tol=eps()*10)
-        λ2,x2 = augnewton(nep,displaylevel=displaylevel,v=ones(size(nep,1)),λ=0,tol=eps()*10)
+        λ1,x1 = newton(nep,logger=displaylevel,v=ones(size(nep,1)),λ=0,tol=eps()*10)
+        λ2,x2 = augnewton(nep,logger=displaylevel,v=ones(size(nep,1)),λ=0,tol=eps()*10)
         @test λ1 ≈ λ2
         @test x1 ≈ x2
         @test compute_resnorm(nep,λ1,x1) < eps()*100
@@ -26,7 +26,7 @@ using LinearAlgebra
     @bench @testset "QuasiNewton" begin
     @info "QuasiNewton  test"
 
-        λ,x = quasinewton(nep,displaylevel=displaylevel,v=ones(size(nep,1)),λ=0,tol=1e-12)
+        λ,x = quasinewton(nep,logger=displaylevel,v=ones(size(nep,1)),λ=0,tol=1e-12)
         @test compute_resnorm(nep,λ,x) < 1e-11*100
 
     end
@@ -35,7 +35,7 @@ using LinearAlgebra
 
         @info "Newton QR test"
         #Run derivative test for left and right eigenvectors returned by newtonqr
-        λ3,x3,y3 =  newtonqr(nep, λ=0, v=ones(size(nep,1)), displaylevel=displaylevel,tol=eps()*10)
+        λ3,x3,y3 =  newtonqr(nep, λ=0, v=ones(size(nep,1)), logger=displaylevel,tol=eps()*10)
         @test compute_resnorm(nep,λ3,x3) < eps()*100
 
         @info "  Testing formula for derivative"
@@ -49,7 +49,7 @@ using LinearAlgebra
         δ=0.0001
         nepp = deepcopy(nep)
         nepp.tauv[2] = nep.tauv[2]+δ
-        λ3δ,x3,y3 = newtonqr(nepp, λ=0, v=ones(size(nep,1)), displaylevel=displaylevel,tol=eps()*10)
+        λ3δ,x3,y3 = newtonqr(nepp, λ=0, v=ones(size(nep,1)), logger=displaylevel,tol=eps()*10)
         λp_approx = (λ3δ-λ3)/δ
         @test abs(λp-λp_approx)< (δ*10)
     end
@@ -59,7 +59,7 @@ using LinearAlgebra
         nep1=nep_gallery("periodicdde", name="mathieu")
         # basic functionality of resinv. Start close to solution to speed up unit test
         λ4,x4 =  resinv(nep1, λ=-0.2447, v=[0.970208+0.0im, -0.242272+0.0im],
-                        displaylevel=displaylevel,tol=eps()*10)
+                        logger=displaylevel,tol=eps()*10)
         r4=compute_resnorm(nep1,λ4,x4)
 
         @test r4 < eps()*100
@@ -108,7 +108,7 @@ using LinearAlgebra
     @bench @testset "implicitdet" begin
         @info "Implicitdet test"
         nepd=nep_gallery("periodicdde", name="mathieu")
-        λ,v=implicitdet(nepd, v=ones(size(nepd,1)), displaylevel=displaylevel)
+        λ,v=implicitdet(nepd, v=ones(size(nepd,1)), logger=displaylevel)
         @test norm(compute_Mder(nepd,λ)*v) < eps()*100
     end
 

--- a/test/newton.jl
+++ b/test/newton.jl
@@ -75,7 +75,7 @@ using LinearAlgebra
         v0=ones(n)
 
 
-        λ,x,y =rfi(nep, nept, displaylevel=displaylevel, v=ones(n), u=ones(n), tol=1e-15)
+        λ,x,y =rfi(nep, nept, logger=displaylevel, v=ones(n), u=ones(n), tol=1e-15)
         @test compute_resnorm(nep,λ,x) < eps()*100
         @test compute_resnorm(nept,λ,y) < eps()*100
 
@@ -83,7 +83,7 @@ using LinearAlgebra
         # Test RFIb
 
         @info "rfi_b"
-        λb,xb,yb =rfi_b(nep, nept, displaylevel=displaylevel, v=v0, u=u0, λ=λ+0.01, tol=1e-15)
+        λb,xb,yb =rfi_b(nep, nept, logger=displaylevel, v=v0, u=u0, λ=λ+0.01, tol=1e-15)
         @test λ ≈ λb
 
 
@@ -100,7 +100,7 @@ using LinearAlgebra
         nepp.tauv[2] = nep.tauv[2]+δ
         neptp = deepcopy(nept)
         neptp.tauv[2] = nept.tauv[2]+δ
-        λδ,x,y = rfi(nepp,neptp,displaylevel=displaylevel, v=ones(n), u=ones(n))
+        λδ,x,y = rfi(nepp,neptp,logger=displaylevel, v=ones(n), u=ones(n))
         λp_approx=(λδ-λ)/δ
         @test abs(λp-λp_approx)< (δ*10)
     end

--- a/test/nlar.jl
+++ b/test/nlar.jl
@@ -29,7 +29,7 @@ using Random
     nep1 = shift_and_scale(nep1_spmf,shift=shift,scale=scale);
 
     #Run NLAR on the shifted and scaled NEP (neigs set to 1 to save time. Method works for the case of finding multiple eigenvalues as well)
-    λ,u = nlar(nep1, tol=TOL, λ=0, maxit=100, neigs=2, R=0.01, displaylevel=displaylevel, v=ones(n),
+    λ,u = nlar(nep1, tol=TOL, λ=0, maxit=100, neigs=2, R=0.01, logger=displaylevel, v=ones(n),
         eigval_sorter=residual_eigval_sorter, inner_solver_method=IARInnerSolver,
         qrfact_orth=false, num_restart_ritz_vecs=8, max_subspace=150)
 
@@ -51,7 +51,7 @@ using Random
     c = sortperm(abs.(Dc))
     @info " 6 smallest eigenvalues found by polyeig() according to the absolute values: $(Dc[c[1:6]])"
 
-    λ,u = nlar(pepnep, tol=TOL, maxit=60, neigs=3, R=0.001, displaylevel=displaylevel,
+    λ,u = nlar(pepnep, tol=TOL, maxit=60, neigs=3, R=0.001, logger=displaylevel,
         λ=Dc[4]+1e-2, v=ones(size(pepnep,1)), eigval_sorter=residual_eigval_sorter,
         inner_solver_method=IARInnerSolver, qrfact_orth=false, errmeasure=ResidualErrmeasure)
 

--- a/test/nlar.jl
+++ b/test/nlar.jl
@@ -21,7 +21,7 @@ using Random
     scale = 330^2-220^2;
 
     #Run Quasi-Newton for initial guess obtained from the knowledge of the eigenvalue distribution
-    λ_ref,v_ref = quasinewton(nep, λ = shift+scale*(-0.131403+0.00759532im), v = ones(n), displaylevel = displaylevel, tol = TOL/50, maxit = 500)
+    λ_ref,v_ref = quasinewton(nep, λ = shift+scale*(-0.131403+0.00759532im), v = ones(n), logger = displaylevel, tol = TOL/50, maxit = 500)
     @info "Eigenvalue computed by quasi newton: $λ_ref"
 
     #Shift and scale the NEP(mainly to avoid round-off errors because of the large entries in the coefficient matrices)

--- a/test/nleigs/nleigs_gun_naive.jl
+++ b/test/nleigs/nleigs_gun_naive.jl
@@ -5,6 +5,6 @@ using Test
 @bench @testset "NLEIGS: Naive Gun" begin
     nep = nep_gallery("nlevp_native_gun")
     square = [-1-1im; -1+1im; 1+1im; 1-1im]
-    λ, X, _ = nleigs(nep, 150^2 .+ 200.0*square, displaylevel=displaylevel)
+    λ, X, _ = nleigs(nep, 150^2 .+ 200.0*square, logger=displaylevel)
     verify_lambdas(1, nep, λ, X)
 end

--- a/test/nleigs/nleigs_gun_variant_p.jl
+++ b/test/nleigs/nleigs_gun_variant_p.jl
@@ -12,7 +12,7 @@ include(joinpath("..", "rk_helper", "gun_test_utils.jl"))
     nep, Σ, _, v, nodes, funres = gun_init()
 
     # solve nlep
-    lambda, X, res, solution_info = nleigs(nep, Σ, displaylevel=verbose > 0 ? 1 : 0, maxit=100, v=v, leja=0, nodes=nodes, reusefact=2, errmeasure=funres, return_details=verbose > 1)
+    lambda, X, res, solution_info = nleigs(nep, Σ, logger=verbose > 0 ? 1 : 0, maxit=100, v=v, leja=0, nodes=nodes, reusefact=2, errmeasure=funres, return_details=verbose > 1)
 
     verify_lambdas(17, nep, lambda, X)
 

--- a/test/nleigs/nleigs_gun_variant_r1.jl
+++ b/test/nleigs/nleigs_gun_variant_r1.jl
@@ -12,7 +12,7 @@ include(joinpath("..", "rk_helper", "gun_test_utils.jl"))
     nep, Σ, Ξ, v, nodes, funres = gun_init()
 
     # solve nlep
-    lambda, X, res, solution_info = nleigs(nep, Σ, Ξ=Ξ, displaylevel=verbose > 0 ? 1 : 0, maxit=100, v=v, leja=0, nodes=nodes, reusefact=2, errmeasure=funres, return_details=verbose > 1)
+    lambda, X, res, solution_info = nleigs(nep, Σ, Ξ=Ξ, logger=verbose > 0 ? 1 : 0, maxit=100, v=v, leja=0, nodes=nodes, reusefact=2, errmeasure=funres, return_details=verbose > 1)
 
     verify_lambdas(21, nep, lambda, X)
 

--- a/test/nleigs/nleigs_gun_variant_r2.jl
+++ b/test/nleigs/nleigs_gun_variant_r2.jl
@@ -12,7 +12,7 @@ include(joinpath("..", "rk_helper", "gun_test_utils.jl"))
     nep, Σ, Ξ, v, nodes, funres = gun_init()
 
     # solve nlep
-    lambda, X, res, solution_info = nleigs(nep, Σ, Ξ=Ξ, displaylevel=verbose > 0 ? 1 : 0, minit=60, maxit=100, v=v, nodes=nodes, errmeasure=funres, return_details=verbose > 1)
+    lambda, X, res, solution_info = nleigs(nep, Σ, Ξ=Ξ, logger=verbose > 0 ? 1 : 0, minit=60, maxit=100, v=v, nodes=nodes, errmeasure=funres, return_details=verbose > 1)
 
     verify_lambdas(21, nep, lambda, X)
 

--- a/test/nleigs/nleigs_gun_variant_s.jl
+++ b/test/nleigs/nleigs_gun_variant_s.jl
@@ -12,7 +12,7 @@ include(joinpath("..", "rk_helper", "gun_test_utils.jl"))
     nep, Σ, Ξ, v, nodes, funres = gun_init()
 
     # solve nlep
-    lambda, X, res, solution_info = nleigs(nep, Σ, Ξ=Ξ, displaylevel=verbose > 0 ? 1 : 0, minit=70, maxit=100, v=v, nodes=nodes, static=true, errmeasure=funres, return_details=verbose > 1)
+    lambda, X, res, solution_info = nleigs(nep, Σ, Ξ=Ξ, logger=verbose > 0 ? 1 : 0, minit=70, maxit=100, v=v, nodes=nodes, static=true, errmeasure=funres, return_details=verbose > 1)
 
     verify_lambdas(21, nep, lambda, X)
 

--- a/test/nleigs/nleigs_particle_variant_r2.jl
+++ b/test/nleigs/nleigs_particle_variant_r2.jl
@@ -12,7 +12,7 @@ include("particle_test_utils.jl")
     nep, Σ, Ξ, v, nodes, xmin, xmax = particle_init(2)
 
     # solve nlep
-    lambda, X, res, solution_info = nleigs(nep, Σ, Ξ=Ξ, displaylevel=verbose > 0 ? 1 : 0, maxdgr=50, minit=30, maxit=100, v=v, nodes=nodes, return_details=verbose > 1)
+    lambda, X, res, solution_info = nleigs(nep, Σ, Ξ=Ξ, logger=verbose > 0 ? 1 : 0, maxdgr=50, minit=30, maxit=100, v=v, nodes=nodes, return_details=verbose > 1)
 
     verify_lambdas(2, nep, lambda, X)
 

--- a/test/nleigs/nleigs_particle_variant_s.jl
+++ b/test/nleigs/nleigs_particle_variant_s.jl
@@ -12,7 +12,7 @@ include("particle_test_utils.jl")
     nep, Σ, Ξ, v, nodes, xmin, xmax = particle_init(2)
 
     # solve nlep
-    lambda, X, res, solution_info = nleigs(nep, Σ, Ξ=Ξ, displaylevel=verbose > 0 ? 1 : 0, maxdgr=50, minit=120, maxit=200, v=v, nodes=nodes, static=true, return_details=verbose > 1)
+    lambda, X, res, solution_info = nleigs(nep, Σ, Ξ=Ξ, logger=verbose > 0 ? 1 : 0, maxdgr=50, minit=120, maxit=200, v=v, nodes=nodes, static=true, return_details=verbose > 1)
 
     verify_lambdas(2, nep, lambda, X)
 

--- a/test/nleigs/nleigs_scalar.jl
+++ b/test/nleigs/nleigs_scalar.jl
@@ -16,7 +16,7 @@ function nleigs_scalar()
     Σ = complex([0.01, 4])
 
     @bench @testset "Polynomial" begin
-        lambda, X = nleigs(nep, Σ, displaylevel=displaylevel, maxit=100, v=ones(n).+0im, leja=2, isfunm=false)
+        lambda, X = nleigs(nep, Σ, logger=displaylevel, maxit=100, v=ones(n).+0im, leja=2, isfunm=false)
 
         # single eigenvalue converges
         verify_lambdas(1, nep, lambda, X)
@@ -26,7 +26,7 @@ function nleigs_scalar()
         # set of poles candidates
         Ξ = -10 .^ range(-6, stop = 5, length = 10000)
 
-        lambda, X = nleigs(nep, Σ, Ξ=Ξ, displaylevel=displaylevel, maxit=100, v=ones(n).+0im, leja=2, isfunm=false)
+        lambda, X = nleigs(nep, Σ, Ξ=Ξ, logger=displaylevel, maxit=100, v=ones(n).+0im, leja=2, isfunm=false)
 
         # three eigenvalues converge
         verify_lambdas(3, nep, lambda, X)

--- a/test/proj.jl
+++ b/test/proj.jl
@@ -76,7 +76,7 @@ using Random
         @test norm(x/x[1]-x1)<1e-8
 
         @info "Running IAR for projected problem ($nepstr)"
-        λv,X=iar(pnep,σ=complex(round(λ_exact*10)/10),displaylevel=0,
+        λv,X=iar(pnep,σ=complex(round(λ_exact*10)/10),
                  Neig=3,maxit=100, v=ones(size(pnep,1)))
 
         mydiff = minimum(abs.(λv .- λ_exact))

--- a/test/proj.jl
+++ b/test/proj.jl
@@ -66,7 +66,7 @@ using Random
         Q = Matrix(Q)
         set_projectmatrices!(pnep,Q,Q);
         @info "Running Newton on projected problem with very good start value ($nepstr)"
-        λ1,z1=newton(pnep,λ=(λ_exact+0.00001),displaylevel=0,v=ones(size(pnep,1)))
+        λ1,z1=newton(pnep,λ=(λ_exact+0.00001),logger=0,v=ones(size(pnep,1)))
 
         x1=Q*z1; x1=x1/x1[1];
 
@@ -89,7 +89,7 @@ using Random
         Vnew=[Q ones(n)];
         Wnew=[Q ones(n)];
         expand_projectmatrices!(pnep,Wnew,Vnew);
-        λ1,zz1=newton(pnep,λ=(λ_exact+0.00001),displaylevel=0,
+        λ1,zz1=newton(pnep,λ=(λ_exact+0.00001),logger=0,
                       v=ones(4),maxit=20)
 
         xx1=Vnew*zz1; xx1=xx1/xx1[1]

--- a/test/sgiter.jl
+++ b/test/sgiter.jl
@@ -14,7 +14,7 @@ using LinearAlgebra
                  λ_min = -10,
                  λ_max = 0,
                  λ = -10,
-                 displaylevel = displaylevel,
+                 logger = displaylevel,
                  maxit = 100, tol=1e-12)
    @test norm(compute_Mlincomb(nep,λ,v)) < 1e-9
 
@@ -22,7 +22,7 @@ using LinearAlgebra
    λ,v = sgiter(Float64,
                 nep,
                 2,
-                displaylevel = displaylevel,
+                logger = displaylevel,
                 tol = 1e-9,
                 maxit = 100,
                 errmeasure = ResidualErrmeasure)

--- a/test/tiar.jl
+++ b/test/tiar.jl
@@ -35,22 +35,22 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
 
     # NOW TEST DIFFERENT ORTHOGONALIZATION METHODS
     @bench @testset "DGKS" begin
-        (λ,Q,err,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
+        (λ,Q,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
         @test opnorm(Z'*Z - I) < 1e-6
      end
 
      @bench @testset "User provided doubleGS" begin
-         (λ,Q,err,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100);
+         (λ,Q,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100);
          @test opnorm(Z'*Z - I) < 1e-6
       end
 
       @bench @testset "ModifiedGramSchmidt" begin
-          (λ,Q,err,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100);
+          (λ,Q,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100);
           @test opnorm(Z'*Z - I) < 1e-6
       end
 
        @bench @testset "ClassicalGramSchmidt" begin
-           (λ,Q,err,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100);
+           (λ,Q,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100);
            @test opnorm(Z'*Z - I) < 1e-6
        end
     end

--- a/test/tiar.jl
+++ b/test/tiar.jl
@@ -22,12 +22,12 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
     dep=nep_gallery("dep0",n);
 
     @bench @testset "accuracy eigenpairs" begin
-        (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),displaylevel=0,maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
+        (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
         verify_lambdas(4, dep, λ, Q, eps()*100)
     end
 
     @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
-        (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=Inf,v=ones(n),displaylevel=0,maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
+        (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=Inf,v=ones(n),maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
         verify_lambdas(4, dep, λ, Q, eps()*100)
     end
 
@@ -35,22 +35,22 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
 
     # NOW TEST DIFFERENT ORTHOGONALIZATION METHODS
     @bench @testset "DGKS" begin
-        (λ,Q,err,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),displaylevel=0,maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
+        (λ,Q,err,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
         @test opnorm(Z'*Z - I) < 1e-6
      end
 
      @bench @testset "User provided doubleGS" begin
-         (λ,Q,err,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),displaylevel=0,maxit=50,tol=eps()*100);
+         (λ,Q,err,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100);
          @test opnorm(Z'*Z - I) < 1e-6
       end
 
       @bench @testset "ModifiedGramSchmidt" begin
-          (λ,Q,err,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),displaylevel=0,maxit=50,tol=eps()*100);
+          (λ,Q,err,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100);
           @test opnorm(Z'*Z - I) < 1e-6
       end
 
        @bench @testset "ClassicalGramSchmidt" begin
-           (λ,Q,err,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),displaylevel=0,maxit=50,tol=eps()*100);
+           (λ,Q,err,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100);
            @test opnorm(Z'*Z - I) < 1e-6
        end
     end
@@ -58,8 +58,8 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
     # iar and tiar ara mathematically equivalent it maxit<<nep
     # verify the equivalence numerically
     @bench @testset "equivalance with IAR" begin
-        (λ_tiar,Q_tiar)=tiar(dep,σ=2.0,γ=3,Neig=2,v=ones(n),displaylevel=0,maxit=50,tol=eps()*100);
-        (λ_iar,Q_iar)=iar(dep,σ=2.0,γ=3,Neig=2,v=ones(n),displaylevel=0,maxit=50,tol=eps()*100);
+        (λ_tiar,Q_tiar)=tiar(dep,σ=2.0,γ=3,Neig=2,v=ones(n),maxit=50,tol=eps()*100);
+        (λ_iar,Q_iar)=iar(dep,σ=2.0,γ=3,Neig=2,v=ones(n),maxit=50,tol=eps()*100);
         @test norm(λ_tiar-λ_iar)<1e-6
         @test norm(Q_tiar-Q_iar)<1e-6
     end
@@ -70,7 +70,7 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
         nn=opnorm(compute_Mder(depp,0));
         errmeasure= (λ,v) -> norm(compute_Mlincomb(depp,λ,v))/nn;
 
-        λ,Q = tiar(depp, σ=0, γ=3, Neig=3, v=ones(np), displaylevel=0, maxit=50,
+        λ,Q = tiar(depp, σ=0, γ=3, Neig=3, v=ones(np), maxit=50,
                    tol=sqrt(eps()), check_error_every=3,
                    proj_solve=true, inner_solver_method=IARInnerSolver,
                    errmeasure=errmeasure);
@@ -81,7 +81,7 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
     @testset "Errors thrown" begin
         np=100;
         dep=nep_gallery("dep0",np);
-        @test_throws NEPCore.NoConvergenceException (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(np),displaylevel=0,maxit=5,tol=eps()*100,errmeasure=ResidualErrmeasure);
+        @test_throws NEPCore.NoConvergenceException (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(np),maxit=5,tol=eps()*100,errmeasure=ResidualErrmeasure);
     end
 
 end

--- a/test/wep_small.jl
+++ b/test/wep_small.jl
@@ -45,12 +45,12 @@ n=size(nep,1);
 
     myerrmeasure=(λ,v) -> abs(λ-λstar) # Use eigenvalue error as errmeasure
 
-   λ,v = resinv(ComplexF64,nep,displaylevel=displaylevel,λ=λ0,v=v0,
+   λ,v = resinv(ComplexF64,nep,logger=displaylevel,λ=λ0,v=v0,
               errmeasure=myerrmeasure,tol=1e-12)
 
     @test  norm(compute_Mlincomb(nep,λ,v))/norm(v)  < 1e-10
 
-    λ,v = resinv(ComplexF64,nep,displaylevel=displaylevel,λ=λ0,v=v0,
+    λ,v = resinv(ComplexF64,nep,logger=displaylevel,λ=λ0,v=v0,
                errmeasure=myerrmeasure,tol=1e-12,linsolvercreator=backslash_linsolvercreator)
 
     @test  norm(compute_Mlincomb(nep,λ,v))/norm(v)  < 1e-10

--- a/test/wep_small.jl
+++ b/test/wep_small.jl
@@ -55,7 +55,7 @@ n=size(nep,1);
 
     @test  norm(compute_Mlincomb(nep,λ,v))/norm(v)  < 1e-10
 
-    λ,v = quasinewton(ComplexF64,nep,displaylevel=displaylevel,λ=λ0,v=v0,
+    λ,v = quasinewton(ComplexF64,nep,logger=displaylevel,λ=λ0,v=v0,
                     errmeasure=WEPErrmeasure,tol=1e-12)
 
     @test  norm(compute_Mlincomb(nep,λ,v))/norm(v)  < 1e-10

--- a/test/wep_small.jl
+++ b/test/wep_small.jl
@@ -62,7 +62,7 @@ n=size(nep,1);
 
 
     nev=3
-    λ,v = iar(ComplexF64,nep,σ=λ0, displaylevel=displaylevel,Neig=nev,maxit=100,v=v0,
+    λ,v = iar(ComplexF64,nep,σ=λ0, logger=displaylevel,Neig=nev,maxit=100,v=v0,
                   tol=1e-8);
 
     @test minimum(abs.(λstar .- λ)) < 1e-10


### PR DESCRIPTION
This is an attempt to incorporate a logging functionality #170.  

As a user: You can use the new `logger` kwarg for the NEP-solver:
* If `logger` is an Int, it will behave as displaylevel before, under the hood a `PrintLogger` is instantiated.
* If `logger <: Logger` one can obtain more detailed control of what is printed and one can store iteration info in the `logger` object.

As a NEP-method developer:
* `push_info!(logger,"text")` can be used to dump info to the logger. If the logger is a PrintLogger "text" will just be printed. Note that you can add variables by using the dollar sign: "x=$x"  
* `push_iteration_info(logger,iter,kwargs...)` can be used to push information about iteration `iter`. kwargs include things such as `err`, `v`, etc

* [x] method_newton 
* [x] iar tiar 
* [x] ErrorLogger storing information
* [x] rfi
* [x] nlar
* [x] infbilanczos
* [x] contour integrals
* [x] nleigs 
* [x] sgiter
* [x] mslp
* [x] jd
* [x] ilan
* [x] broyden (w inner solves)
* [x] block newton
* [x] unit tests
* [x] comments + documentation

Done with: a level parameter:  ~~At the moment I am not sure how to handle `iar`~~ ~~and other methods which compute many eigenvalues. Just printing all the eigval approximations by default would be give too many printouts, but we want this information when we want to study the method (e.g convergence diagrams).~~

