### PR TITLE
Inf number of target eigenvalues in ILAN

### DIFF
--- a/src/method_ilan.jl
+++ b/src/method_ilan.jl
@@ -30,9 +30,14 @@ end
 
 Run the infinite Lanczos method on the symmetric nonlinear eigenvalue problem stored in `nep`.
 
-The target `σ` is the center around which eiganvalues are computed. The kwarg `errmeasure` is a function handle which can be used to specify how the error is measured to be used in termination (default is absolute residual norm). A Ritz pair `λ` and `v` is flagged a as converged (to an eigenpair) if `errmeasure` is less than `tol`. The vector
-`v` is the starting vector for constructing the Krylov space. The orthogonalization method, used in contructing the orthogonal basis of the Krylov space, is specified by `orthmethod`, see the package `IterativeSolvers.jl`. The iteration
-is continued until `Neig` Ritz pairs converge. This function throws a `NoConvergenceException` if the wanted eigenpairs are not computed after `maxit` iterations.
+The target `σ` is the center around which eiganvalues are computed. The kwarg `errmeasure` is a function handle which can be used
+to specify how the error is measured to be used in termination (default is absolute residual norm). A Ritz pair `λ` and `v` is flagged
+a as converged (to an eigenpair) if `errmeasure` is less than `tol`. The vector
+`v` is the starting vector for constructing the Krylov space. The orthogonalization method, used in contructing the orthogonal basis of the
+ Krylov space, is specified by `orthmethod`, see the package `IterativeSolvers.jl`.
+The iteration is continued until `Neig` Ritz pairs have converged.
+This function throws a `NoConvergenceException` if the wanted eigenpairs are not computed after `maxit` iterations.
+However, if `Neig` is set to `Inf` the iteration is continued until `maxit` iterations without an error being thrown.
 
 See [`newton`](@ref) for other parameters.
 

--- a/src/method_ilan.jl
+++ b/src/method_ilan.jl
@@ -180,21 +180,28 @@ function ilan(
             λ,ZZ=iar(pnep;Neig=Inf,displaylevel=0,maxit=150,tol=tol,check_error_every=Inf,errmeasure=err_lifted)
             W=VV*ZZ;
 
-            # eigenvectors computation
             conv_eig=length(λ)
-            if conv_eig>Neig
-                λ=λ[1:Neig]; W=W[:,1:Neig]
+            # extract the converged Ritzpairs
+            if (k==m)||(conv_eig>=Neig)
+                nrof_eigs = Int(min(length(λ),Neig))
+                λ=λ[1:nrof_eigs]
+                W=W[:,1:nrof_eigs]
             end
-
         end
 
         k=k+1;
         # shift the vectors
         Qp=Q;   Q=Qn;
         Qn=zero(Qn);
-
     end
+
     k=k-1
+    if conv_eig<Neig && Neig != Inf
+        err=Missing; # TODO: Should an error be computed and added?
+        msg="Number of iterations exceeded. maxit=$(maxit)."
+        throw(NoConvergenceException(λ,W,err,msg))
+    end
+
     return λ,W,V[:,1:k+1], H[1:k,1:k-1], ω[1:k], HH[1:k,1:k]
 end
 

--- a/src/method_ilan_benchmark.jl
+++ b/src/method_ilan_benchmark.jl
@@ -6,31 +6,7 @@ using Random
 using Statistics
 
 """
-    iar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tolerance=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][displaylevel=0,][check_error_every=1,][orthmethod=DGKS])
-
-Run the infinite Arnoldi method on the nonlinear eigenvalue problem stored in `nep`.
-
-The target `σ` is the center around which eiganvalues are computed. The kwarg `errmeasure` is a function handle which can be used to specify how the error is measured to be used in termination (default is absolute residual norm). A Ritz pair `λ` and `v` is flagged a as converged (to an eigenpair) if `errmeasure` is less than `tol`. The vector
-`v` is the starting vector for constructing the Krylov space. The orthogonalization method, used in contructing the orthogonal basis of the Krylov space, is specified by `orthmethod`, see the package `IterativeSolvers.jl`. The iteration
-is continued until `Neig` Ritz pairs converge. This function throws a `NoConvergenceException` if the wanted eigenpairs are not computed after `maxit` iterations. The `linsolvercreator` is a function which specifies how the linear system is created and solved.
-
-
-# Example
-```julia-repl
-julia> using NonlinearEigenproblems, LinearAlgebra
-julia> nep=nep_gallery("dep0",100);
-julia> v0=ones(size(nep,1));
-julia> λ,v=iar(nep;v=v0,tol=1e-5,Neig=3);
-julia> norm(compute_Mlincomb!(nep,λ[1],v[:,1])) # Is it an eigenvalue?
-julia> λ    # print the computed eigenvalues
-3-element Array{Complex{Float64},1}:
- -0.15606211475666945 - 0.12273439802763578im
- -0.15606211475666862 + 0.12273439802763489im
-  0.23169243065648365 - 9.464790582509696e-17im
-```
-
-# References
-* Algorithm 2 in Jarlebring, Michiels Meerbergen, A linear eigenvalue algorithm for the nonlinear eigenvalue problem, Numer. Math, 2012
+    ilan_benchmark()
 """
 ilan_benchmark(nep::NEP;params...)=ilan_benchmark(ComplexF64,nep;params...)
 function ilan_benchmark(

--- a/src/method_tiar.jl
+++ b/src/method_tiar.jl
@@ -225,9 +225,9 @@ function tiar(
     k=k-1
     # NoConvergenceException
     if conv_eig<Neig && Neig != Inf
-       err=err[end,1:Neig];
-       idx=sortperm(err); # sort the error
-       λ=λ[idx];  Q=Q[:,idx]; err=err[idx];
+        err=err[end,1:Neig];
+        idx=sortperm(err); # sort the error
+        λ=λ[idx];  Q=Q[:,idx]; err=err[idx];
         msg="Number of iterations exceeded. maxit=$(maxit)."
         if conv_eig<3
             msg=string(msg, " Check that σ is not an eigenvalue.")

--- a/test/ilan.jl
+++ b/test/ilan.jl
@@ -20,7 +20,7 @@ using SparseArrays
         nep=DEP([A1,A2,A3],[0,1,0.8])
         v0=rand(n)
         V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0,errmeasure=ResidualErrmeasure)
-        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0,errmeasure=ResidualErrmeasure)
+        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=Inf,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0,errmeasure=ResidualErrmeasure)
 
         # Disabled. This unit test requires rewriting (and ilan_benchmark can be removed)
         @test norm(V-V2)<sqrt(eps())
@@ -44,14 +44,37 @@ using SparseArrays
 
         f1= S -> -S; f2= S -> one(S); f3= S -> exp(-S); f4= S -> exp(-0.8*S)
         nep=SPMF_NEP([one(A1),A1,A2,A3],[f1,f2,f3,f4])
-        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
+        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=Inf,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
 
         @test norm(V-V2)<sqrt(eps())
         @test norm(H-H2)<sqrt(eps())
         @test norm(ω-ω2)<sqrt(eps())
         @test norm(HH-HH2)<sqrt(eps())
-
     end
 
+    @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
+        n=100
+        Random.seed!(1) # reset the random seed
+        K = [1:n;2:n;1:n-1]; J=[1:n;1:n-1;2:n]
+        A1 = sparse(K, J, rand(3*n-2)); A1 = A1+A1';
+        A2 = sparse(K, J, rand(3*n-2)); A2 = A2+A2';
+        A3 = sparse(K, J, rand(3*n-2)); A3 = A3+A3';
+        nep=DEP([A1,A2,A3],[0,1,0.8])
+        v0=rand(n)
+        λ,W,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=Inf,displaylevel=0,maxit=30,tol=eps()*100,check_error_every=5,v=v0,errmeasure=ResidualErrmeasure)
+        verify_lambdas(2, nep, λ, W, eps()*100)
+    end
+
+    @testset "Errors thrown" begin
+        n=100
+        Random.seed!(1) # reset the random seed
+        K = [1:n;2:n;1:n-1]; J=[1:n;1:n-1;2:n]
+        A1 = sparse(K, J, rand(3*n-2)); A1 = A1+A1';
+        A2 = sparse(K, J, rand(3*n-2)); A2 = A2+A2';
+        A3 = sparse(K, J, rand(3*n-2)); A3 = A3+A3';
+        nep=DEP([A1,A2,A3],[0,1,0.8])
+        v0=rand(n)
+        @test_throws NEPCore.NoConvergenceException _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=2,displaylevel=0,maxit=3,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
+    end
 
 end

--- a/test/ilan.jl
+++ b/test/ilan.jl
@@ -74,7 +74,7 @@ using SparseArrays
         A3 = sparse(K, J, rand(3*n-2)); A3 = A3+A3';
         nep=DEP([A1,A2,A3],[0,1,0.8])
         v0=rand(n)
-        @test_throws NEPCore.NoConvergenceException _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=2,displaylevel=0,maxit=3,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
+        @test_throws NEPCore.NoConvergenceException λ,W,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=2,displaylevel=0,maxit=3,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
     end
 
 end


### PR DESCRIPTION
Implements a feature requested in #177, where` Neig=Inf` should be interpreted as running `maxit` iterations and return all converged Ritz pairs. Also makes ILAN throw a `NoConvergenceException` if not enough eigenvalues found (unless ` Neig=Inf`).