### PR TITLE
Notation: Neig -> neigs

### DIFF
--- a/docs/src/movebc_tutorial.md
+++ b/docs/src/movebc_tutorial.md
@@ -231,7 +231,7 @@ methods, e.g., infinite Arnoldi method terminate in a reasonable
 number of iterations:
 ```julia-repl
 julia> (λ,v)=iar(nep,logger=1,σ=-36,v=ones(n),tol=1e-9,
-                 errmeasure=BackwardErrmeasure,Neig=5,maxit=100);
+                 errmeasure=BackwardErrmeasure,neigs=5,maxit=100);
 Iteration:1 conveig:0
 Iteration:2 conveig:0
 Iteration:3 conveig:0

--- a/docs/src/tutorial_call_python.md
+++ b/docs/src/tutorial_call_python.md
@@ -126,7 +126,7 @@ we can now use many NEP-solvers to solve this problem.
 Here we use IAR:
 ```julia-repl
 
-julia> (λv,vv)=iar(pnep,v=[1;1],σ=1,logger=1,Neig=3);
+julia> (λv,vv)=iar(pnep,v=[1;1],σ=1,logger=1,neigs=3);
 Iteration:1 conveig:0
 Iteration:2 conveig:0
 Iteration:3 conveig:0

--- a/profiling/iar.jl
+++ b/profiling/iar.jl
@@ -10,6 +10,6 @@ include("../src/method_iar.jl");
 Profile.clear()
 nep=nep_gallery("dep0_tridiag",100)
 Profile.init(n = 10^7, delay = 0.01)
-@profile iar(nep,σ=-1,γ=2;Neig=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+@profile iar(nep,σ=-1,γ=2;neigs=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
 #Profile.print()
 Profile.print(format=:flat,sortedby=:count)

--- a/profiling/iar_chebyshev.jl
+++ b/profiling/iar_chebyshev.jl
@@ -7,6 +7,6 @@ import NEPSolver.inner_solve; include("../src/inner_solver.jl");import NEPSolver
 Profile.clear()
 nep=nep_gallery("dep0_tridiag",5000)
 Profile.init(n = 10^7, delay = 0.01)
-@profile iar_chebyshev(nep,Neig=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+@profile iar_chebyshev(nep,neigs=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
 #Profile.print()
 Profile.print(format=:flat,sortedby=:count)

--- a/profiling/iar_time.jl
+++ b/profiling/iar_time.jl
@@ -21,12 +21,12 @@ function compute_Mlincomb(nep::DEP,λ::Number,V;a=ones(size(V,2)))
 	return z-λ*view(V,:,1:1)
 end
 
-iar(nep,Neig=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
-@time iar(nep,Neig=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+iar(nep,neigs=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+@time iar(nep,neigs=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
 
-iar_chebyshev(nep,Neig=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
-@time iar_chebyshev(nep,Neig=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+iar_chebyshev(nep,neigs=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+@time iar_chebyshev(nep,neigs=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
 
-tiar(nep,Neig=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
-@time tiar(nep,Neig=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+tiar(nep,neigs=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+@time tiar(nep,neigs=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
 1

--- a/profiling/ilan.jl
+++ b/profiling/ilan.jl
@@ -25,5 +25,5 @@ f4= S -> sqrt(one(S)-2*S)
 
 nep=SPMF_NEP([A1,A2,A3,A4],[f1,f2,f3,f4])
 v0=ones(3)
-V,H,ω=ilan(nep,σ=0,γ=1;Neig=10,v=v0,displaylevel=1,maxit=5,tol=eps()*100,check_error_every=1)
+V,H,ω=ilan(nep,σ=0,γ=1;neigs=10,v=v0,displaylevel=1,maxit=5,tol=eps()*100,check_error_every=1)
 V

--- a/profiling/ilan_improve.jl
+++ b/profiling/ilan_improve.jl
@@ -21,6 +21,6 @@ f4= S -> sqrt(one(S)-2*S)
 
 v0=rand(n)
 nep=SPMF_NEP([A1,A2,A3,A4],[f1,f2,f3,f4])
-V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;Neig=10,displaylevel=1,maxit=40,tol=eps()*100,check_error_every=1,v=v0)
+V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;neigs=10,displaylevel=1,maxit=40,tol=eps()*100,check_error_every=1,v=v0)
 
-V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=10,displaylevel=1,maxit=40,tol=eps()*100,check_error_every=1,v=v0)
+V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;neigs=10,displaylevel=1,maxit=40,tol=eps()*100,check_error_every=1,v=v0)

--- a/profiling/ilan_test.jl
+++ b/profiling/ilan_test.jl
@@ -23,9 +23,9 @@ include("../src/method_ilan_benchmark.jl");
     v0=rand(n)
     nep=SPMF_NEP([A1,A2,A3,A4],[f1,f2,f3,f4])
 
-    V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;Neig=10,displaylevel=1,maxit=40,tol=eps()*100,check_error_every=1,v=v0)
+    V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;neigs=10,displaylevel=1,maxit=40,tol=eps()*100,check_error_every=1,v=v0)
 
-    V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=10,displaylevel=1,maxit=40,tol=eps()*100,check_error_every=1,v=v0)
+    V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;neigs=10,displaylevel=1,maxit=40,tol=eps()*100,check_error_every=1,v=v0)
 
     @test norm(V-V2)<1e-12
     @test norm(H-H2)<1e-12

--- a/profiling/ilan_timed.jl
+++ b/profiling/ilan_timed.jl
@@ -17,9 +17,9 @@ nep=SPMF_NEP([A1,A2,A3,A4],[f1,f2,f3,f4])
 σ=0
 Dnep=DerSPMF(nep,σ,200)
 function time_ilan()
-@btime begin ilan(Dnep;Neig=10,displaylevel=0,maxit=200,tol=eps()*100,check_error_every=1) end
-@btime begin ilan(nep;Neig=10,displaylevel=0,maxit=200,tol=eps()*100,check_error_every=1) end
-@btime begin tiar(nep;Neig=10,displaylevel=0,maxit=200,tol=eps()*100,check_error_every=200) end
+@btime begin ilan(Dnep;neigs=10,displaylevel=0,maxit=200,tol=eps()*100,check_error_every=1) end
+@btime begin ilan(nep;neigs=10,displaylevel=0,maxit=200,tol=eps()*100,check_error_every=1) end
+@btime begin tiar(nep;neigs=10,displaylevel=0,maxit=200,tol=eps()*100,check_error_every=200) end
 end
 
 time_ilan()

--- a/profiling/ilan_with_DerSPMF.jl
+++ b/profiling/ilan_with_DerSPMF.jl
@@ -17,7 +17,7 @@ nep=SPMF_NEP([A1,A2,A3,A4],[f1,f2,f3,f4])
 σ=0
 Dnep=DerSPMF(nep,σ,200)
 
-V,H,ω,HH=ilan(Dnep;Neig=10,displaylevel=1,maxit=200,tol=eps()*100,check_error_every=1)
+V,H,ω,HH=ilan(Dnep;neigs=10,displaylevel=1,maxit=200,tol=eps()*100,check_error_every=1)
 Q=V;
 
 # project (hardcoded for now)
@@ -29,7 +29,7 @@ AA4=Q'*(A4*Q);
 err_lifted=(λ,z)->compute_resnorm(nep,λ,Q*z)/n;
 
 pnep=SPMF_NEP([AA1,AA2,AA3,AA4],[f1,f2,f3,f4])
-λ,_,err=iar(pnep;Neig=100,displaylevel=1,maxit=100,tol=eps()*100,check_error_every=1,errmeasure=err_lifted)
+λ,_,err=iar(pnep;neigs=100,displaylevel=1,maxit=100,tol=eps()*100,check_error_every=1,errmeasure=err_lifted)
 
 m,p=size(err);
 

--- a/profiling/nlar_debug.jl
+++ b/profiling/nlar_debug.jl
@@ -3,8 +3,8 @@ using NonlinearEigenproblems, Random, SparseArrays, Revise, LinearAlgebra, Bench
 nep=nep_gallery("dep0",100);
 v0=ones(size(nep,1));
 try
-    λ,v=iar(nep;v=v0,tol=1e-5,Neig=10,maxit=10);
+    λ,v=iar(nep;v=v0,tol=1e-5,neigs=10,maxit=10);
 catch e
     λ=e.λ
     v=e.v
-end      
+end

--- a/profiling/test_iar.jl
+++ b/profiling/test_iar.jl
@@ -9,4 +9,4 @@ A0 = sparse(K, J, rand(3*n-2));
 A1 = sparse(K, J, rand(3*n-2));
 
 nep=DEP([A0,A1],[0,1])
-λ,v=iar(nep;tol=1e-12,Neig=10);
+λ,v=iar(nep;tol=1e-12,neigs=10);

--- a/profiling/tiar.jl
+++ b/profiling/tiar.jl
@@ -1,3 +1,3 @@
 include("../src/method_tiar.jl");
 nep=nep_gallery("dep_symm_double",1000)
-tiar(nep,σ=-1,γ=2;Neig=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+tiar(nep,σ=-1,γ=2;neigs=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)

--- a/profiling/tiar_DEP.jl
+++ b/profiling/tiar_DEP.jl
@@ -9,14 +9,14 @@ nep=nep_gallery("dep0_tridiag",1000)
 
 v0=ones(size(nep,1))
 
-tiar(nep,Neig=10,v=v0,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
-@time tiar(nep,Neig=10,v=v0,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+tiar(nep,neigs=10,v=v0,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+@time tiar(nep,neigs=10,v=v0,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
 
 
 import NEPCore.compute_Mlincomb
 compute_Mlincomb_from_MMcompute_Mlincomb(nep::DEP,λ::Number,V;a=ones(size(V,2)))=
 compute_Mlincomb_from_MM(nep,λ,V,a)
 
-@profile tiar(nep,Neig=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+@profile tiar(nep,neigs=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
 Profile.print(format=:flat,sortedby=:count)
 1

--- a/profiling/tiar_DEP_time.jl
+++ b/profiling/tiar_DEP_time.jl
@@ -12,20 +12,20 @@ nep=nep_gallery("dep0_tridiag",500)
 v0=ones(size(nep,1))
 
 
-tiar(nep,Neig=10,v=v0,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
-@time tiar(nep,Neig=10,v=v0,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+tiar(nep,neigs=10,v=v0,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+@time tiar(nep,neigs=10,v=v0,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
 
 
 
 
-tiar(nep,Neig=10,v=v0,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
-@time tiar(nep,Neig=10,v=v0,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+tiar(nep,neigs=10,v=v0,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+@time tiar(nep,neigs=10,v=v0,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
 
 # debug
 nep=nep_gallery("dep0",100);
 
-(λ,Q)=tiar(nep,σ=2.0,γ=3,Neig=4,v=ones(100),displaylevel=1,maxit=50,tol=eps()*100);
+(λ,Q)=tiar(nep,σ=2.0,γ=3,neigs=4,v=ones(100),displaylevel=1,maxit=50,tol=eps()*100);
 1
 
-#@profile tiar(nep,Neig=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
+#@profile tiar(nep,neigs=10,displaylevel=0,maxit=100,tol=eps()*100,check_error_every=100)
 #Profile.print(format=:flat,sortedby=:count)

--- a/src/inner_solver.jl
+++ b/src/inner_solver.jl
@@ -115,7 +115,7 @@ abstract type ContourBeynInnerSolver <: InnerSolver end;
 
 
 """
-  inner_solve(T,T_arit,nep;kwargs...)
+    inner_solve(T,T_arit,nep;kwargs...)
 
 Solves the projected linear problem with solver specied with T. This is to be used
 as an inner solver in an inner-outer iteration. T specifies which method
@@ -126,13 +126,13 @@ The type `T_arit` defines the arithmetics used in the outer iteration and should
 also be used in the inner iteration.
 
 Different inner_solve methods take different kwargs. The meaning of
-the kwargs are the following:\\
-`neigs`: Number of wanted eigenvalues (but less or more may be returned)\\
-`σ`: target specifying where eigenvalues\\
-`λv`, `V`: Vector/matrix of guesses to be used as starting values\\
-`j`: the jth eigenvalue in a min-max characterization\\
-`tol`: Termination tolarance for inner solver\\
-`inner_logger`: Determines how the inner solves are logged. See [`Logger`](@ref) for further references
+the kwargs are the following:
+- `neigs`: Number of wanted eigenvalues (but less or more may be returned)
+- `σ`: target specifying where eigenvalues
+- `λv`, `V`: Vector/matrix of guesses to be used as starting values
+- `j`: the jth eigenvalue in a min-max characterization
+- `tol`: Termination tolarance for inner solver
+- `inner_logger`: Determines how the inner solves are logged. See [`Logger`](@ref) for further references
 """
 function inner_solve(TT::Type{DefaultInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;kwargs...)
     if (typeof(nep.orgnep)==NEPTypes.PEP)

--- a/src/inner_solver.jl
+++ b/src/inner_solver.jl
@@ -127,7 +127,7 @@ also be used in the inner iteration.
 
 Different inner_solve methods take different kwargs. The meaning of
 the kwargs are the following:\\
-`Neig`: Number of wanted eigenvalues (but less or more may be returned)\\
+`neigs`: Number of wanted eigenvalues (but less or more may be returned)\\
 `σ`: target specifying where eigenvalues\\
 `λv`, `V`: Vector/matrix of guesses to be used as starting values\\
 `j`: the jth eigenvalue in a min-max characterization\\
@@ -189,10 +189,10 @@ end
 
 
 
-function inner_solve(TT::Type{IARInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;σ=0,Neig=10,inner_logger=0,kwargs...)
+function inner_solve(TT::Type{IARInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;σ=0,neigs=10,inner_logger=0,kwargs...)
     @parse_logger_param!(inner_logger)
     try
-        λ,V=iar(T_arit,nep,σ=σ,Neig=Neig,tol=1e-13,maxit=50,logger=inner_logger);
+        λ,V=iar(T_arit,nep,σ=σ,neigs=neigs,tol=1e-13,maxit=50,logger=inner_logger);
         return λ,V
     catch e
         if (isa(e, NoConvergenceException))
@@ -207,7 +207,7 @@ end
 
 
 
-function inner_solve(TT::Type{IARChebInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;σ=0,Neig=10,inner_logger=0,kwargs...)
+function inner_solve(TT::Type{IARChebInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;σ=0,neigs=10,inner_logger=0,kwargs...)
     @parse_logger_param!(inner_logger)
     if isa(nep.orgnep, NEPTypes.DEP)
         AA = get_Av(nep)
@@ -223,7 +223,7 @@ function inner_solve(TT::Type{IARChebInnerSolver},T_arit::Type,nep::NEPTypes.Pro
     end
 
     try
-        λ,V=iar_chebyshev(T_arit,nep,σ=σ,Neig=Neig,tol=1e-13,maxit=50,logger=inner_logger);
+        λ,V=iar_chebyshev(T_arit,nep,σ=σ,neigs=neigs,tol=1e-13,maxit=50,logger=inner_logger);
         return λ,V
     catch e
         if (isa(e, NoConvergenceException))
@@ -246,11 +246,11 @@ end
 
 
 
-function inner_solve(TT::Type{ContourBeynInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;σ=0,λv=[0,1],Neig=10,inner_logger=0,kwargs...)
+function inner_solve(TT::Type{ContourBeynInnerSolver},T_arit::Type,nep::NEPTypes.Proj_NEP;σ=0,λv=[0,1],neigs=10,inner_logger=0,kwargs...)
     @parse_logger_param!(inner_logger)
     # Radius  computed as the largest distance σ and λv and a litte more
     radius = maximum(abs.(σ .- λv))*1.5
-    Neig = min(Neig,size(nep,1))
-    λ,V = contour_beyn(T_arit,nep,neigs=Neig,σ=σ,radius=radius,logger=inner_logger)
+    neigs = min(neigs,size(nep,1))
+    λ,V = contour_beyn(T_arit,nep,neigs=neigs,σ=σ,radius=radius,logger=inner_logger)
     return λ,V
 end

--- a/src/method_iar.jl
+++ b/src/method_iar.jl
@@ -6,7 +6,7 @@ using Random
 using Statistics
 
 """
-    iar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tol=eps()*10000,][Neig=6,][errmeasure,][v=rand(size(nep,1),1),][logger=0,][check_error_every=1,][orthmethod=DGKS,][proj_solve=false,][inner_solver_method=DefaultInnerSolver,][inner_logger=0])
+    iar(nep,[maxit=30,][σ=0,][γ=1,][linsolvecreator=default_linsolvecreator,][tol=eps()*10000,][neigs=6,][errmeasure,][v=rand(size(nep,1),1),][logger=0,][check_error_every=1,][orthmethod=DGKS,][proj_solve=false,][inner_solver_method=DefaultInnerSolver,][inner_logger=0])
 
 Run the infinite Arnoldi method on the nonlinear eigenvalue problem stored in `nep`.
 
@@ -17,9 +17,9 @@ of the disk and `γ` as the radius.
 The vector `v` is the starting vector for constructing the Krylov space. The orthogonalization
 method, used in contructing the orthogonal basis of the Krylov space, is specified by
 `orthmethod`, see the package `IterativeSolvers.jl`.
-The iteration is continued until `Neig` Ritz pairs have converged.
+The iteration is continued until `neigs` Ritz pairs have converged.
 This function throws a `NoConvergenceException` if the wanted eigenpairs are not computed after `maxit` iterations.
-However, if `Neig` is set to `Inf` the iteration is continued until `maxit` iterations without an error being thrown.
+However, if `neigs` is set to `Inf` the iteration is continued until `maxit` iterations without an error being thrown.
 The parameter `proj_solve` determines if the Ritz paris are extracted using the Hessenberg matrix (false),
 or as the solution to a projected problem (true). If true, the method is descided by `inner_solver_method`, and the
 logging of the inner solvers are descided by `inner_logger`, which works in the same way as `logger`.
@@ -31,7 +31,7 @@ See [`newton`](@ref) for other parameters.
 julia> using NonlinearEigenproblems, LinearAlgebra
 julia> nep=nep_gallery("dep0",100);
 julia> v0=ones(size(nep,1));
-julia> λ,v=iar(nep;v=v0,tol=1e-5,Neig=3);
+julia> λ,v=iar(nep;v=v0,tol=1e-5,neigs=3);
 julia> norm(compute_Mlincomb!(nep,λ[1],v[:,1])) # Is it an eigenvalue?
 julia> λ    # print the computed eigenvalues
 3-element Array{Complex{Float64},1}:
@@ -51,7 +51,7 @@ function iar(
     maxit=30,
     linsolvercreator::Function=default_linsolvercreator,
     tol=eps(real(T))*10000,
-    Neig=6,
+    neigs=6,
     errmeasure::ErrmeasureType = DefaultErrmeasure,
     σ=zero(T),
     γ=one(T),
@@ -92,7 +92,7 @@ function iar(
     # Init errmeasure
     ermdata=init_errmeasure(errmeasure,nep);
 
-    while (k <= m) && (conv_eig<Neig)
+    while (k <= m) && (conv_eig<neigs)
 
 
         VV=view(V,1:1:n*(k+1),1:k); # extact subarrays, memory-CPU efficient
@@ -123,7 +123,7 @@ function iar(
                 # Make a call to the inner solve method
                 λproj,Qproj=inner_solve(inner_solver_method,T,pnep,
                                         V=RR*Z,λv=copy(λ),
-                                        Neig=size(λ,1)+3,
+                                        neigs=size(λ,1)+3,
                                         σ=mean(λ),
                                         tol=tol,
                                         inner_logger=inner_logger);
@@ -154,8 +154,8 @@ function iar(
             err[k,1:k]=err[k,idx];
 
             # extract the converged Ritzpairs
-            if (k==m)||(conv_eig>=Neig)
-                nrof_eigs = Int(min(length(λ),Neig))
+            if (k==m)||(conv_eig>=neigs)
+                nrof_eigs = Int(min(length(λ),neigs))
                 λ=λ[idx[1:nrof_eigs]]
                 Q=Q[:,idx[1:length(λ)]]
             end
@@ -166,8 +166,8 @@ function iar(
     end
     k=k-1
     # NoConvergenceException
-    if conv_eig<Neig && Neig != Inf
-        err=err[end,1:Neig];
+    if conv_eig<neigs && neigs != Inf
+        err=err[end,1:neigs];
         idx=sortperm(err); # sort the error
         λ=λ[idx];  Q=Q[:,idx]; err=err[idx];
         msg="Number of iterations exceeded. maxit=$(maxit)."

--- a/src/method_ilan_benchmark.jl
+++ b/src/method_ilan_benchmark.jl
@@ -16,7 +16,7 @@ function ilan_benchmark(
     maxit=30,
     linsolvercreator::Function=default_linsolvercreator,
     tol=eps(real(T))*10000,
-    Neig=6,
+    neigs=6,
     errmeasure::ErrmeasureType = DefaultErrmeasure,
     σ=zero(T),
     γ=one(T),
@@ -81,7 +81,7 @@ function ilan_benchmark(
         pnep=create_proj_NEP(nep);
     end
 
-    while (k <= m) && (conv_eig<Neig)
+    while (k <= m) && (conv_eig<neigs)
         if (displaylevel>0) && ((rem(k,check_error_every)==0) || (k==m))
             println("Iteration:",k, " conveig:",conv_eig)
         end

--- a/src/method_infbilanczos.jl
+++ b/src/method_infbilanczos.jl
@@ -3,16 +3,16 @@ using Random
 
 export infbilanczos
 """
-    λv,V,U=infbilanczos([eltype],nep, nept,[linsolvecreator,][linsolvertcreator,][v,][u,][σ,][γ,][tol,][Neig,][errmeasure,][logger,][maxit,][check_error_every])
+    λv,V,U=infbilanczos([eltype],nep, nept,[linsolvecreator,][linsolvertcreator,][v,][u,][σ,][γ,][tol,][neigs,][errmeasure,][logger,][maxit,][check_error_every])
 
 Executes the Infinite Bi-Lanczos method on the problem defined by `nep::NEP`
 and `nept::NEP`. `nep:NEP` is the original nonlinear eigenvalue problem and
 `nept::NEP` is its (hermitian) transpose: ``M(λ^*)^H``.
  `v` and `u` are starting vectors,
 `σ` is the shift and `γ` the scaling.
-The iteration is continued until `Neig` Ritz pairs have converged.
+The iteration is continued until `neigs` Ritz pairs have converged.
 This function throws a `NoConvergenceException` if the wanted eigenpairs are not computed after `maxit` iterations.
-However, if `Neig` is set to `Inf` the iteration is continued until `maxit` iterations without an error being thrown.
+However, if `neigs` is set to `Inf` the iteration is continued until `maxit` iterations without an error being thrown.
 See [`newton`](@ref) for other parameters.
 
 # Example:
@@ -21,7 +21,7 @@ julia> nep=nep_gallery("dep0");
 julia> A=get_Av(nep); fv=get_fv(nep);
 julia> At=[copy(A[1]'),copy(A[2]'),copy(A[3]')]
 julia> nept=SPMF_NEP(At,fv); # Create the transposed NEP
-julia> λv,V=infbilanczos(nep,nept,Neig=3)
+julia> λv,V=infbilanczos(nep,nept,neigs=3)
 julia> norm(compute_Mlincomb(nep,λv[1],V[:,1]))
 ```
 
@@ -38,7 +38,7 @@ julia> norm(compute_Mlincomb(nep,λv[1],V[:,1]))
                           v::Vector=randn(real(T),size(nep,1)),
                           u::Vector=randn(real(T),size(nep,1)),
                           tol::Real=1e-12,
-                          Neig=5,
+                          neigs=5,
                           errmeasure::ErrmeasureType = DefaultErrmeasure,
                           σ::Number=0.0,
                           γ::Number=1,
@@ -208,14 +208,14 @@ julia> norm(compute_Mlincomb(nep,λv[1],V[:,1]))
                 idx=sortperm(err[1:k]); # sort the error
                 err=err[idx];
 
-                if (conv_eig>=Neig) || (k==m)
-                    nrof_eigs = Int(min(length(λ),Neig,conv_eig))
+                if (conv_eig>=neigs) || (k==m)
+                    nrof_eigs = Int(min(length(λ),neigs,conv_eig))
                     λ=λ[idx[1:nrof_eigs]]
                     Q=Q[:,idx[1:nrof_eigs]]
                     for i=1:nrof_eigs
                         normalize!(view(Q,1:n,i))
                     end
-                    if (conv_eig>=Neig) || (Neig==Inf)
+                    if (conv_eig>=neigs) || (neigs==Inf)
                         return λ,Q,TT
                     end
                 end

--- a/src/method_nlar.jl
+++ b/src/method_nlar.jl
@@ -116,7 +116,7 @@ function nlar(::Type{T},
 
             #Use inner_solve() to solve the smaller projected problem
             push_info!(logger, 2, "Solving inner problem",continues=true)
-            dd,vv = inner_solve(inner_solver_method,T,proj_nep,Neig=neigs,σ=σ,inner_logger=inner_logger);
+            dd,vv = inner_solve(inner_solver_method,T,proj_nep,neigs=neigs,σ=σ,inner_logger=inner_logger);
             push_info!(logger, 2, ". Done.")
             # Sort the eigenvalues of the projected problem
             nuv,yv = eigval_sorter(nep,dd,vv,σ,D,R,Vk);

--- a/test/dep_distributed.jl
+++ b/test/dep_distributed.jl
@@ -47,7 +47,7 @@ end
 
 
 
-    (λ,V)=iar(dep,σ=3,Neig=5,errmeasure=MyErrmeasure, v=ones(n),
+    (λ,V)=iar(dep,σ=3,neigs=5,errmeasure=MyErrmeasure, v=ones(n),
               logger=displaylevel,maxit=100,tol=eps()*100)
 
     @info λ

--- a/test/fiber.jl
+++ b/test/fiber.jl
@@ -90,7 +90,7 @@ using GalleryNLEVP
         @info "Interpolating: $intpoints"
         pep=interpolate(nep_org,intpoints);
         @info "Running IAR"
-        λ,v=iar(pep,σ=7e-7,maxit=100,logger=displaylevel,Neig=2)
+        λ,v=iar(pep,σ=7e-7,maxit=100,logger=displaylevel,neigs=2)
         minerr1=minimum(abs.(sol_val.-λ)) ./ abs(sol_val)
         @info "Error: $minerr1"
         @test minerr1<1e-4
@@ -102,7 +102,7 @@ using GalleryNLEVP
         @info "Interpolating: $intpoints"
         pep=interpolate(nep_org,intpoints);
         @info "Running IAR"
-        λ,v=iar(pep,σ=7e-7,maxit=100,logger=displaylevel,Neig=2)
+        λ,v=iar(pep,σ=7e-7,maxit=100,logger=displaylevel,neigs=2)
         minerr2=minimum(abs.(sol_val.-λ)) ./ abs(sol_val)
         @info "Error: $minerr2"
         @test minerr2<minerr1

--- a/test/gallery.jl
+++ b/test/gallery.jl
@@ -184,7 +184,7 @@ using Test
     @test rank(M)<size(M,1)
     @onlybench @testset "bem_fichera + IAR" begin
        v=ones(size(nep,1));
-       (λ,vv)=iar(nep,σ=9,v=v,logger=displaylevel,Neig=4,maxit=50,tol=1e-6) # normally takes 30 iterations
+       (λ,vv)=iar(nep,σ=9,v=v,logger=displaylevel,neigs=4,maxit=50,tol=1e-6) # normally takes 30 iterations
        @test norm(compute_Mlincomb(nep,λ[1],vv[:,1]))<sqrt(eps());
     end
     @info "non-existing example"

--- a/test/iar.jl
+++ b/test/iar.jl
@@ -22,19 +22,19 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
     n=size(dep,1);
 
     @bench @testset "accuracy eigenpairs" begin
-        (λ,Q)=iar(dep,σ=3,Neig=5,v=ones(n),
+        (λ,Q)=iar(dep,σ=3,neigs=5,v=ones(n),
                   maxit=100,tol=eps()*100,errmeasure=ResidualErrmeasure);
         verify_lambdas(5, dep, λ, Q, eps()*100)
     end
 
     @bench @testset "Solve by projection" begin
-        (λ,Q)=iar(dep,σ=3,Neig=5,v=ones(n),
+        (λ,Q)=iar(dep,σ=3,neigs=5,v=ones(n),
                   maxit=100,tol=eps()*100,errmeasure=ResidualErrmeasure, proj_solve=true);
         verify_lambdas(5, dep, λ, Q, eps()*100)
     end
 
-    @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
-        (λ,Q)=iar(dep,σ=3,Neig=Inf,v=ones(n),
+    @testset "Compute as many eigenpairs as possible (neigs=Inf)" begin
+        (λ,Q)=iar(dep,σ=3,neigs=Inf,v=ones(n),
                   maxit=38,tol=eps()*100);
         verify_lambdas(3, dep, λ, Q, eps()*100)
     end
@@ -43,22 +43,22 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
         # NOW TEST DIFFERENT ORTHOGONALIZATION METHODS
 
         @bench @testset "DGKS" begin
-            (λ,Q,V)=iar(dep,orthmethod=DGKS,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
+            (λ,Q,V)=iar(dep,orthmethod=DGKS,σ=3,neigs=5,v=ones(n),maxit=100,tol=eps()*100)
             @test opnorm(V'*V - I) < 1e-6
         end
 
         @bench @testset "User provided doubleGS" begin
-            (λ,Q,V)=iar(dep,orthmethod=DoubleGS,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
+            (λ,Q,V)=iar(dep,orthmethod=DoubleGS,σ=3,neigs=5,v=ones(n),maxit=100,tol=eps()*100)
             @test opnorm(V'*V - I) < 1e-6
         end
 
         @bench @testset "ModifiedGramSchmidt" begin
-            (λ,Q,V)=iar(dep,orthmethod=ModifiedGramSchmidt,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
+            (λ,Q,V)=iar(dep,orthmethod=ModifiedGramSchmidt,σ=3,neigs=5,v=ones(n),maxit=100,tol=eps()*100)
             @test opnorm(V'*V - I) < 1e-6
         end
 
         @bench @testset "ClassicalGramSchmidt" begin
-            (λ,Q,V)=iar(dep,orthmethod=ClassicalGramSchmidt,σ=3,Neig=5,v=ones(n),maxit=100,tol=eps()*100)
+            (λ,Q,V)=iar(dep,orthmethod=ClassicalGramSchmidt,σ=3,neigs=5,v=ones(n),maxit=100,tol=eps()*100)
             @test opnorm(V'*V - I) < 1e-6
         end
     end
@@ -66,7 +66,7 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
     @testset "Errors thrown" begin
         np=100;
         dep=nep_gallery("dep0",np);
-        @test_throws NEPCore.NoConvergenceException (λ,Q)=iar(dep,σ=3,Neig=6,v=ones(np),
+        @test_throws NEPCore.NoConvergenceException (λ,Q)=iar(dep,σ=3,neigs=6,v=ones(np),
                   maxit=7,tol=eps()*100);
     end
 

--- a/test/iar_chebyshev.jl
+++ b/test/iar_chebyshev.jl
@@ -79,19 +79,19 @@ end
     @bench @testset "Scale Cheb's to different interval w DEP" begin
         a=-maximum(dep.tauv)
         b=0;
-        (λ,Q)=iar_chebyshev(dep,a=a,b=b,Neig=10,maxit=100)
+        (λ,Q)=iar_chebyshev(dep,a=a,b=b,neigs=10,maxit=100)
         verify_lambdas(10, dep, λ, Q, n*sqrt(eps()))
     end
 
 
     dep=nep_gallery("dep0"); n=size(dep,1);
     @bench @testset "accuracy eigenpairs" begin
-        (λ,Q)=iar_chebyshev(dep,σ=0,Neig=5,logger=0,maxit=100,tol=eps()*100);
+        (λ,Q)=iar_chebyshev(dep,σ=0,neigs=5,logger=0,maxit=100,tol=eps()*100);
         verify_lambdas(5, dep, λ, Q, n*sqrt(eps()))
     end
 
-    @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
-        (λ,Q)=iar_chebyshev(dep,σ=0,Neig=Inf,logger=0,maxit=30,tol=eps()*100);
+    @testset "Compute as many eigenpairs as possible (neigs=Inf)" begin
+        (λ,Q)=iar_chebyshev(dep,σ=0,neigs=Inf,logger=0,maxit=30,tol=eps()*100);
         verify_lambdas(8, dep, λ, Q, n*sqrt(eps()))
     end
 
@@ -101,22 +101,22 @@ end
 
     # NOW TEST DIFFERENT ORTHOGONALIZATION METHODS
     @bench @testset "DGKS" begin
-        (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=DGKS,σ=0,Neig=5,logger=0,maxit=100,tol=eps()*100)
+        (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=DGKS,σ=0,neigs=5,logger=0,maxit=100,tol=eps()*100)
         @test opnorm(V'*V - Matrix(1.0I, size(V,2), size(V,2))) < n*sqrt(eps())
      end
 
      @bench @testset "User provided doubleGS" begin
-         (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=DoubleGS,σ=0,Neig=5,logger=0,maxit=100,tol=eps()*100)
+         (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=DoubleGS,σ=0,neigs=5,logger=0,maxit=100,tol=eps()*100)
          @test opnorm(V'*V - Matrix(1.0I, size(V,2), size(V,2))) < n*sqrt(eps())
       end
 
       @bench @testset "ModifiedGramSchmidt" begin
-          (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=ModifiedGramSchmidt,σ=0,Neig=5,logger=0,maxit=100,tol=eps()*100)
+          (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=ModifiedGramSchmidt,σ=0,neigs=5,logger=0,maxit=100,tol=eps()*100)
           @test opnorm(V'*V - Matrix(1.0I, size(V,2), size(V,2))) < n*sqrt(eps())
       end
 
        @bench @testset "ClassicalGramSchmidt" begin
-           (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=ClassicalGramSchmidt,σ=0,Neig=5,logger=0,maxit=100,tol=eps()*100)
+           (λ,Q,err,V)=iar_chebyshev(dep,orthmethod=ClassicalGramSchmidt,σ=0,neigs=5,logger=0,maxit=100,tol=eps()*100)
            @test opnorm(V'*V - Matrix(1.0I, size(V,2), size(V,2))) < n*sqrt(eps())
        end
     end
@@ -130,7 +130,7 @@ end
                 A[j+1]=rand(n,n)
             end
             nep=PEP(A)
-            (λ,Q)=iar_chebyshev(nep,σ=0,Neig=5,logger=0,maxit=100,tol=eps()*100)
+            (λ,Q)=iar_chebyshev(nep,σ=0,neigs=5,logger=0,maxit=100,tol=eps()*100)
 
             verify_lambdas(5, nep, λ, Q, n*sqrt(eps()))
         end
@@ -141,7 +141,7 @@ end
             nep = SPMF_NEP([sparse(1.0I, n, n), A0, A1], [λ -> -λ, λ -> one(λ), λ -> exp(-λ)])
 
             compute_Mlincomb(nep::DEP,λ::Number,V;a=ones(size(V,2)))=compute_Mlincomb_from_MM!(nep,λ,V,a)
-            (λ,Q,err)=iar_chebyshev(nep,σ=0,γ=1,Neig=7,logger=0,maxit=100,tol=eps()*100,check_error_every=1,a=-1,b=2)
+            (λ,Q,err)=iar_chebyshev(nep,σ=0,γ=1,neigs=7,logger=0,maxit=100,tol=eps()*100,check_error_every=1,a=-1,b=2)
 
             verify_lambdas(7, nep, λ, Q, n*sqrt(eps()))
         end
@@ -150,14 +150,14 @@ end
             n=100; A1=rand(n,n); A2=rand(n,n); A3=rand(n,n);
             tau1=0; tau2=1.1; tau3=.2;
             nep=DEP([A1,A2,A3],[tau1,tau2,tau3])
-            (λ,Q)=iar_chebyshev(nep,σ=0,Neig=3,logger=0,maxit=90,tol=eps()*100)
+            (λ,Q)=iar_chebyshev(nep,σ=0,neigs=3,logger=0,maxit=90,tol=eps()*100)
 
             verify_lambdas(3, nep, λ, Q, n*sqrt(eps()))
         end
 
         @bench @testset "DEP SHIFTED AND SCALED" begin
             nep=nep_gallery("dep0_tridiag",1000)
-            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2;Neig=5,logger=0,maxit=100,tol=eps()*100)
+            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2;neigs=5,logger=0,maxit=100,tol=eps()*100)
             verify_lambdas(5, nep, λ, Q, n*sqrt(eps()))
         end
 
@@ -168,7 +168,7 @@ end
                 A[j+1]=rand(n,n)
             end
             nep=PEP(A)
-            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2;Neig=5,logger=0,maxit=100,tol=eps()*100)
+            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2;neigs=5,logger=0,maxit=100,tol=eps()*100)
 
             verify_lambdas(5, nep, λ, Q, n*sqrt(eps()))
         end
@@ -176,17 +176,17 @@ end
         @bench @testset "compute_y0 AS INPUT FOR QEP (naive)" begin
             A0=rand(n,n); A1=rand(n,n); A2=rand(n,n);
             nep = SPMF_NEP([A0, A1, A2], [λ -> one(λ), λ -> λ, λ -> λ^2])
-            λ,Q,err,V = iar_chebyshev(nep,compute_y0_method=ComputeY0Cheb_QEP,maxit=100,Neig=10,σ=0.0,γ=1,logger=0,check_error_every=1);
+            λ,Q,err,V = iar_chebyshev(nep,compute_y0_method=ComputeY0Cheb_QEP,maxit=100,neigs=10,σ=0.0,γ=1,logger=0,check_error_every=1);
 
             verify_lambdas(10, nep, λ, Q, n*sqrt(eps()))
         end
 
         @bench @testset "QDEP IN SPMF format" begin
             nep=nep_gallery("qdep1")
-            λ,Q,err,V = iar_chebyshev(nep,maxit=100,Neig=8,σ=0.0,γ=1,logger=0,check_error_every=1);
+            λ,Q,err,V = iar_chebyshev(nep,maxit=100,neigs=8,σ=0.0,γ=1,logger=0,check_error_every=1);
             verify_lambdas(8, nep, λ, Q, n*sqrt(eps()))
             # with scaling
-            λ,Q,err,V = iar_chebyshev(nep,maxit=100,Neig=8,σ=0.0,γ=0.9,logger=0,check_error_every=1);
+            λ,Q,err,V = iar_chebyshev(nep,maxit=100,neigs=8,σ=0.0,γ=0.9,logger=0,check_error_every=1);
             verify_lambdas(8, nep, λ, Q, n*sqrt(eps()))
         end
 
@@ -194,16 +194,16 @@ end
             A0=rand(n,n); A1=rand(n,n); A2=rand(n,n);
             nep = SPMF_NEP([A0, A1, A2], [λ -> one(λ), λ -> λ, λ -> λ^2])
 
-            λ,Q,err,V = iar_chebyshev(nep,maxit=100,Neig=10,σ=0.0,γ=1,logger=0,check_error_every=1,v=ones(n));
+            λ,Q,err,V = iar_chebyshev(nep,maxit=100,neigs=10,σ=0.0,γ=1,logger=0,check_error_every=1,v=ones(n));
             verify_lambdas(10, nep, λ, Q, n*sqrt(eps()))
 
-            λ2,Q2,err2,V2, H2 = iar_chebyshev(nep,maxit=100,Neig=20,σ=0.0,γ=1,logger=0,check_error_every=1,compute_y0_method=ComputeY0Cheb,v=ones(n));
+            λ2,Q2,err2,V2, H2 = iar_chebyshev(nep,maxit=100,neigs=20,σ=0.0,γ=1,logger=0,check_error_every=1,compute_y0_method=ComputeY0Cheb,v=ones(n));
             @test opnorm(V[:,1:10]-V2[:,1:10])<n*sqrt(eps());
         end
 
         @bench @testset "DEP format with ComputeY0ChebSPMF_NEP" begin
             nep=nep_gallery("dep0_tridiag",1000)
-            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2;Neig=5,logger=0,maxit=100,tol=eps()*100,compute_y0_method=NEPSolver.ComputeY0ChebSPMF_NEP)
+            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2;neigs=5,logger=0,maxit=100,tol=eps()*100,compute_y0_method=NEPSolver.ComputeY0ChebSPMF_NEP)
             verify_lambdas(5, nep, λ, Q, 1e-10)
         end
 
@@ -214,18 +214,18 @@ end
                 A[j+1]=rand(n,n)
             end
             nep=PEP(A)
-            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2,Neig=5,logger=0,maxit=100,tol=eps()*100,compute_y0_method=NEPSolver.ComputeY0ChebSPMF_NEP)
+            (λ,Q)=iar_chebyshev(nep,σ=-1,γ=2,neigs=5,logger=0,maxit=100,tol=eps()*100,compute_y0_method=NEPSolver.ComputeY0ChebSPMF_NEP)
 
             verify_lambdas(5, nep, λ, Q, 1e-10)
         end
 
         @bench @testset "compute_y0 AS INPUT FOR QDEP (combine DEP and PEP)" begin
             nep=nep_gallery("qdep1")
-            λ,Q,err,V,H = iar_chebyshev(nep,compute_y0_method=ComputeY0Cheb_QDEP,maxit=100,Neig=10,logger=0,
+            λ,Q,err,V,H = iar_chebyshev(nep,compute_y0_method=ComputeY0Cheb_QDEP,maxit=100,neigs=10,logger=0,
                                         check_error_every=1,v=ones(size(nep,1)));
             verify_lambdas(10, nep, λ, Q, 1e-10)
 
-            λ2,Q2,err2,V2,H2 = iar_chebyshev(nep,compute_y0_method=ComputeY0Cheb_QDEP,maxit=100,Neig=10,logger=0,
+            λ2,Q2,err2,V2,H2 = iar_chebyshev(nep,compute_y0_method=ComputeY0Cheb_QDEP,maxit=100,neigs=10,logger=0,
                                         check_error_every=1,v=ones(size(nep,1)));
             verify_lambdas(10, nep, λ, Q, 1e-10)
 
@@ -236,6 +236,6 @@ end
     @testset "Errors thrown" begin
         np=100;
         dep=nep_gallery("dep0",np);
-        @test_throws NEPCore.NoConvergenceException (λ,Q)=iar_chebyshev(dep,σ=0,Neig=8,logger=0,maxit=10,tol=eps()*100);
+        @test_throws NEPCore.NoConvergenceException (λ,Q)=iar_chebyshev(dep,σ=0,neigs=8,logger=0,maxit=10,tol=eps()*100);
     end
 end

--- a/test/ilan.jl
+++ b/test/ilan.jl
@@ -19,8 +19,8 @@ using SparseArrays
 
         nep=DEP([A1,A2,A3],[0,1,0.8])
         v0=rand(n)
-        V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0,errmeasure=ResidualErrmeasure)
-        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=Inf,logger=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0,errmeasure=ResidualErrmeasure)
+        V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;neigs=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0,errmeasure=ResidualErrmeasure)
+        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;neigs=Inf,logger=0,maxit=10,tol=eps()*100,check_error_every=1,v=v0,errmeasure=ResidualErrmeasure)
 
         # Disabled. This unit test requires rewriting (and ilan_benchmark can be removed)
         @test norm(V-V2)<sqrt(eps())
@@ -40,11 +40,11 @@ using SparseArrays
 
         nep=DEP([A1,A2,A3],[0,1,0.8])
         v0=rand(n)
-        V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;Neig=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
+        V,H,ω,HH=ilan_benchmark(nep,σ=0,γ=1;neigs=10,displaylevel=0,maxit=10,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
 
         f1= S -> -S; f2= S -> one(S); f3= S -> exp(-S); f4= S -> exp(-0.8*S)
         nep=SPMF_NEP([one(A1),A1,A2,A3],[f1,f2,f3,f4])
-        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=Inf,logger=0,maxit=10,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
+        _,_,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;neigs=Inf,logger=0,maxit=10,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
 
         @test norm(V-V2)<sqrt(eps())
         @test norm(H-H2)<sqrt(eps())
@@ -52,7 +52,7 @@ using SparseArrays
         @test norm(HH-HH2)<sqrt(eps())
     end
 
-    @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
+    @testset "Compute as many eigenpairs as possible (neigs=Inf)" begin
         n=100
         Random.seed!(1) # reset the random seed
         K = [1:n;2:n;1:n-1]; J=[1:n;1:n-1;2:n]
@@ -61,7 +61,7 @@ using SparseArrays
         A3 = sparse(K, J, rand(3*n-2)); A3 = A3+A3';
         nep=DEP([A1,A2,A3],[0,1,0.8])
         v0=rand(n)
-        λ,W,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=Inf,logger=0,maxit=30,tol=eps()*100,check_error_every=5,v=v0,errmeasure=ResidualErrmeasure)
+        λ,W,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;neigs=Inf,logger=0,maxit=30,tol=eps()*100,check_error_every=5,v=v0,errmeasure=ResidualErrmeasure)
         verify_lambdas(2, nep, λ, W, eps()*100)
     end
 
@@ -74,7 +74,7 @@ using SparseArrays
         A3 = sparse(K, J, rand(3*n-2)); A3 = A3+A3';
         nep=DEP([A1,A2,A3],[0,1,0.8])
         v0=rand(n)
-        @test_throws NEPCore.NoConvergenceException λ,W,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;Neig=2,logger=0,maxit=3,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
+        @test_throws NEPCore.NoConvergenceException λ,W,V2,H2,ω2,HH2=ilan(nep,σ=0,γ=1;neigs=2,logger=0,maxit=3,tol=eps()*100,check_error_every=Inf,v=v0,errmeasure=ResidualErrmeasure)
     end
 
 end

--- a/test/infbilanczos.jl
+++ b/test/infbilanczos.jl
@@ -11,7 +11,7 @@ using LinearAlgebra
     n=size(nep,1);
 
     m=40;
-    λ,V,T = infbilanczos(Float64,nep,nept,maxit=m,Neig=3,σ=0,logger=displaylevel,
+    λ,V,T = infbilanczos(Float64,nep,nept,maxit=m,neigs=3,σ=0,logger=displaylevel,
                          v=ones(Float64,n),u=ones(Float64,n),check_error_every=3,
                          tol=1e-7, errmeasure=ResidualErrmeasure);
 
@@ -30,9 +30,9 @@ using LinearAlgebra
     @test length(findall(thiserr .< 1e-7)) == 3
 
 
-    @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
+    @testset "Compute as many eigenpairs as possible (neigs=Inf)" begin
         m=30;
-        λ,V,T = infbilanczos(Float64,nep,nept,maxit=m,Neig=Inf,σ=0,logger=displaylevel,
+        λ,V,T = infbilanczos(Float64,nep,nept,maxit=m,neigs=Inf,σ=0,logger=displaylevel,
                              v=ones(Float64,n),u=ones(Float64,n),check_error_every=3,
                              tol=1e-7, errmeasure=ResidualErrmeasure);
         verify_lambdas(3, nep, λ, V, 1e-6)
@@ -40,7 +40,7 @@ using LinearAlgebra
 
 
     @testset "Errors thrown" begin
-        @test_throws NEPCore.NoConvergenceException λ,V,T = infbilanczos(Float64,nep,nept,maxit=9,Neig=8,σ=0,logger=displaylevel,
+        @test_throws NEPCore.NoConvergenceException λ,V,T = infbilanczos(Float64,nep,nept,maxit=9,neigs=8,σ=0,logger=displaylevel,
                              v=ones(Float64,n),u=ones(Float64,n),check_error_every=3,
                              tol=1e-7, errmeasure=ResidualErrmeasure);
     end
@@ -49,7 +49,7 @@ end
 # Disabled to improve unit test performance
 #@testset "Infbilanczos σ=$x" for x in (1.0, 1.0+0.1im)
 #    m=30;
-#    λ,V,T = infbilanczos(nep,nept,maxit=m,Neig=2,σ=x,tol=1e-7,
+#    λ,V,T = infbilanczos(nep,nept,maxit=m,neigs=2,σ=x,tol=1e-7,
 #                         v=ones(n),u=ones(n));
 #    thiserr=ones(m)*NaN
 #    for i=1:length(λ)

--- a/test/inner_solves.jl
+++ b/test/inner_solves.jl
@@ -20,7 +20,7 @@ using LinearAlgebra
     set_projectmatrices!(pnep,Q,Q)
 
     logger=ErrorLogger(1,100,0);
-    λv,V = inner_solve(DefaultInnerSolver, ComplexF64, pnep; λv=[0.0,1.0] .+ 0im, Neig=3, V=ones(k, 2), tol=eps()*100, inner_logger=logger)
+    λv,V = inner_solve(DefaultInnerSolver, ComplexF64, pnep; λv=[0.0,1.0] .+ 0im, neigs=3, V=ones(k, 2), tol=eps()*100, inner_logger=logger)
     verify_lambdas(2, pnep, λv, V, eps()*500)
     E=logger.errs[:,1]; E=E[(!isnan).(E)];
     @test length(E) > 5 #Has done more than 5 iterations
@@ -40,7 +40,7 @@ using LinearAlgebra
     verify_lambdas(10, pnep, λv, V, sqrt(eps()))
 
     # TODO: this test results in a "Rank drop" warning, and a third eigenvalue that's not converged
-    λv,V = inner_solve(ContourBeynInnerSolver, ComplexF64, pnep; λv=[0,1] .+ 0.0im, Neig=3)
+    λv,V = inner_solve(ContourBeynInnerSolver, ComplexF64, pnep; λv=[0,1] .+ 0.0im, neigs=3)
     # @test minimum(svdvals(compute_Mder(pnep,λv[1]))) < eps()*100
     verify_lambdas(2, pnep, λv[1:2], V[:,1:2], sqrt(eps()))
 end

--- a/test/jd.jl
+++ b/test/jd.jl
@@ -15,7 +15,7 @@ using LinearAlgebra
 @info "Testing a PEP"
 nep = nep_gallery("pep0",60)
 TOL = 1e-11;
-λ,u = jd_betcke(nep, tol=TOL, maxit=55, Neig = 3, logger=displaylevel, v=ones(size(nep,1)),errmeasure=ResidualErrmeasure)
+λ,u = jd_betcke(nep, tol=TOL, maxit=55, neigs = 3, logger=displaylevel, v=ones(size(nep,1)),errmeasure=ResidualErrmeasure)
 @info " Smallest eigenvalue found: $λ"
 Dc,Vc = polyeig(nep,DefaultEigSolver)
 c = sortperm(abs.(Dc))
@@ -40,7 +40,7 @@ verify_lambdas(1, nep, λ, u, TOL)
 v0 = vec(u)
 
 @info "Testing convergence before starting"
-λ,u=jd_betcke(nep, tol=TOL, maxit=25, Neig=1, logger=displaylevel, λ=λ0, v=v0)
+λ,u=jd_betcke(nep, tol=TOL, maxit=25, neigs=1, logger=displaylevel, λ=λ0, v=v0)
 verify_lambdas(1, nep, λ, u, TOL)
 
 
@@ -53,7 +53,7 @@ nep = nep_gallery("pep0",4)
 # An undefined projection type
 @test_throws ErrorException λ,u=jd_betcke(nep, tol=TOL, maxit=4, projtype = :MYNOTDEFINED, v=ones(size(nep,1)))
 # Too many required eigenvalues, will not converge and hence throw an exception
-@test_throws NEPCore.NoConvergenceException λ,u=jd_betcke(nep, tol=TOL, maxit=4, Neig=1000, v=ones(size(nep,1)))
+@test_throws NEPCore.NoConvergenceException λ,u=jd_betcke(nep, tol=TOL, maxit=4, neigs=1000, v=ones(size(nep,1)))
 
 end
 
@@ -64,16 +64,16 @@ end
 
 TOL = 1e-10
 nep = nep_gallery("pep0",250)
-λ, u = jd_effenberger(nep, Neig=5, logger=displaylevel, tol=TOL, maxit=80, λ=0.82+0.9im, v=ones(ComplexF64,size(nep,1)))
+λ, u = jd_effenberger(nep, neigs=5, logger=displaylevel, tol=TOL, maxit=80, λ=0.82+0.9im, v=ones(ComplexF64,size(nep,1)))
 verify_lambdas(5, nep, λ, u, TOL)
 
 TOL = 1e-10
 nep = nep_gallery("dep0",60)
-λ, u = jd_effenberger(nep, Neig=3, logger=displaylevel, tol=TOL, maxit=55, λ=0.6+0im, v=ones(ComplexF64,size(nep,1)))#, inner_solver_method = IARChebInnerSolver)
+λ, u = jd_effenberger(nep, neigs=3, logger=displaylevel, tol=TOL, maxit=55, λ=0.6+0im, v=ones(ComplexF64,size(nep,1)))#, inner_solver_method = IARChebInnerSolver)
 verify_lambdas(3, nep, λ, u, TOL)
 
 @info "Testing convergence before starting"
-λ,u=jd_effenberger(nep, Neig=1, logger=displaylevel, tol=TOL, maxit=55, λ=λ[1], v=vec(u[:,1]))
+λ,u=jd_effenberger(nep, neigs=1, logger=displaylevel, tol=TOL, maxit=55, λ=λ[1], v=vec(u[:,1]))
 verify_lambdas(1, nep, λ, u, TOL)
 
 
@@ -84,7 +84,7 @@ nep = nep_gallery("pep0",50)
 # SG not possible with Effenberger
 @test_throws ErrorException λ, u = jd_effenberger(nep, tol=TOL, maxit=40, inner_solver_method = SGIterInnerSolver, v=ones(size(nep,1)))
 # Too many required eigenvalues, will not converge and hence throw an exception
-@test_throws NEPCore.NoConvergenceException λ, u = jd_effenberger(nep, Neig=1000, tol=TOL, maxit=20, v=ones(size(nep,1)))
+@test_throws NEPCore.NoConvergenceException λ, u = jd_effenberger(nep, neigs=1000, tol=TOL, maxit=20, v=ones(size(nep,1)))
 
 end
 

--- a/test/proj.jl
+++ b/test/proj.jl
@@ -77,7 +77,7 @@ using Random
 
         @info "Running IAR for projected problem ($nepstr)"
         λv,X=iar(pnep,σ=complex(round(λ_exact*10)/10),
-                 Neig=3,maxit=100, v=ones(size(pnep,1)))
+                 neigs=3,maxit=100, v=ones(size(pnep,1)))
 
         mydiff = minimum(abs.(λv .- λ_exact))
         @info "Difference of solution from projected problem ($nepstr): $mydiff"

--- a/test/tiar.jl
+++ b/test/tiar.jl
@@ -22,12 +22,12 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
     dep=nep_gallery("dep0",n);
 
     @bench @testset "accuracy eigenpairs" begin
-        (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
+        (λ,Q)=tiar(dep,σ=2.0,γ=3,neigs=4,v=ones(n),maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
         verify_lambdas(4, dep, λ, Q, eps()*100)
     end
 
-    @testset "Compute as many eigenpairs as possible (Neig=Inf)" begin
-        (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=Inf,v=ones(n),maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
+    @testset "Compute as many eigenpairs as possible (neigs=Inf)" begin
+        (λ,Q)=tiar(dep,σ=2.0,γ=3,neigs=Inf,v=ones(n),maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
         verify_lambdas(4, dep, λ, Q, eps()*100)
     end
 
@@ -35,22 +35,22 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
 
     # NOW TEST DIFFERENT ORTHOGONALIZATION METHODS
     @bench @testset "DGKS" begin
-        (λ,Q,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
+        (λ,Q,Z)=tiar(dep,σ=2.0,γ=3,neigs=4,v=ones(n),maxit=50,tol=eps()*100,errmeasure=ResidualErrmeasure);
         @test opnorm(Z'*Z - I) < 1e-6
      end
 
      @bench @testset "User provided doubleGS" begin
-         (λ,Q,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100);
+         (λ,Q,Z)=tiar(dep,σ=2.0,γ=3,neigs=4,v=ones(n),maxit=50,tol=eps()*100);
          @test opnorm(Z'*Z - I) < 1e-6
       end
 
       @bench @testset "ModifiedGramSchmidt" begin
-          (λ,Q,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100);
+          (λ,Q,Z)=tiar(dep,σ=2.0,γ=3,neigs=4,v=ones(n),maxit=50,tol=eps()*100);
           @test opnorm(Z'*Z - I) < 1e-6
       end
 
        @bench @testset "ClassicalGramSchmidt" begin
-           (λ,Q,Z)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(n),maxit=50,tol=eps()*100);
+           (λ,Q,Z)=tiar(dep,σ=2.0,γ=3,neigs=4,v=ones(n),maxit=50,tol=eps()*100);
            @test opnorm(Z'*Z - I) < 1e-6
        end
     end
@@ -58,8 +58,8 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
     # iar and tiar ara mathematically equivalent it maxit<<nep
     # verify the equivalence numerically
     @bench @testset "equivalance with IAR" begin
-        (λ_tiar,Q_tiar)=tiar(dep,σ=2.0,γ=3,Neig=2,v=ones(n),maxit=50,tol=eps()*100);
-        (λ_iar,Q_iar)=iar(dep,σ=2.0,γ=3,Neig=2,v=ones(n),maxit=50,tol=eps()*100);
+        (λ_tiar,Q_tiar)=tiar(dep,σ=2.0,γ=3,neigs=2,v=ones(n),maxit=50,tol=eps()*100);
+        (λ_iar,Q_iar)=iar(dep,σ=2.0,γ=3,neigs=2,v=ones(n),maxit=50,tol=eps()*100);
         @test norm(λ_tiar-λ_iar)<1e-6
         @test norm(Q_tiar-Q_iar)<1e-6
     end
@@ -70,7 +70,7 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
         nn=opnorm(compute_Mder(depp,0));
         errmeasure= (λ,v) -> norm(compute_Mlincomb(depp,λ,v))/nn;
 
-        λ,Q = tiar(depp, σ=0, γ=3, Neig=3, v=ones(np), maxit=50,
+        λ,Q = tiar(depp, σ=0, γ=3, neigs=3, v=ones(np), maxit=50,
                    tol=sqrt(eps()), check_error_every=3,
                    proj_solve=true, inner_solver_method=IARInnerSolver,
                    errmeasure=errmeasure);
@@ -81,7 +81,7 @@ function orthogonalize_and_normalize!(V,v,h,::Type{DoubleGS})
     @testset "Errors thrown" begin
         np=100;
         dep=nep_gallery("dep0",np);
-        @test_throws NEPCore.NoConvergenceException (λ,Q)=tiar(dep,σ=2.0,γ=3,Neig=4,v=ones(np),maxit=5,tol=eps()*100,errmeasure=ResidualErrmeasure);
+        @test_throws NEPCore.NoConvergenceException (λ,Q)=tiar(dep,σ=2.0,γ=3,neigs=4,v=ones(np),maxit=5,tol=eps()*100,errmeasure=ResidualErrmeasure);
     end
 
 end

--- a/test/transf.jl
+++ b/test/transf.jl
@@ -50,12 +50,12 @@ using LinearAlgebra
         α=0.9;
         nep3_transf=shift_and_scale(nep3,shift=σ,scale=α);
         @test norm(compute_Mlincomb(nep3_transf,(λ-σ)/α,v))<sqrt(eps())*10;
-        λ,V=iar(nep3_transf,σ=0,Neig=2,maxit=60)
+        λ,V=iar(nep3_transf,σ=0,neigs=2,maxit=60)
         @test norm(compute_Mlincomb(nep3,α*λ[1]+σ,V[:,1]))<sqrt(eps())
         @test norm(compute_Mlincomb(nep3,α*λ[2]+σ,V[:,2]))<sqrt(eps())
 
 
-        λ,V=iar(nep3_transf,σ=0,Neig=2,maxit=60)
+        λ,V=iar(nep3_transf,σ=0,neigs=2,maxit=60)
         @test norm(compute_Mlincomb(nep3,α*λ[1]+σ,V[:,1]))<sqrt(eps())
         @test norm(compute_Mlincomb(nep3,α*λ[2]+σ,V[:,2]))<sqrt(eps())
         #

--- a/test/wep_small.jl
+++ b/test/wep_small.jl
@@ -62,12 +62,12 @@ n=size(nep,1);
 
 
     nev=3
-    λ,v = iar(ComplexF64,nep,σ=λ0, logger=displaylevel,Neig=nev,maxit=100,v=v0,
+    λ,v = iar(ComplexF64,nep,σ=λ0, logger=displaylevel,neigs=nev,maxit=100,v=v0,
                   tol=1e-8);
 
     @test minimum(abs.(λstar .- λ)) < 1e-10
 
-    #λ,v = tiar(nep,σ=λ0, displaylevel=displaylevel,Neig=nev,maxit=100,v=v0,
+    #λ,v = tiar(nep,σ=λ0, displaylevel=displaylevel,neigs=nev,maxit=100,v=v0,
     #               tol=1e-8);
 
 end


### PR DESCRIPTION
Changing from `Neig` to `neigs` as in the [style guide](https://github.com/nep-pack/NonlinearEigenproblems.jl/wiki/Style-guidelines-and-notes). See #184 