### PR TITLE
PEPs in Chebyshev basis

### DIFF
--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -44,20 +44,19 @@ get_fv
 
 
 ## PEP
-The Polynomial Eigenvalue Problem is described by
+A PEP is a matrix polynomial in `λ`:
 ```math
 M(λ) = \sum_{i} A_i λ^i.
 ```
-
-```@docs
-PEP
-```
-
-In order to construct a `PEP`, we only need to provide
-the matrices.
+There are two types to represent PEPs natively in
+NEP-PACK. You can use a monomial basis with
+`PEP` or a Chebyshev basis with `ChebPEP`.
 
 ```@docs
 PEP(AA::Array)
+```
+```@docs
+ChebPEP(AA::Array)
 ```
 
 

--- a/src/NEPTypes.jl
+++ b/src/NEPTypes.jl
@@ -513,218 +513,7 @@ julia> norm(M1-M2)
         return fv
     end
 
-    ###########################################################
-    # Polynomial eigenvalue problem - PEP
-    #
-
-    """
-    struct PEP <: AbstractSPMF
-
-A polynomial eigenvalue problem (PEP) is defined by the sum the sum ``Σ_i A_i λ^i``, where i = 0,1,2,..., and  all of the matrices are of size n times n.
-"""
-    struct PEP <: AbstractSPMF{AbstractMatrix}
-        n::Int
-        A::Array   # Monomial coefficients of PEP
-    end
-
-"""
-    PEP(AA::Array)
-
-Creates a polynomial eigenvalue problem with monomial matrices specified in
-AA, which is an array of matrices.
-
-```julia-repl
-julia> A0=[1 3; 4 5]; A1=A0.+one(2); A2=ones(2,2);
-julia> pep=PEP([A0,A1,A2])
-julia> compute_Mder(pep,3)-(A0+A1*3+A2*9)
-2×2 Array{Float64,2}:
- 0.0  0.0
- 0.0  0.0
-```
-"""
-    function PEP(AA::Array)
-        n=size(AA[1],1)
-        AA=reshape(AA,size(AA,1))
-        return PEP(n,AA)
-    end
-
-# Computes the sum ``Σ_i M_i V f_i(S)`` for a PEP
-    function compute_MM(nep::PEP,S,V)
-        T=promote_type(promote_type(eltype(nep.A[1]),eltype(S)),eltype(V))
-        local Z
-        if (issparse(nep))
-            Z=spzeros(T,size(V,1),size(V,2))
-            Si=sparse(one(T)*I, size(S,1), size(S,1))
-        else
-            Z=zeros(T,size(V,1),size(V,2))
-            Si=Matrix(one(T)*I, size(S,1), size(S,1))
-        end
-        for i=1:size(nep.A,1)
-            Z+=nep.A[i]*V*Si;
-            Si=Si*S;
-        end
-        return Z
-    end
-
-    compute_rf(nep::PEP,x;params...) = compute_rf(ComplexF64,nep,x;params...)
-    function compute_rf(::Type{T},nep::PEP,x; y=x, target=zero(T), λ0=target,
-                        TOL=eps(real(T))*1e3,max_iter=10) where T<:Real
-
-        a=zeros(T,size(nep.A,1))
-        for i=1:size(nep.A,1)
-            a[i]=dot(y,nep.A[i]*x);
-        end
-        m=size(nep.A,1);
-        # Build a bigfloat companion matrix
-        A=zeros(T,m-1,m-1);
-        for k=1:m-1
-            if (k<m-1)
-                A[k,k+1]=1;
-            end
-            A[end,k]=-a[k]/a[end]
-        end
-        pp=eigvals(A);
-        if (T <: Real) # If we specify real arithmetic, return real eigvals
-            pp=real(pp);
-        end
-
-        II=sortperm(abs.(pp .- target))
-        return pp[II];
-    end
-
-    # Overload a version of eigvals(::Matrix{BigFloat}) for compute_rf
-    import LinearAlgebra.eigvals
-    function eigvals(A::Union{Matrix{BigFloat},Matrix{Complex{BigFloat}}})
-        T=eltype(A);
-        Tfloat= (T <: Complex) ? (ComplexF64) : (Float64)
-        Afloat=Matrix{Tfloat}(A);
-        λv,X=eigen(Afloat);
-        local λv_bigfloat=Vector{Complex{BigFloat}}(λv);
-        # Some Rayleigh quotient iteration steps in bigfloat to improve accuracy:
-        for j=1:size(λv,1)
-            local s=λv_bigfloat[j];
-            z=Vector{Complex{BigFloat}}(X[:,j])
-            for f=1:3
-                z=(A-s*I)\z; normalize!(z);
-                s=z'*A*z;
-            end
-            λv_bigfloat[j]=s
-        end
-        if (maximum(abs.((λv_bigfloat-λv)./λv_bigfloat)) > eps()*100)
-            @warn("Correction iteration of eigvals for bigfloat, made the eigenvalues move considerably")
-        end
-
-        return λv_bigfloat
-    end
-
-
-
-# Compute the ith derivative of a PEP
-    function compute_Mder(nep::PEP,λ::Number,i::Integer=0)
-        if (issparse(nep))
-            Z=spzeros(eltype(nep.A[1]),size(nep,1),size(nep,1));
-        else
-            Z=zeros(eltype(nep.A[1]),size(nep,1),size(nep,1));
-        end
-        for j=(i+1):size(nep.A,1)
-            # Derivatives of monimials
-            Z+= nep.A[j]*(λ^(j-i-1)*factorial(j-1)/factorial(j-i-1))
-        end
-        return Z
-    end
-
-    #  Fetch the Av's, since they are not explicitly stored in PEPs
-    function get_Av(nep::PEP)
-        return nep.A;
-    end
-    #  Fetch the Fv's, since they are not explicitly stored in PEPs
-    function get_fv(nep::PEP)
-        fv=Vector{Function}(undef, size(nep.A,1))
-        # Construct monomial functions
-        for i=1:size(nep.A,1)
-            if (i==1); # optimization for constant and linear term
-                fv[1] = S -> one(S);
-            elseif (i==2);
-                fv[2]=S->S;
-            else
-                # we need to introuce j otherwise the function is not typestable
-                j=i-1; # power of the coefficient
-                fv[i]=S->S^j;
-            end
-        end
-        return fv;
-    end
-
-
-"""
-    interpolate([T=ComplexF64,] nep::NEP, intpoints::Array)
- Interpolates a NEP in the points `intpoints` and returns a `PEP`.\\
- `T` is the Type in which the matrices of the PEP should be defined.
-"""
-    interpolate(nep::NEP, intpoints::Array) = interpolate(ComplexF64, nep, intpoints)
-    function interpolate(::Type{T}, nep::NEP, intpoints::Array) where {T<:Number}
-
-        n = size(nep, 1)
-        d = length(intpoints)
-
-        V = zeros(T,d,d) #Vandermonde matrix
-        pwr = ones(d,1)
-        for i = 1:d
-            V[:,i] = pwr
-            pwr = pwr.*intpoints
-        end
-
-        if (issparse(nep)) #If Sparse, do elementwise interpolation
-            b = Vector{SparseMatrixCSC{T}}(undef, d)
-            AA = Vector{SparseMatrixCSC{T}}(undef, d)
-            V = factorize(V) # Will be used multiple times, factorize
-
-            for i=1:d
-                b[i] = compute_Mder(nep, intpoints[i])
-            end
-
-            # OBS: The following lines and hence the following method assumes that Sparsity-structure is the same!
-            nnz_AA = nnz(b[1])
-            for i=1:d
-                AA[i] = copy(b[1])
-            end
-
-            f = zeros(d,1)
-            for i = 1:nnz_AA
-                for j = 1:d
-                    f[j] = b[j].nzval[i]
-                end
-                a = \(V,f)
-                for j = 1:d
-                    AA[j].nzval[i] = a[j]
-                end
-            end
-
-        else # If dense, use Vandermonde
-            b = zeros(T,n*d,n)
-            AA = Vector{Matrix{T}}(undef,d)
-            (L, U, p) = lu(V)
-
-            LL = kron(L, SparseMatrixCSC(I,(n,n)))
-            UU = kron(U, SparseMatrixCSC(I,(n,n)))
-
-            for i = 1:d
-                b[(1:n).+(i-1)*n,:] =  compute_Mder(nep,intpoints[p[i]])
-            end
-
-            A = \(UU, \(LL,b))
-
-            for i = 1:d
-                AA[i] = A[(1:n).+(i-1)*n,:]
-            end
-        end
-
-        return PEP(AA)
-    end
-  # TODO: Implement interpolation similar to Effenberger and Kressner. "Chebyshev interpolation for nonlinear eigenvalue problems." BIT Numerical Mathematics 52.4 (2012): 933-951.
-
-
-
+    include("types_poly.jl");
 
     ###########################################################
     # Rational eigenvalue problem - REP
@@ -1363,8 +1152,8 @@ Returns true/false if the NEP is sparse (if compute_Mder() returns sparse)
 """
     newspmf=DerSPMF(spmf,σ,m)
 
-Creates a `DerSPMF` representing the NEP `spmf` where the first `m` derivatives of the functions `f_i` in the number 
-`σ` are precomputed. This will in general speed up the execution of [`compute_Mlincomb`](@ref) for the 
+Creates a `DerSPMF` representing the NEP `spmf` where the first `m` derivatives of the functions `f_i` in the number
+`σ` are precomputed. This will in general speed up the execution of [`compute_Mlincomb`](@ref) for the
 selected shift `σ`.
 
 # Parameters
@@ -1383,7 +1172,7 @@ julia> m=5 # Precompute 5 derivatives
 julia> σ=3.3
 julia> dnep=DerSPMF(nep,σ,m)
 julia> V=rand(2,m)
-julia> z=compute_Mlincomb(dnep,σ,V)  # Same as below ... 
+julia> z=compute_Mlincomb(dnep,σ,V)  # Same as below ...
 2-element Array{Float64,1}:
 39.47327945131233
 64.31391434063991

--- a/src/method_companion.jl
+++ b/src/method_companion.jl
@@ -116,12 +116,12 @@ polyeig(pep::ChebPEP,vargs...)=polyeig(ComplexF64,pep,vargs...)
 function polyeig(::Type{T}, pep::ChebPEP{TT,Ftype}) where {T,Ftype,TT}
         k=pep.k
         Fk=get_Av(pep);
-        @show k
+
         n=size(pep,1);
         L0=zeros(T,n*(k-1),n*(k-1));
         L1=zeros(T,n*(k-1),n*(k-1));
         II=Matrix{Ftype}(I,n,n);
-        @show L0
+
         for j=1:(k-2)
             L0[((j-1)*n) .+ (1:n), j*n .+ (1:n)]=II
             L0[j*n .+ (1:n), ((j-1)*n) .+ (1:n)]=II
@@ -131,10 +131,8 @@ function polyeig(::Type{T}, pep::ChebPEP{TT,Ftype}) where {T,Ftype,TT}
             L0[((k-2)*n) .+ (1:n), (n*(j-1)).+ (1:n)]=-Fk[j];
         end
 
-        @show L0
         L0[((k-2)*n) .+ (1:n), (n*(k-3)) .+ (1:n)] += Fk[k];
 
-        @show L0
         for j=1:k-2
             factor=2;
             if (j==1)
@@ -147,8 +145,8 @@ function polyeig(::Type{T}, pep::ChebPEP{TT,Ftype}) where {T,Ftype,TT}
 
         LL=eigen(L0,L1);
 
-        @show L1
-        return (LL.values,
+        a=pep.a; b=pep.b;
+        return ((b-a)*(LL.values .+ 1)/2 .+ a,
                 hcat(map(i -> normalize(LL.vectors[1:n,i]), 1:(n*(k-1)))...))
 
     end

--- a/src/method_companion.jl
+++ b/src/method_companion.jl
@@ -100,14 +100,26 @@ julia> norm(compute_Mlincomb(pep,λ[2],vec(V[:,2])))
 
 
 
-    # TODO: Implement interpolation similar to Effenberger and Kressner. "Chebyshev interpolation for nonlinear eigenvalue problems." BIT Numerical Mathematics 52.4 (2012): 933-951.
-    function polyeig(pep::ChebPEP{T,Ftype}) where {T,Ftype}
+"""
+    λ,v = polyeig([eltype],nep::ChebPEP)
+
+Computes a companion linearization for the NEP represented
+in a Chebyshev basis, and returns eigenpairs.
+
+# References:
+
+* Amiraslani, A., Corless, R. M. & Lancaster, P. "Linearization of matrix polynomials expressed in poly-nomial bases" IMA J. Numer. Anal.,29 (2009): 141–157.
+* Effenberger and Kressner. "Chebyshev interpolation for nonlinear eigenvalue problems." BIT Numerical Mathematics 52.4 (2012): 933-951.
+
+"""
+polyeig(pep::ChebPEP,vargs...)=polyeig(ComplexF64,pep,vargs...)
+function polyeig(::Type{T}, pep::ChebPEP{TT,Ftype}) where {T,Ftype,TT}
         k=pep.k
         Fk=get_Av(pep);
         @show k
         n=size(pep,1);
-        L0=zeros(Ftype,n*(k-1),n*(k-1));
-        L1=zeros(Ftype,n*(k-1),n*(k-1));
+        L0=zeros(T,n*(k-1),n*(k-1));
+        L1=zeros(T,n*(k-1),n*(k-1));
         II=Matrix{Ftype}(I,n,n);
         @show L0
         for j=1:(k-2)

--- a/src/types_cheb_pep.jl
+++ b/src/types_cheb_pep.jl
@@ -1,0 +1,180 @@
+
+struct ChebPEPFull <: AbstractSPMF{AbstractMatrix}
+    n::Int # size
+    a; b # Chebyshev polys are scaled to the interval
+    Fk::Array   # function values in Chebyshev nodes
+    spmf::SPMF_NEP; # The cheb-coefficents are stored directly in the SPMF
+end
+
+
+
+#type ChebPEPEco <: AbstractSPMF
+#    n::Int # size
+#    a,b # Chebyshev polys are scaled to the interval
+#    Fk::Array   # function values in Chebyshev nodes
+#end
+#
+#ChebPEP = Union{ChebPEPFull}
+#ChebPEP = ChebPEPFull;
+
+# Returns the chebyshev nodes scaled to interval [a,b]
+# computed with type T
+function get_chebyshev_nodes(::Type{T},a,b,k) where {T<:Real}
+    mypi=T(pi);
+    return (T(a)+T(b))/2 .+ (T(b)-T(a))*(cos.((2*Vector(1:k).-1)*mypi/(2*k)))/2
+end
+function cheb_f_cosine_formula(a,b,x,k)
+    x1=2*(x-a*one(x))/(b-a)-one(x);
+    return cos(k*acos(x1));
+end
+function cheb_f_poly(a,b,x,k)
+    x1=2*(x-a*one(x))/(b-a) -one(x);
+    if (k==0)
+        return 1;
+    elseif k==1
+        return x1
+    elseif k==2
+        return 2*x1^2-one(x1)
+    elseif k==3
+        return 4*x1^3-3*x1
+    elseif k==4
+        return 8*x1^4-8*x^2+one(x1)
+    else
+        error("Not implemented")
+    end
+end
+function cheb_f(a,b,x,k)
+    return cheb_f_cosine_formula(a,b,x,k);
+#    return cheb_f_poly(a,b,x,k);
+end
+
+# Evaluate F in the chebyshev nodes
+function chebyshev_eval(a,b,k,F::Function)
+    x=get_chebyshev_nodes(Float64,a,b,k)
+    Fk=F.(x);
+    return (Fk,x)
+end
+
+
+function chebyshev_compute_coefficients_naive(a,b,Fk,k)
+    xk=get_chebyshev_nodes(Float64,a,b,k)
+    @show xk
+    if (size(xk) != size(Fk))
+        error("Incompatible sizes");
+    end
+
+
+    Tinv=zeros(k,k);
+    for i=1:k
+        for j=1:k
+            Tinv[i,j]=cheb_f(a,b,xk[i],j-1);
+        end
+    end
+    @show Tinv
+
+    Ck=Tinv\Fk
+
+    return Ck
+
+end
+
+function chebyshev_compute_coefficients(a,b,Fk,k)
+    # Return coefficient
+    xk=get_chebyshev_nodes(Float64,a,b,k)
+    if (size(xk) != size(Fk))
+        error("Incompatible sizes");
+    end
+    Tmat=zeros(k,k);
+    for i=1:k
+        Tmat[i,:]= map(x->cheb_f(a,b,x,i-1)*2/k,xk)
+    end
+    Tmat[1,:] *= 0.5; # Fix the prime in the sum
+
+    # Compute the coefficients from the Tmat via
+    # a "matrix vector multiplication"
+
+    # When Fk are scalars
+    #Ck=Tmat*Fk;
+    # Generalization when Fk are vectors or matrices:
+    Ck=map(i-> sum(Fk .* Tmat[i,:]), 1:k)
+
+
+    return Ck
+end
+
+# Evaluate a ChebPEP in a point: <=> Interpolate
+# Compute coefficients:
+# http://inis.jinr.ru/sl/M_Mathematics/MRef_References/Mason,%20Hanscomb.%20Chebyshev%20polynomials%20(2003)/C0355-Ch06.pdf
+
+
+f=s-> ones(3)-(1:3)*sin(s);
+#f=s-> 1-1/(s+6);
+#f=s-> 1+s;
+k=3;
+a=-1;b=4;
+
+(Fk,xk)=chebyshev_eval(a,b,k,f);
+
+Ck0=chebyshev_compute_coefficients(a,b,Fk,k);
+#Ck1=chebyshev_compute_coefficients_naive(a,b,Fk,k);
+
+Ck=Ck1;
+xk=get_chebyshev_nodes(Float64,a,b,k)
+xx=xk[1];
+ff0=mapreduce(i->Ck0[i]*cheb_f(a,b,xx,i-1), +, 1:k)
+#ff1=mapreduce(i->Ck1[i]*cheb_f(a,b,xx,i-1), +, 1:k)
+
+@show norm(ff0-f(xx))
+#@show ff1-f(xx)
+
+
+
+
+function ChebPEP()
+
+end
+
+
+#function polyeig(pep::ChebPEP)
+#
+#end
+
+# Compute Mlincomb?
+
+
+"""
+
+Interpolates the orgspmf in the interval [a,b] with
+k chebyshev nodes and gives a representation
+in terms of a Chebyshev basis.
+"""
+function ChebPEPFull(orgspmf,a,b,k)
+    F=s-> compute_Mder(orgspmf,s);
+    (Fk,xk)=chebyshev_eval(a,b,k,F);
+    @show Fk
+    @show xk
+    Ck=chebyshev_compute_coefficients(a,b,Fk,k);
+
+    fv=Array{Function}(undef,0);
+    for j=1:k
+        push!(fv, S-> cheb_f(a,b,S,j-1))
+    end
+    cheb_spmf=SPMF_NEP(Ck,fv);
+
+    n=size(Fk[1],1);
+    return ChebPEPFull(n,a,b,Fk,cheb_spmf);
+end
+
+nep=nep_gallery("dep0");
+nep2=ChebPEPFull(nep,-2,3,23);
+nep3=nep2.spmf;
+
+s=0;
+
+compute_Mder(nep,s)-compute_Mder(nep3,s)
+
+λ1=iar(nep,neigs=2,logger=1)[1]
+λ3=iar(nep3,neigs=2,logger=1)[1]
+
+
+@show norm(λ1-λ3)

--- a/src/types_cheb_pep.jl
+++ b/src/types_cheb_pep.jl
@@ -147,7 +147,13 @@ get_fv(nep::ChebPEP)=get_fv(nep.spmf)
 The type `ChebPEP<:AbstractSPMF` represents a polynomial function
 where the
 function is stored using a Chebyshev basis scaled to the
-interval `[a,b]`. The creator `ChebPEP` takes `nep::NEP` as an input
+interval `[a,b]`, i.e.,
+```math
+M(λ)= B_0T_0(λ)+⋯+B_{k-1}T_{k-1}(λ)
+```
+where `T_i` are the scaled and shifted Chebyshev polynomials.
+
+The creator `ChebPEP` takes `nep::NEP` as an input
 and interpolates this NEP in `k` Chebyshev nodes, resulting
 in a polynomial of degree `k-1`, represented by its
 coefficients in the Chebyshev basis.

--- a/src/types_cheb_pep.jl
+++ b/src/types_cheb_pep.jl
@@ -65,6 +65,8 @@ end
 
 # Compute the chebyshev coefficients of the coefficients
 # stored in Fk. xk should be the chebyshev points
+# Chebyshev Polynomials, 1st Edition, J.C. Mason, David C. Handscomb
+# Chapter 8
 function chebyshev_compute_coefficients(a,b,Fk,xk)
     # Return coefficient
     k=size(Fk,1);
@@ -158,46 +160,4 @@ function ChebPEP(orgspmf,k,a=-1,b=1)
     n=size(Fk[1],1);
     # Instantiate the type
     return ChebPEP{MatType,T}(n,a,b,k,cheb_spmf);
-end
-
-
-# TODO: Implement interpolation similar to Effenberger and Kressner. "Chebyshev interpolation for nonlinear eigenvalue problems." BIT Numerical Mathematics 52.4 (2012): 933-951.
-function polyeig(pep::ChebPEP{T,Ftype}) where {T,Ftype}
-    k=pep.k
-    Fk=get_Av(pep);
-    @show k
-    n=size(pep,1);
-    L0=zeros(Ftype,n*(k-1),n*(k-1));
-    L1=zeros(Ftype,n*(k-1),n*(k-1));
-    II=Matrix{Ftype}(I,n,n);
-    @show L0
-    for j=1:(k-2)
-        L0[((j-1)*n) .+ (1:n), j*n .+ (1:n)]=II
-        L0[j*n .+ (1:n), ((j-1)*n) .+ (1:n)]=II
-    end
-
-    for j=1:k-1
-        L0[((k-2)*n) .+ (1:n), (n*(j-1)).+ (1:n)]=-Fk[j];
-    end
-
-    @show L0
-    L0[((k-2)*n) .+ (1:n), (n*(k-3)) .+ (1:n)] += Fk[k];
-
-    @show L0
-    for j=1:k-2
-        factor=2;
-        if (j==1)
-            factor=1
-        end
-        L1[((j-1)*n) .+ (1:n), ((j-1)*n) .+ (1:n)]=factor*II
-    end
-    L1[((k-2)*n) .+ (1:n),
-       ((k-2)*n) .+ (1:n)]=2*Fk[k]
-
-    LL=eigen(L0,L1);
-
-    @show L1
-    return (LL.values,
-            hcat(map(i -> normalize(LL.vectors[1:n,i]), 1:(n*(k-1)))...))
-
 end

--- a/src/types_cheb_pep.jl
+++ b/src/types_cheb_pep.jl
@@ -135,10 +135,32 @@ get_fv(nep::ChebPEP)=get_fv(nep.spmf)
 
 
 """
+    ChebPEP(orgnep::NEP,k,[a=-1,[b=1]])
 
-Interpolates the orgspmf in the interval [a,b] with
-k chebyshev nodes and gives a representation
-in terms of a Chebyshev basis.
+The type `ChebPEP<:AbstractSPMF` represents a polynomial function
+where the
+function is stored using a Chebyshev basis scaled to the
+interval `[a,b]`. The creator `ChebPEP` takes `nep::NEP` as an input
+and interpolates this NEP in `k` Chebyshev nodes, resulting
+in a polynomial of degree `k-1`.
+Interpolation in Chebyshev nodes is known to have
+attractive approximation properties, as well
+as robustness with respect to round-off errors.
+
+# Example:
+
+```julia
+julia> nep=nep_gallery("dep0");
+julia> chebpep=ChebPEP(nep,9);
+julia> using LinearAlgebra;
+julia> norm(compute_Mder(nep,0.3)-compute_Mder(chebpep,0.3))
+1.6920305863798614e-8
+julia> chebpep=ChebPEP(nep,19); # Better interpolation
+julia> norm(compute_Mder(nep,0.3)-compute_Mder(chebpep,0.3))
+2.2782119183158333e-15
+```
+
+See also: `polyeig`
 """
 function ChebPEP(orgspmf,k,a=-1,b=1)
     F=s-> compute_Mder(orgspmf,s);

--- a/src/types_cheb_pep.jl
+++ b/src/types_cheb_pep.jl
@@ -1,13 +1,13 @@
 
 export ChebPEP
 
-
 # Returns the chebyshev nodes scaled to interval [a,b]
 # computed with type T
 function get_chebyshev_nodes(::Type{T},a,b,k) where {T<:Real}
     mypi=T(pi);
     return (T(a)+T(b))/2 .+ (T(b)-T(a))*(cos.((2*Vector(1:k).-1)*mypi/(2*k)))/2
 end
+
 import Base.acos
 function acos(S::LowerTriangular)
     # Specialized acos-function for a lower triangular matrix
@@ -30,7 +30,7 @@ end
 function cheb_f_poly(a,b,x,k)
     x1=2*(x-a*one(x))/(b-a) -one(x);
     if (k==0)
-        return 1;
+        return one(x1);
     elseif k==1
         return x1
     elseif k==2
@@ -38,14 +38,16 @@ function cheb_f_poly(a,b,x,k)
     elseif k==3
         return 4*x1^3-3*x1
     elseif k==4
-        return 8*x1^4-8*x^2+one(x1)
+        return 8*x1^4-8*x1^2+one(x1)
+    elseif k==5
+        return 16*x1^5 - 20*x1^3 + 5*x1;
     else
         error("Not implemented")
     end
 end
+
 function cheb_f(a,b,x,k)
     return cheb_f_cosine_formula(a,b,x,k);
-#    return cheb_f_poly(a,b,x,k);
 end
 
 # Evaluate F in the chebyshev nodes
@@ -122,15 +124,6 @@ end
 
 
 # Delegate compute functions
-#import NonlinearEigenproblems.NEPCore.compute_Mder
-#import NonlinearEigenproblems.NEPCore.compute_Mlincomb
-#import NonlinearEigenproblems.NEPCore.compute_MM
-#import NonlinearEigenproblems.NEPTypes.get_Av
-#import NonlinearEigenproblems.NEPTypes.get_fv
-#import NonlinearEigenproblems.NEPSolver.polyeig
-#import Base.size
-#using LinearAlgebra
-#
 
 function size(nep::ChebPEP)
     return (nep.n,nep.n)
@@ -138,7 +131,6 @@ end
 function size(nep::ChebPEP,dim)
     return nep.n
 end
-
 compute_Mlincomb(nep::ChebPEP,λ::Number,V::AbstractVecOrMat,a::Vector)= compute_Mlincomb(nep.spmf,λ,V,a);
 compute_Mlincomb(nep::ChebPEP,λ::Number,V::AbstractVecOrMat)= compute_Mlincomb(nep.spmf,λ,V);
 compute_Mder(nep::ChebPEP,λ::Number)=compute_Mder(nep.spmf,λ,0)
@@ -150,17 +142,26 @@ get_fv(nep::ChebPEP)=get_fv(nep.spmf)
 
 
 """
-    ChebPEP(orgnep::NEP,k,[a=-1,[b=1]])
+    ChebPEP(orgnep::NEP,k,[a=-1,[b=1]] [,cosine_formula_cutoff=5])
 
 The type `ChebPEP<:AbstractSPMF` represents a polynomial function
 where the
 function is stored using a Chebyshev basis scaled to the
 interval `[a,b]`. The creator `ChebPEP` takes `nep::NEP` as an input
 and interpolates this NEP in `k` Chebyshev nodes, resulting
-in a polynomial of degree `k-1`.
+in a polynomial of degree `k-1`, represented by its
+coefficients in the Chebyshev basis.
 Interpolation in Chebyshev nodes is known to have
 attractive approximation properties, as well
 as robustness with respect to round-off errors.
+
+The kwarg `cosine_formula_cutoff` decides how the Chebyshev
+polynomials should be computed. For larger degrees, one
+wants to use the cosine formula, whereas for low degrees
+the explicit monomial expression is more efficient.
+The explicit monomial expression will be used for degrees
+lower than `cosine_formula_cutoff`.
+
 
 # Example:
 
@@ -177,14 +178,18 @@ julia> norm(compute_Mder(nep,0.3)-compute_Mder(chebpep,0.3))
 
 See also: `polyeig`
 """
-function ChebPEP(orgspmf,k,a=-1,b=1)
+function ChebPEP(orgspmf,k,a=-1,b=1;cosine_formula_cutoff=5)
     F=s-> compute_Mder(orgspmf,s);
     (Fk,xk)=chebyshev_eval(a,b,k,F);
     Ck=chebyshev_compute_coefficients(a,b,Fk,xk);
 
     fv=Array{Function}(undef,0);
     for j=1:k
-        push!(fv, S-> cheb_f(a,b,S,j-1))
+        if (j>cosine_formula_cutoff)
+            push!(fv, S-> cheb_f_cosine_formula(a,b,S,j-1))
+        else
+            push!(fv, S-> cheb_f_poly(a,b,S,j-1))
+        end
     end
 
     # Determine the types (based on Ck[1])

--- a/src/types_cheb_pep.jl
+++ b/src/types_cheb_pep.jl
@@ -41,6 +41,12 @@ function cheb_f_poly(a,b,x,k)
         return 8*x1^4-8*x1^2+one(x1)
     elseif k==5
         return 16*x1^5 - 20*x1^3 + 5*x1;
+    elseif k==6
+        return 32*x1^6-48*x1^4+18*x1^2-one(x1);
+    elseif k==7
+        return 64*x1^7-112*x1^5+56*x1^3-7*x1;
+    elseif k==8
+        return 128*x1^8-256*x1^6+160*x1^4-32*x1^2+one(x1);
     else
         error("Not implemented")
     end

--- a/src/types_cheb_pep.jl
+++ b/src/types_cheb_pep.jl
@@ -8,8 +8,23 @@ function get_chebyshev_nodes(::Type{T},a,b,k) where {T<:Real}
     mypi=T(pi);
     return (T(a)+T(b))/2 .+ (T(b)-T(a))*(cos.((2*Vector(1:k).-1)*mypi/(2*k)))/2
 end
+import Base.acos
+function acos(S::LowerTriangular)
+    # Specialized acos-function for a lower triangular matrix
+    # Some extra allocations, but preserves realness.
+    #
+    # This is a work-around julia issue:
+    #    https://github.com/JuliaLang/julia/issues/32721
+    F=acos(Matrix(S));
+    if (all(isreal.(acos.(diag(S)))))
+        F .= real(F);
+    end
+end
 function cheb_f_cosine_formula(a,b,x,k)
     x1=2*(x-a*one(x))/(b-a)-one(x);
+    if (istril(x1) && (x1 isa AbstractMatrix))
+        x1=LowerTriangular(x1);
+    end
     return cos(k*acos(x1));
 end
 function cheb_f_poly(a,b,x,k)

--- a/src/types_poly.jl
+++ b/src/types_poly.jl
@@ -206,7 +206,6 @@ function interpolate(::Type{T}, nep::NEP, intpoints::Array) where {T<:Number}
 
     return PEP(AA)
 end
-# TODO: Implement interpolation similar to Effenberger and Kressner. "Chebyshev interpolation for nonlinear eigenvalue problems." BIT Numerical Mathematics 52.4 (2012): 933-951.
 
 
-#include("types_cheb_pep.jl");
+include("types_cheb_pep.jl");

--- a/src/types_poly.jl
+++ b/src/types_poly.jl
@@ -209,48 +209,4 @@ end
 # TODO: Implement interpolation similar to Effenberger and Kressner. "Chebyshev interpolation for nonlinear eigenvalue problems." BIT Numerical Mathematics 52.4 (2012): 933-951.
 
 
-type ChebPEPFull <: AbstractSPMF
-    n::Int # size
-    a,b # Chebyshev polys are scaled to the interval
-    Fk::Array   # function values in Chebyshev nodes
-    spmf::SPMF_NEP; # The cheb-coefficents are stored directly in the SPMF
-end
-
-
-type ChebPEPEco <: AbstractSPMF
-    n::Int # size
-    a,b # Chebyshev polys are scaled to the interval
-    Fk::Array   # function values in Chebyshev nodes
-end
-
-ChebPEPCommon = Union{ChebPEPFull,ChebPEPEco};
-
-
-function get_chebyshev_nodes(a,b,k)
-end
-
-function chebyshev_eval(a,b,F)
-    # Evaluate F in the chebyshev nodes
-    return Fk
-end
-function chebyshev_compute_coefficients(a,b,Fk)
-    # Return coefficient
-    return Ck
-end
-
-# Evaluate a ChebPEP in a point: <=> Interpolate
-# Compute coefficients:
-# http://inis.jinr.ru/sl/M_Mathematics/MRef_References/Mason,%20Hanscomb.%20Chebyshev%20polynomials%20(2003)/C0355-Ch06.pdf
-
-
-function ChebPEP()
-
-end
-
-
-
-function polyeig(pep::ChebPEP)
-
-end
-
-# Compute Mlincomb?
+#include("types_cheb_pep.jl");

--- a/src/types_poly.jl
+++ b/src/types_poly.jl
@@ -1,0 +1,256 @@
+###########################################################
+# Polynomial eigenvalue problem - PEP
+#
+
+"""
+    struct PEP <: AbstractSPMF
+
+A polynomial eigenvalue problem (PEP) is defined by the sum the sum ``Σ_i A_i λ^i``, where i = 0,1,2,..., and  all of the matrices are of size n times n.
+"""
+struct PEP <: AbstractSPMF{AbstractMatrix}
+    n::Int
+    A::Array   # Monomial coefficients of PEP
+end
+
+"""
+    PEP(AA::Array)
+
+Creates a polynomial eigenvalue problem with monomial matrices specified in
+AA, which is an array of matrices.
+
+```julia-repl
+julia> A0=[1 3; 4 5]; A1=A0.+one(2); A2=ones(2,2);
+julia> pep=PEP([A0,A1,A2])
+julia> compute_Mder(pep,3)-(A0+A1*3+A2*9)
+2×2 Array{Float64,2}:
+ 0.0  0.0
+ 0.0  0.0
+```
+"""
+function PEP(AA::Array)
+    n=size(AA[1],1)
+    AA=reshape(AA,size(AA,1))
+    return PEP(n,AA)
+end
+
+# Computes the sum ``Σ_i M_i V f_i(S)`` for a PEP
+function compute_MM(nep::PEP,S,V)
+    T=promote_type(promote_type(eltype(nep.A[1]),eltype(S)),eltype(V))
+    local Z
+    if (issparse(nep))
+        Z=spzeros(T,size(V,1),size(V,2))
+        Si=sparse(one(T)*I, size(S,1), size(S,1))
+    else
+        Z=zeros(T,size(V,1),size(V,2))
+        Si=Matrix(one(T)*I, size(S,1), size(S,1))
+    end
+    for i=1:size(nep.A,1)
+        Z+=nep.A[i]*V*Si;
+        Si=Si*S;
+    end
+    return Z
+end
+
+compute_rf(nep::PEP,x;params...) = compute_rf(ComplexF64,nep,x;params...)
+function compute_rf(::Type{T},nep::PEP,x; y=x, target=zero(T), λ0=target,
+                    TOL=eps(real(T))*1e3,max_iter=10) where T<:Real
+
+    a=zeros(T,size(nep.A,1))
+    for i=1:size(nep.A,1)
+        a[i]=dot(y,nep.A[i]*x);
+    end
+    m=size(nep.A,1);
+    # Build a bigfloat companion matrix
+    A=zeros(T,m-1,m-1);
+    for k=1:m-1
+        if (k<m-1)
+            A[k,k+1]=1;
+        end
+        A[end,k]=-a[k]/a[end]
+    end
+    pp=eigvals(A);
+    if (T <: Real) # If we specify real arithmetic, return real eigvals
+        pp=real(pp);
+    end
+
+    II=sortperm(abs.(pp .- target))
+    return pp[II];
+end
+
+# Overload a version of eigvals(::Matrix{BigFloat}) for compute_rf
+import LinearAlgebra.eigvals
+function eigvals(A::Union{Matrix{BigFloat},Matrix{Complex{BigFloat}}})
+    T=eltype(A);
+    Tfloat= (T <: Complex) ? (ComplexF64) : (Float64)
+    Afloat=Matrix{Tfloat}(A);
+    λv,X=eigen(Afloat);
+    local λv_bigfloat=Vector{Complex{BigFloat}}(λv);
+    # Some Rayleigh quotient iteration steps in bigfloat to improve accuracy:
+    for j=1:size(λv,1)
+        local s=λv_bigfloat[j];
+        z=Vector{Complex{BigFloat}}(X[:,j])
+        for f=1:3
+            z=(A-s*I)\z; normalize!(z);
+            s=z'*A*z;
+        end
+        λv_bigfloat[j]=s
+    end
+    if (maximum(abs.((λv_bigfloat-λv)./λv_bigfloat)) > eps()*100)
+        @warn("Correction iteration of eigvals for bigfloat, made the eigenvalues move considerably")
+    end
+
+    return λv_bigfloat
+end
+
+
+
+# Compute the ith derivative of a PEP
+function compute_Mder(nep::PEP,λ::Number,i::Integer=0)
+    if (issparse(nep))
+        Z=spzeros(eltype(nep.A[1]),size(nep,1),size(nep,1));
+    else
+        Z=zeros(eltype(nep.A[1]),size(nep,1),size(nep,1));
+    end
+    for j=(i+1):size(nep.A,1)
+        # Derivatives of monimials
+        Z+= nep.A[j]*(λ^(j-i-1)*factorial(j-1)/factorial(j-i-1))
+    end
+    return Z
+end
+
+#  Fetch the Av's, since they are not explicitly stored in PEPs
+function get_Av(nep::PEP)
+    return nep.A;
+end
+#  Fetch the Fv's, since they are not explicitly stored in PEPs
+function get_fv(nep::PEP)
+    fv=Vector{Function}(undef, size(nep.A,1))
+    # Construct monomial functions
+    for i=1:size(nep.A,1)
+        if (i==1); # optimization for constant and linear term
+            fv[1] = S -> one(S);
+        elseif (i==2);
+            fv[2]=S->S;
+        else
+            # we need to introuce j otherwise the function is not typestable
+            j=i-1; # power of the coefficient
+            fv[i]=S->S^j;
+        end
+    end
+    return fv;
+end
+
+
+"""
+    interpolate([T=ComplexF64,] nep::NEP, intpoints::Array)
+ Interpolates a NEP in the points `intpoints` and returns a `PEP`.\\
+ `T` is the Type in which the matrices of the PEP should be defined.
+"""
+interpolate(nep::NEP, intpoints::Array) = interpolate(ComplexF64, nep, intpoints)
+function interpolate(::Type{T}, nep::NEP, intpoints::Array) where {T<:Number}
+
+    n = size(nep, 1)
+    d = length(intpoints)
+
+    V = zeros(T,d,d) #Vandermonde matrix
+    pwr = ones(d,1)
+    for i = 1:d
+        V[:,i] = pwr
+        pwr = pwr.*intpoints
+    end
+
+    if (issparse(nep)) #If Sparse, do elementwise interpolation
+        b = Vector{SparseMatrixCSC{T}}(undef, d)
+        AA = Vector{SparseMatrixCSC{T}}(undef, d)
+        V = factorize(V) # Will be used multiple times, factorize
+
+        for i=1:d
+            b[i] = compute_Mder(nep, intpoints[i])
+        end
+
+        # OBS: The following lines and hence the following method assumes that Sparsity-structure is the same!
+        nnz_AA = nnz(b[1])
+        for i=1:d
+            AA[i] = copy(b[1])
+        end
+
+        f = zeros(d,1)
+        for i = 1:nnz_AA
+            for j = 1:d
+                f[j] = b[j].nzval[i]
+            end
+            a = \(V,f)
+            for j = 1:d
+                AA[j].nzval[i] = a[j]
+            end
+        end
+
+    else # If dense, use Vandermonde
+        b = zeros(T,n*d,n)
+        AA = Vector{Matrix{T}}(undef,d)
+        (L, U, p) = lu(V)
+
+        LL = kron(L, SparseMatrixCSC(I,(n,n)))
+        UU = kron(U, SparseMatrixCSC(I,(n,n)))
+
+        for i = 1:d
+            b[(1:n).+(i-1)*n,:] =  compute_Mder(nep,intpoints[p[i]])
+        end
+
+        A = \(UU, \(LL,b))
+
+        for i = 1:d
+            AA[i] = A[(1:n).+(i-1)*n,:]
+        end
+    end
+
+    return PEP(AA)
+end
+# TODO: Implement interpolation similar to Effenberger and Kressner. "Chebyshev interpolation for nonlinear eigenvalue problems." BIT Numerical Mathematics 52.4 (2012): 933-951.
+
+
+type ChebPEPFull <: AbstractSPMF
+    n::Int # size
+    a,b # Chebyshev polys are scaled to the interval
+    Fk::Array   # function values in Chebyshev nodes
+    spmf::SPMF_NEP; # The cheb-coefficents are stored directly in the SPMF
+end
+
+
+type ChebPEPEco <: AbstractSPMF
+    n::Int # size
+    a,b # Chebyshev polys are scaled to the interval
+    Fk::Array   # function values in Chebyshev nodes
+end
+
+ChebPEPCommon = Union{ChebPEPFull,ChebPEPEco};
+
+
+function get_chebyshev_nodes(a,b,k)
+end
+
+function chebyshev_eval(a,b,F)
+    # Evaluate F in the chebyshev nodes
+    return Fk
+end
+function chebyshev_compute_coefficients(a,b,Fk)
+    # Return coefficient
+    return Ck
+end
+
+# Evaluate a ChebPEP in a point: <=> Interpolate
+# Compute coefficients:
+# http://inis.jinr.ru/sl/M_Mathematics/MRef_References/Mason,%20Hanscomb.%20Chebyshev%20polynomials%20(2003)/C0355-Ch06.pdf
+
+
+function ChebPEP()
+
+end
+
+
+
+function polyeig(pep::ChebPEP)
+
+end
+
+# Compute Mlincomb?

--- a/test/chebpep.jl
+++ b/test/chebpep.jl
@@ -19,7 +19,8 @@ using SparseArrays
     (λ2,V2)=iar(chebpep,neigs=2,errmeasure=ResidualErrmeasure,v=v0)
     @test norm(compute_Mlincomb(nep,λ2[1],V2[:,1])) < eps()*5000
 
-    # polyeig with chebyshev basis
+    # polyeig with chebyshev basis (non-standard interval)
+    chebpep=ChebPEP(nep,16,-0.9,1.5);
     (λ,V)=polyeig(chebpep)
     j=argmin(abs.(λ));
     # Verify against the original problem

--- a/test/chebpep.jl
+++ b/test/chebpep.jl
@@ -1,56 +1,27 @@
-# Evaluate a ChebPEP in a point: <=> Interpolate
-# Compute coefficients:
-# http://inis.jinr.ru/sl/M_Mathematics/MRef_References/Mason,%20Hanscomb.%20Chebyshev%20polynomials%20(2003)/C0355-Ch06.pdf
+using NonlinearEigenproblemsTest
+using NonlinearEigenproblems
+using Test
+using LinearAlgebra
+using SparseArrays
 
+@testset "ChebPEP" begin
+    nep=nep_gallery("dep0",5);
+    n=size(nep,1);
+    chebpep=ChebPEP(nep,13,-1,1);
 
-f=s-> ones(3)-(1:3)*sin(s);
-#f=s-> 1-1/(s+6);
-#f=s-> 1+s;
-k=3;
-a=-1;b=4;
+    # If we k is odd and the interval is symmetric, 0 is an
+    # interpolation point
+    s=0;
+    @test norm(compute_Mder(nep,s)-compute_Mder(chebpep,s))<eps()*100
 
-(Fk,xk)=chebyshev_eval(a,b,k,f);
+    # Check that we get a valid solution if we solve chebpep
+    v0=ones(n);
+    (λ2,V2)=iar(chebpep,neigs=2,errmeasure=ResidualErrmeasure,v=v0)
+    @test norm(compute_Mlincomb(nep,λ2[1],V2[:,1])) < eps()*5000
 
-Ck0=chebyshev_compute_coefficients(a,b,Fk,xk);
-#Ck1=chebyshev_compute_coefficients_naive(a,b,Fk,k);
-
-#Ck=Ck1;
-xk=get_chebyshev_nodes(Float64,a,b,k)
-xx=xk[1];
-ff0=mapreduce(i->Ck0[i]*cheb_f(a,b,xx,i-1), +, 1:k)
-#ff1=mapreduce(i->Ck1[i]*cheb_f(a,b,xx,i-1), +, 1:k)
-
-@show norm(ff0-f(xx))
-#@show ff1-f(xx)
-
-
-
-
-nep=nep_gallery("dep0",5);
-nep2=ChebPEP(nep,11,-1,1);
-nep3=nep2.spmf;
-
-s=0;
-
-compute_Mder(nep,s)-compute_Mder(nep3,s)
-
-λ1=iar(nep,neigs=2,logger=1)[1]
-λ2=iar(nep2,neigs=2,logger=1,errmeasure=ResidualErrmeasure)[1]
-λ3=iar(nep3,neigs=2,logger=1,errmeasure=ResidualErrmeasure)[1]
-
-
-@show norm(λ1-λ3)
-
-
-
-
-
-# Implement linearization technique (e.g. Effenberger & Kressner)
-#function polyeig(pep::ChebPEP)
-#
-#end
-
-
-(λ,V)=polyeig(nep2)
-
-norm(compute_Mder(nep2,λ[1])*V[:,1])
+    # polyeig with chebyshev basis
+    (λ,V)=polyeig(chebpep)
+    j=argmin(abs.(λ));
+    # Verify against the original problem
+    @test norm(compute_Mlincomb(nep,λ[j],normalize(V[:,j]))) < eps()*1000
+end

--- a/test/chebpep.jl
+++ b/test/chebpep.jl
@@ -1,0 +1,56 @@
+# Evaluate a ChebPEP in a point: <=> Interpolate
+# Compute coefficients:
+# http://inis.jinr.ru/sl/M_Mathematics/MRef_References/Mason,%20Hanscomb.%20Chebyshev%20polynomials%20(2003)/C0355-Ch06.pdf
+
+
+f=s-> ones(3)-(1:3)*sin(s);
+#f=s-> 1-1/(s+6);
+#f=s-> 1+s;
+k=3;
+a=-1;b=4;
+
+(Fk,xk)=chebyshev_eval(a,b,k,f);
+
+Ck0=chebyshev_compute_coefficients(a,b,Fk,xk);
+#Ck1=chebyshev_compute_coefficients_naive(a,b,Fk,k);
+
+#Ck=Ck1;
+xk=get_chebyshev_nodes(Float64,a,b,k)
+xx=xk[1];
+ff0=mapreduce(i->Ck0[i]*cheb_f(a,b,xx,i-1), +, 1:k)
+#ff1=mapreduce(i->Ck1[i]*cheb_f(a,b,xx,i-1), +, 1:k)
+
+@show norm(ff0-f(xx))
+#@show ff1-f(xx)
+
+
+
+
+nep=nep_gallery("dep0",5);
+nep2=ChebPEP(nep,11,-1,1);
+nep3=nep2.spmf;
+
+s=0;
+
+compute_Mder(nep,s)-compute_Mder(nep3,s)
+
+λ1=iar(nep,neigs=2,logger=1)[1]
+λ2=iar(nep2,neigs=2,logger=1,errmeasure=ResidualErrmeasure)[1]
+λ3=iar(nep3,neigs=2,logger=1,errmeasure=ResidualErrmeasure)[1]
+
+
+@show norm(λ1-λ3)
+
+
+
+
+
+# Implement linearization technique (e.g. Effenberger & Kressner)
+#function polyeig(pep::ChebPEP)
+#
+#end
+
+
+(λ,V)=polyeig(nep2)
+
+norm(compute_Mder(nep2,λ[1])*V[:,1])


### PR DESCRIPTION
This adds representation of a PEP in a Chebyshev basis (scaled to arbitrary interval). It supports creation via interpolation of another NEP in Chebyshev nodes, and an implementation of polyeig which uses a Chebyshev companion linearization:

```julia
julia> nep=nep_gallery("dep0",5);
julia> n=size(nep,1);
julia> chebpep=ChebPEP(nep,13,-1,1); # Create ChebPEP based on interpolation in chebyshev nodes
julia> compute_Mder(nep,0)
5×5 Array{Float64,2}:
  0.790529   1.72038   -0.182033   0.293983  -0.302562
  0.47053    0.473334  -0.819734  -1.9292     0.66847 
  0.120707   0.479604  -1.37354   -2.23445    0.979773
  0.16538   -0.810488   2.40225    2.09744   -0.155803
 -0.17606    2.26544    1.05071   -1.25819    0.856748
julia> compute_Mder(chebpep,0)
5×5 Array{Float64,2}:
  0.790529   1.72038   -0.182033   0.293983  -0.302562
  0.47053    0.473334  -0.819734  -1.9292     0.66847 
  0.120707   0.479604  -1.37354   -2.23445    0.979773
  0.16538   -0.810488   2.40225    2.09744   -0.155803
 -0.17606    2.26544    1.05071   -1.25819    0.856748
julia> v0=ones(n);
julia> (λ2,V2)=iar(chebpep,neigs=2,errmeasure=ResidualErrmeasure,v=v0)
(Complex{Float64}[-0.358719+4.25641e-17im, 0.834735-2.3048e-16im], Complex{Float64}[-0.297881+2.63211e-16im 0.534069+2.23465e-16im; 0.149929+3.37404e-17im 0.0702221+1.40189e-16im; … ; 0.524012+1.09274e-17im 0.238219-7.1747e-17im; 0.641947+6.04079e-17im 0.420887-1.79986e-16im], Complex{Float64}[0.447214+0.0im 0.721426-0.0im … -0.0108986+1.07354e-11im 0.0258408-9.68579e-11im; 0.447214+0.0im -0.250357-0.0im … 0.0279483-2.95601e-11im -0.00884929+5.71576e-12im; … ; 0.0+0.0im 0.0+0.0im … 0.0+0.0im 0.0+0.0im; 0.0+0.0im 0.0+0.0im … 0.0+0.0im 0.0+0.0im])
julia> norm(compute_Mlincomb(nep,λ2[1],V2[:,1]))
5.403860318376269e-14
julia> (λ,V)=polyeig(chebpep);  # polyeig with chebyshev basis
julia> j=argmin(abs.(λ .- λ2[1])); # See if we found what we found with iar
julia> λ[j]
-0.35871894596860465 + 0.0im
julia> λ2[1]
-0.35871894596860465 + 4.256411657408781e-17im
```

Still remaining: 

* [x] `polyeig(ChebPEP)` should not only support the unit interval.
* [x]  There are two ways to compute chebyshev polys: the monomial formula or the cosine-formula. If we only consider efficiency, the best would probably be to make a cut-off and switch to cosine-formula for the higher poly's.
* [x] *fixed by new acos(LowerTriangular) * Derivatives currently do not work since  `acos(A)` rounds in a strange way (cf julia issue 32721)
```julia
julia> compute_Mder(chebpep,0.1,1);
julia> compute_Mder(chebpep,0.1,2);
ERROR: InexactError: Float64(0.0 - 5.551115123125783e-16im)
```

