### PR TITLE
Broyden improvements

### DIFF
--- a/src/method_broyden.jl
+++ b/src/method_broyden.jl
@@ -8,25 +8,6 @@ export broyden;
 
 abstract type NEPBroydenDeflated <: NEP  end
 
-struct NEPBroydenDeflatedEll1 <: NEPBroydenDeflated;
-    orgnep::NEP;
-    S::AbstractArray;
-    X::AbstractArray;
-    function NEPBroydenDeflatedEll1(orgnep,S::AbstractArray,X)
-        return new(orgnep,reshape(S,size(S,1),size(S,1)),
-                   reshape(X,size(orgnep,1),size(X,2)))
-    end
-end
-
-struct NEPBroydenDeflatedEll2 <: NEPBroydenDeflated;
-    orgnep::NEP;
-    S::AbstractArray;
-    X::AbstractArray;
-    function NEPBroydenDeflatedEll2(orgnep,S::AbstractArray,X)
-        return new(orgnep,reshape(S,size(S,1),size(S,1)),
-                   reshape(X,size(orgnep,1),size(X,2)))
-    end
-end
 
 function compute_Mder(nep::NEPBroydenDeflated,λ::Number,i::Integer=0)
     if (i>0)
@@ -45,30 +26,6 @@ function deflated_errmeasure(nep::NEP,λ,v)
     return norm(compute_Mlincomb(nep,λ,v))/norm(v);
 end
 
-function extract_eigenpair(nep::NEPBroydenDeflatedEll1,λ)
-    S=nep.S
-    X=nep.X
-    dd,VV = eigen(S)
-    I=argmin(abs.(dd-λ))
-    w=X*VV[:,I]; w=w/norm(w);
-    return (λ,w);
-end
-
-function deflated_errmeasure(nep::NEPBroydenDeflatedEll1,λ,v)
-    n0=size(nep.orgnep,1);
-    p=size(nep.X,2);
-    if (p==0)
-        return norm(compute_Mlincomb(nep.orgnep,λ,v))/norm(v)
-    end
-
-    S=[nep.S v[(n0+1):(n0+p)];zeros(1,p) λ]
-    X=[nep.X v[1:n0]];
-    dd,VV = eigen(S)
-    I=argmin(abs.(dd-λ))
-    w=X*VV[:,I];
-
-    return norm(compute_Mlincomb(nep.orgnep,λ,w))/norm(w)
-end
 
 function size(nep::NEPBroydenDeflated,dim=-1)
     n0=size(nep.orgnep,1);
@@ -80,287 +37,13 @@ function size(nep::NEPBroydenDeflated,dim=-1)
     end
 end
 
-function compute_Mlincomb(nep::NEPBroydenDeflatedEll1,λ::Number,x::AbstractArray)
-    n0=size(nep.orgnep,1);
-    p=size(nep.S,1);
-    b1=x[1:n0];
-    b2=x[(n0+1):(n0+p)];
-    local z;
-    if (p==0)
-        z=b1
-        f=compute_Mlincomb(nep.orgnep,λ,z);
-    else
-        z = b1 + nep.X*((λ*Matrix{eltype(λ)}(I, p, p) - nep.S) \ b2)
-        f=vcat(compute_Mlincomb(nep.orgnep,λ,z),nep.X'*b1);
-    end
-    return Array{eltype(x),1}(f);
-end
 
-function compute_Mlincomb(nep::NEPBroydenDeflatedEll2,λ::Number,x::AbstractArray)
-    n0=size(nep.orgnep,1);
-    p=size(nep.S,1);
-    b1=x[1:n0];
-    b2=x[(n0+1):(n0+p)];
-    local z;
-    if (p==0)
-        z=b1
-        f=compute_Mlincomb(nep.orgnep,λ,z);
-    else
-        z = b1 + nep.X*((λ*Matrix{eltype(λ)}(I, p, p) - nep.S) \ b2)
-        f1=compute_Mlincomb(nep.orgnep,λ,z);
-        #f2=nep.X'*b1; # ell1
-        # ell2
-        f2=nep.X'*b1+λ*nep.S'*nep.X'*b1; # ell1
-        f2=f2+nep.S'*(nep.X'*(nep.X*b2));
-        f=vcat(f1,f2);
-    end
-    return Array{eltype(x),1}(f);
-end
-
-function broyden_naive_H(::Type{TT},nep::NEPBroydenDeflated;
-                         v1=0,u1=[],λ1=TT(0),
-                         CH=0,T1=0,W1=0,
-                         maxit=100,
-                         S=zeros(TT,0,0),X=zeros(TT,0,0),
-                         check_error_every=10,
-                         print_error_every=1,
-                         tol=1e-12,
-                         threshold=0.4,
-                         time0=time_ns(),
-                         errmeasure::Function=broyden_default_errmeasure,
-                         logger=0
-                         ) where {TT<:Number}
-
-    @parse_logger_param!(logger)
-
-    n=size(nep.orgnep,1);
-    p=size(nep,1)-n;
-
-    T1=Array{TT,2}(T1);
-    CH=Array{TT,2}(CH);
-    v1=Array{TT,1}(v1);
-    λ1=TT(λ1);
-
-    M1=inv(T1);
-    c=zeros(TT,n+p);
-    c[1:n]=CH[end:end,:]';
-    #K=[M1 W1[1:n,1:p]; CH[1:p,:] zeros(TT,p,p)];
-    #k=zeros(TT,n+p);
-    #k[1:n]=W1[:,p+1];
-    J=[M1 W1;CH zeros(TT,p+1,p+1)]
-    H=inv(J);
-
-
-    x=Array{TT,1}([v1;u1;λ1]);
-    F=vcat(compute_Mlincomb(nep,x[n+p+1],x[1:(n+p)]),0)
-    #(y1,y2)=fake_Mlincomb(nep,x[n+p+1],x[1:n],x[n+1:n+p]);
-    #F=vcat(y1,y2);
-    errhist=Array{real(TT),1}(NaN*ones(real(TT),maxit));
-    timehist=Vector{Float64}(maxit)*NaN;
-    II = Matrix{TT}(I, p, p)
-
-    for j=1:maxit
-
-        Δx=-H*F; # called s_k
-
-
-        γ=TT(1.0);
-        tt=norm(Δx);
-        if (tt>threshold)  # Avoid too big λ-steps
-            γ=TT(threshold)/tt;
-        end
-        #        γ=TT(1.0);
-        #        if (abs(Δx[end])>threshold)  # Avoid too big λ-steps
-        #            γ=TT(threshold)/abs(Δx[end]);
-        #        end
-
-        xp=x+γ*Δx;
-
-        # Impose structure => This improves performance (at least for deflation)
-        #if (impose_normalization)
-        #    xp[1:n]=xp[1:(n+p)]/(c'*xp[1:(n+p)]); Δx=xp-x;
-        #end
-
-        #(y1,y2)=fake_Mlincomb(nep,xp[n+p+1],xp[1:n],xp[n+1:n+p]);
-        #Fp=vcat(y1,y2);
-        Fp=vcat(compute_Mlincomb(nep,xp[n+p+1],xp[1:(n+p)]),c'*xp[1:(n+p)]-1)
-        ΔF=Fp-F;
-
-        # Update Jacobian approximation
-        z1=(Fp-(1-γ)*F)/γ;
-        Hz1=H*z1;
-        aH=(Δx'*H)/(norm(Δx)^2+Δx'*Hz1);
-        H=H-Hz1*aH
-
-        # step forward
-        x=xp;
-        F=Fp;
-
-        if (mod(j,check_error_every)==0)
-            #errhist[j]=deflated_errmeasure(nep,x[n+p+1],x[1:n+p])
-            #errhist[j]=opnorm(Fp);
-            λ=x[end];  vv=x[1:nep.orgnep.n];  uu=x[(nep.orgnep.n+1):end-1];
-            errhist[j]=errmeasure(λ,vv+nep.X*((λ*II-nep.S)\uu),  F);
-            timehist[j]=Float64((time_ns()-time0)*1e-9);
-            if (mod(j,print_error_every)==0)
-                d = opnorm(CH*x[1:n] - reverse(Matrix{TT}(I, 1+p, 1), dims = 1))
-            end
-
-            #println(j," Normf=",opnorm(F), " λ=",xp[n+p+1]);
-            if (errhist[j]<tol)
-                return (x[n+p+1],x[1:n],x[(n+1):(n+p)],H,0,j,errhist[1:j],timehist[1:j])
-            end
-
-        end
-
-    end
-
-    push_info!(logger,"Too many iterations"); #" resnorm=",opnorm(rk));
-    #error("Too many iterations")
-    return (x[n+p+1],x[1:n],x[(n+1):(n+p)],H,H[1:n,(n+1):end],maxit,errhist[1:end])
-
-
-end
-
-
-function broyden_naive_J(::Type{TT},nep::NEPBroydenDeflated;
-                         v1=0,u1=[],λ1=TT(0),
-                         CH=0,T1=0,W1=0,
-                         maxit=100,
-                         S=zeros(TT,0,0),X=zeros(TT,0,0),
-                         check_error_every=10,
-                         print_error_every=1,
-                         tol=1e-12,
-                         threshold=0.4,
-                         time0=time_ns(),
-                         errmeasure::Function=broyden_default_errmeasure,
-                         logger=0
-                         ) where {TT<:Number}
-
-    @parse_logger_param!(logger)
-
-    n=size(nep.orgnep,1);
-    p=size(nep,1)-n;
-
-    T1=Array{TT,2}(T1);
-    CH=Array{TT,2}(CH);
-    v1=Array{TT,1}(v1);
-    λ1=TT(λ1);
-    u1=Array{TT,1}(u1);
-
-    M1=inv(T1);
-    c=zeros(TT,n+p);
-    c[1:n]=CH[end:end,:]';
-    #K=[M1 W1[1:n,1:p]; CH[1:p,:] zeros(TT,p,p)];
-    #k=zeros(TT,n+p);
-    #k[1:n]=W1[:,p+1];
-    J=[M1 W1;CH zeros(TT,p+1,p+1)];
-    if (isa(nep,NEPBroydenDeflatedEll2))
-        J[n+1:end-1,:]=[nep.X'+λ1*nep.S'*nep.X'  nep.S'*nep.X'*nep.X nep.S'*nep.X'*v1];
-    end
-
-
-    x=Array{TT,1}([v1;u1;λ1]);
-    F=vcat(compute_Mlincomb(nep,x[n+p+1],x[1:(n+p)]),TT(0))
-    errhist=Array{real(TT),1}(NaN*ones(real(TT),maxit));
-    timehist=Vector{Float64}(maxit)*NaN;
-    II = Matrix{TT}(I, p, p)
-
-
-
-    for j=1:maxit
-
-        Δx=-J\F; # called s_k
-
-
-        γ=TT(1.0);
-        tt=norm(Δx);
-        if (tt>threshold)  # Avoid too big λ-steps
-            γ=TT(threshold)/tt;
-        end
-
-        #γ=TT(1.0);
-        #if (abs(Δx[end])>threshold)  # Avoid too big λ-steps
-        #    γ=TT(threshold)/abs(Δx[end]);
-        #end
-
-        xp=x+γ*Δx;
-
-
-        # Impose structure => This improves performance (at least for deflation)
-        #if (impose_normalization)
-        #    xp[1:n]=xp[1:(n+p)]/(c'*xp[1:(n+p)]); Δx=xp-x;
-        #end
-
-        Fp=vcat(compute_Mlincomb(nep,xp[n+p+1],xp[1:(n+p)]),c'*xp[1:(n+p)]-1)
-        ΔF=Fp-F;
-
-        # Update Jacobian approximation
-        β=1/(norm(Δx)^2);
-
-
-        #z1=(K*Δv+k*Δλ -ΔF[1:n]); # Can be simplified
-        z1=(Fp-(1-γ)*F)/γ;
-
-
-        J=J+z1*(Δx'*β);
-
-
-        # step forward
-        x=xp;
-        F=Fp;
-
-        if (mod(j,check_error_every)==0)
-            λ=x[end];  vv=x[1:nep.orgnep.n];  uu=x[(nep.orgnep.n+1):end-1];
-            errhist[j]=errmeasure(λ,vv+nep.X*((λ*II-nep.S)\uu),  F);
-            #errhist[j]=deflated_errmeasure(nep,x[n+p+1],x[1:n+p])
-            timehist[j]=Float64((time_ns()-time0)*1e-9);
-            if (mod(j,print_error_every)==0)
-                d = opnorm(CH*x[1:n] - reverse(Matrix{TT}(I, 1+p, 1), dims = 1))
-            end
-            #println(j," Normf=",opnorm(F), " λ=",xp[n+p+1]);
-            if (errhist[j]<tol)
-                return (x[n+p+1],x[1:n],x[(n+1):(n+p)],J,0,j,errhist[1:j],timehist[1:j])
-            end
-
-        end
-
-    end
-
-    push_info!(logger,"Too many iterations"); #" resnorm=",opnorm(rk));
-    #error("Too many iterations")
-    return (x[n+p+1],x[1:n],x[(n+1):(n+p)],J[1:n,1:n],J[1:n,(n+1):end],maxit,errhist[1:end])
-
-
-end
 
 function broyden_default_errmeasure(λ,v,r)
     return norm(r)/norm(v)
 end
 
 
-function broyden_ell2(::Type{TT},nep::NEP;
-                      v1=0,u1=[],λ1=TT(0),
-                      CH=0,T1=0,W1=0,
-                      maxit=100,
-                      S=zeros(TT,0,0),X=zeros(TT,size(nep,1),0),
-                      check_error_every=10,
-                      print_error_every=1,
-                      tol=1e-12,
-                      threshold=0.4,
-                      time0=time_ns(),
-                      errmeasure::Function=broyden_default_errmeasure) where {TT<:Number}
-    # Check types are consistent
-
-    v=Array{TT,1}(v1);
-    u=Array{TT,1}(u1);
-    X=Array{TT,2}(X);
-    S=Array{TT,2}(S);
-    CH=Array{TT,2}(CH);
-    λ=TT(λ1);
-
-
-end
 
 
 function broyden_T(::Type{TT},nep::NEP;
@@ -567,7 +250,6 @@ function broyden(::Type{TT},nep::NEP,approxnep::NEP;σ::Number=0,
                  maxit::Integer=1000,addconj=false,
                  check_error_every::Integer=10,
                  print_error_every::Integer=1,
-                 broyden_variant::Symbol=:T,
                  threshold::Real=0.2,
                  tol::Real=1e-12,
                  errmeasure::Function=broyden_default_errmeasure,
@@ -677,58 +359,22 @@ function broyden(::Type{TT},nep::NEP,approxnep::NEP;σ::Number=0,
         W1=[U1 f1];
 
 
-        if (broyden_variant == :T)
-            push_info!(logger,"Running T variant *********************************** n=$n")
-            T=copy(T1);
+        push_info!(logger,"Starting broyden n=$n")
+        T=copy(T1);
 
-            (λm,vm,um,Tm,Wm,iter,errhist,timehist)=
-            broyden_T(TT,nep,
-                      v1=v0,u1=u0,λ1=σ,
-                      CH=CH,T1=T1,W1=W1,
-                      S=S,X=X,
-                      maxit=maxit,
-                      check_error_every=check_error_every,
-                      print_error_every=print_error_every,
-                      threshold=threshold,
-                      tol=tol,
-                      errmeasure=errmeasure,
-                      time0=time0,
-                      logger=inner_logger)
-        elseif (broyden_variant == :J)
-            push_info!(logger,"Running J variant *********************************** n=$n")
-            dnep=NEPBroydenDeflatedEll1(nep,S,X);
-
-            (λm,vm,um,Tm,Wm,iter,errhist,timehist)=
-            broyden_naive_J(TT,dnep,
-                            v1=v0,u1=u0,λ1=σ,
-                            CH=CH,T1=T1,W1=W1,
-                            S=S,X=X,
-                            maxit=maxit,
-                            check_error_every=check_error_every,
-                            print_error_every=print_error_every,
-                            threshold=threshold,
-                            tol=tol,
-                            time0=time0,
-                            logger=inner_logger)
-        elseif (broyden_variant == :H)
-            push_info!(logger,"Running H variant *********************************** n=$n")
-            dnep=NEPBroydenDeflatedEll1(nep,S,X);
-
-            (λm,vm,um,Tm,Wm,iter,errhist,timehist)=
-            broyden_naive_H(TT,dnep,
-                            v1=v0,u1=u0,λ1=σ,
-                            CH=CH,T1=T1,W1=W1,
-                            S=S,X=X,
-                            maxit=maxit,
-                            check_error_every=check_error_every,
-                            print_error_every=print_error_every,
-                            threshold=threshold,
-                            tol=tol,
-                            time0=time0,
-                            logger=inner_logger)
-        else
-            error("Unknown broyden method");
-        end
+        (λm,vm,um,Tm,Wm,iter,errhist,timehist)=
+        broyden_T(TT,nep,
+                  v1=v0,u1=u0,λ1=σ,
+                  CH=CH,T1=T1,W1=W1,
+                  S=S,X=X,
+                  maxit=maxit,
+                  check_error_every=check_error_every,
+                  print_error_every=print_error_every,
+                  threshold=threshold,
+                  tol=tol,
+                  errmeasure=errmeasure,
+                  time0=time0,
+                  logger=inner_logger)
 
         if size(all_iterhist,1) > 0
             iterhist=(1:size(errhist,1)) .+ all_iterhist[end]
@@ -764,39 +410,39 @@ function broyden(::Type{TT},nep::NEP,approxnep::NEP;σ::Number=0,
         #println("J=",[inv(Tm) Wm; CH zeros(k,k)]);
 
         #println("opnorm(MM)=",opnorm(compute_MM(nep,S,X)));
-#println("I-X'*X=",opnorm(Matrix(1.0I, k, k)-X'*X))
+        #println("I-X'*X=",opnorm(Matrix(1.0I, k, k)-X'*X))
 
-if (abs(imag(λm))>tol*10 && addconj)
+        if (abs(imag(λm))>tol*10 && addconj)
 
 
-    v1 = conj(vm + X[:,1:k-1] * ((λm * Matrix{TT}(I, k-1, k-1) - S[1:k-1,1:k-1]) \ um))
-    λ1=conj(λm);
+            v1 = conj(vm + X[:,1:k-1] * ((λm * Matrix{TT}(I, k-1, k-1) - S[1:k-1,1:k-1]) \ um))
+            λ1=conj(λm);
 
-    rnorm=norm(compute_Mlincomb(nep,λ1,v1))
-    push_info!(logger,"Adding conjugate $k")
-    if (rnorm>tol*10)
-        @warn "Trying to add a conjugate pair which does not have a very small residual."
+            rnorm=norm(compute_Mlincomb(nep,λ1,v1))
+            push_info!(logger,"Adding conjugate $k")
+            if (rnorm>tol*10)
+                @warn "Trying to add a conjugate pair which does not have a very small residual."
+            end
+
+            h=X'*v1;
+            v1t=v1-X*h;
+            beta=norm(v1t);
+            X=[X v1t/beta];
+            k=k+1;
+            S1=zeros(TT,k,k);
+            S1[1:(k-1),1:(k-1)]=S;
+            S1[k,k]=λ1;
+            R = Matrix{TT}(I, k, k)
+            R[1:k-1,end]=h; R[k,k]=beta;
+            S=(R*S1)/R;
+            #println("opnorm(XX-I)=",opnorm(X'*X-Matrix(1.0I, size(X,2), size(X,2))))
+            #println("opnorm(MM)=",opnorm(compute_MM(nep,S,X)));
+            #        X=[X v1]
+            #      S=[S conj(v1[(n0+1):(n0+p)]);zeros(1,p) conj(λ1)]
+            #dnep=NEPBroydenDeflated(nep,S,X);
+        end
+        k=k+1;
     end
-
-    h=X'*v1;
-    v1t=v1-X*h;
-    beta=norm(v1t);
-    X=[X v1t/beta];
-    k=k+1;
-    S1=zeros(TT,k,k);
-    S1[1:(k-1),1:(k-1)]=S;
-    S1[k,k]=λ1;
-    R = Matrix{TT}(I, k, k)
-    R[1:k-1,end]=h; R[k,k]=beta;
-    S=(R*S1)/R;
-    #println("opnorm(XX-I)=",opnorm(X'*X-Matrix(1.0I, size(X,2), size(X,2))))
-    #println("opnorm(MM)=",opnorm(compute_MM(nep,S,X)));
-    #        X=[X v1]
-    #      S=[S conj(v1[(n0+1):(n0+p)]);zeros(1,p) conj(λ1)]
-    #dnep=NEPBroydenDeflated(nep,S,X);
-end
-k=k+1;
-end
 push_info!(logger,"Iterations:$sumiter")
 return S,X,T1,all_errhist,all_timehist,all_iterhist;
 
@@ -804,202 +450,6 @@ end
 
 
 
-function deflated_broyden_ell2(::Type{TT},nep::NEP,approxnep::NEP;σ=0,
-                               pmax::Integer=3,
-                               c=ones(TT,size(nep,1)),
-                               maxit=1000,addconj=false,
-                               check_error_every=10,
-                               print_error_every=1,
-                               broyden_variant=:J,threshold=0.2,
-                               tol=1e-12,
-                               errmeasure::Function=broyden_default_errmeasure,
-                               add_nans=false,
-                               include_restart_timing=true
-                               ) where {TT<:Number}
-
-    time0=time_ns();
-    n=size(nep,1);
-    if (pmax>2*size(nep,1))
-        @warn "Too many eigenvalues requested. Reducing"
-        pmax=size(nep,1);
-    end
-    σ=ComplexF64(σ);
-
-
-    # Step 1. Compute M0 and T0
-
-    M1=compute_Mder(approxnep,σ);
-    T1=inv(M1);
-
-
-    X=zeros(ComplexF64,n,0);
-    S=zeros(ComplexF64,0,0);
-
-    k=1;
-
-    all_errhist=[]; sumiter=1;
-    all_timehist=[];
-    all_iterhist=[];
-    sumiter=1;
-    UU = Matrix{TT}(I, n, pmax+1) # For storage
-    U1=view(UU,1:n,1:0);
-    while (k<=pmax)
-
-
-
-        # Step 5
-        p_U1=size(U1,2); # Not documented
-        U1=view(UU,1:n,1:k-1);
-        for i=(p_U1+1):k-1
-            #for i=1:k-1
-            ei=zeros(TT,size(S,1)); ei[i]=1;
-            U1[:,i] = compute_Mlincomb(nep, σ, X * ((σ*Matrix{TT}(I, k-1, k-1) - S) \ ei))
-        end
-
-        # Step 6
-        MM=[M1 U1; X'+σ*S'*X' S'*(X'*X)];
-        d,V = eigen(MM)
-        x=V[:,argmin(abs.(d))];
-
-        # Not in MS yet:
-        # Orthogonalize
-        v0=x[1:n];
-        u0=x[n+1:end];
-        #h=X'*v0;
-        #v0=v0-X*h
-        CH=[X';c'];
-
-        # Normalize it
-        u0=u0/(c'*v0);
-        v0=v0/(c'*v0);
-
-
-        if (!include_restart_timing)
-            time0=time_ns();
-
-        end
-
-        # Step 7
-        d=sqrt(eps(real(TT)));
-        f1a=(compute_Mlincomb(approxnep,σ+d,v0)-compute_Mlincomb(approxnep,σ-d,v0))/2d;
-        f1b = -U1 * ((σ * Matrix{TT}(I, k-1, k-1) - S) \ u0)
-        f1=f1a+f1b;
-        W1=[U1 f1];
-
-
-        if (broyden_variant == :J)
-            println("Running J variant *********************************** n=",n);
-            dnep=NEPBroydenDeflatedEll2(nep,S,X);
-
-
-            (λm,vm,um,Tm,Wm,iter,errhist,timehist)=broyden_naive_J(ComplexF64,dnep,
-                                                                   v1=v0,u1=u0,λ1=σ,
-                                                                   CH=CH,T1=T1,W1=W1,
-                                                                   S=S,X=X,
-                                                                   maxit=maxit,
-                                                                   check_error_every=check_error_every,
-                                                                   print_error_every=print_error_every,                                              threshold=threshold,
-                                                                   tol=tol,
-                                                                   time0=time0,
-                                                                   logger=inner_logger)
-
-        elseif (broyden_variant == :H)
-            println("Running H variant *********************************** n=",n);
-            dnep=NEPBroydenDeflatedEll2(nep,S,X);
-
-
-            (λm,vm,um,Tm,Wm,iter,errhist,timehist)=broyden_naive_H(ComplexF64,dnep,
-                                                                   v1=v0,u1=u0,λ1=σ,
-                                                                   CH=CH,T1=T1,W1=W1,
-                                                                   S=S,X=X,
-                                                                   maxit=maxit,
-                                                                   check_error_every=check_error_every,
-                                                                   print_error_every=print_error_every,                                              threshold=threshold,
-                                                                   tol=tol,
-                                                                   time0=time0,
-                                                                   logger=inner_logger)
-
-        else
-            error("Unknown broyden method");
-        end
-
-        #println("Should_be_zero=",[X X*S]'*[X
-        if (size(all_iterhist,1)>0)
-            iterhist=(1:size(errhist,1))+all_iterhist[end];
-        else
-            iterhist=(1:size(errhist,1))
-        end
-        add_nans=true;
-
-
-        if (add_nans && size(all_iterhist,1)>1)
-            all_errhist=[all_errhist;NaN]
-            all_timehist=[all_timehist;NaN]
-            all_iterhist=[all_iterhist;NaN]
-        end
-        all_errhist=[all_errhist;errhist];
-        all_timehist=[all_timehist;timehist];
-        all_iterhist=[all_iterhist;iterhist];
-        sumiter=sumiter+iter;
-        β=opnorm(vcat(vm,X*um+λm*vm));
-        um=um/β
-        vm=vm/β # Normalize
-        println("Found an eigval ",k,":",λm);
-        #println("Quality of eigval guess:", abs(λ0-λ1)/abs(λ1))
-        #I=argmin(abs.(λv-λ1))
-        #println("Best guess distance:", abs(λv[I]-λ1)/abs(λ1))
-        #println("It was ",λv[I])
-        #println(" not   ",λ0)
-
-
-        X=[X vm]
-        S=[S um;zeros(1,k-1) λm]
-
-        println("normalize:",[X;X*S]'*[X;X*S])
-
-        println("S=",S)
-
-        #println("J=",[inv(Tm) Wm; CH zeros(k,k)]);
-
-        #println("opnorm(MM)=",opnorm(compute_MM(nep,S,X)));
-        #println("I-X'*X=",opnorm(Matrix(1.0I, k, k)-X'*X))
-
-        if (abs(imag(λm))>sqrt(eps()) && addconj)
-
-
-            v1 = conj(vm + X[:,1:k-1] * ((λm * Matrix{TT}(I, k-1, k-1) - S[1:k-1,1:k-1]) \ um))
-            λ1=conj(λm);
-
-            rnorm=norm(compute_Mlincomb(nep,λ1,v1))
-            println("Adding conjugate ",k,
-                    " norm(res)=",rnorm);
-            if (rnorm>tol*10)
-                @warn "Trying to add a conjugate pair which does not have a very small residual."
-            end
-
-            h=X'*v1;
-            v1t=v1-X*h;
-            beta=opnorm(v1t);
-            X=[X v1t/beta];
-            k=k+1;
-            S1=zeros(ComplexF64,k,k);
-            S1[1:(k-1),1:(k-1)]=S;
-            S1[k,k]=λ1;
-            R = Matrix{ComplexF64}(I, k, k)
-            R[1:k-1,end]=h; R[k,k]=beta;
-            S=(R*S1)/R;
-            #println("opnorm(XX-I)=",opnorm(X'*X-Matrix(1.0I, size(X, 2), size(X, 2))))
-            #println("opnorm(MM)=",opnorm(compute_MM(nep,S,X)));
-            #        X=[X v1]
-            #      S=[S conj(v1[(n0+1):(n0+p)]);zeros(1,p) conj(λ1)]
-            #dnep=NEPBroydenDeflated(nep,S,X);
-        end
-k=k+1;
-end
-println("Iterations:",sumiter)
-return S,X,T1,all_errhist,all_timehist,all_iterhist;
-
-end
 
 
 function eigs_invpow(MM;maxit=10,sigma=0)

--- a/src/method_broyden.jl
+++ b/src/method_broyden.jl
@@ -209,7 +209,8 @@ The method computes an invariant pair and can therefore find
 several eigenvalues. The
 retured value is (S,V) is an invariant pair and
 the eigenvalues are on the diagonal of S.
-
+Eigenpairs can be directly extracted with
+[`get_deflated_eigpairs`](@ref).
 
 
 
@@ -232,7 +233,14 @@ julia> minimum(svdvals(compute_Mder(nep,λ)))
 5.905315846211231e-16
 julia> broyden(nep,logger=2,check_error_every=1);  # Prints out a lot more convergence info
 ```
-
+In order to extract eigenpairs you can use the following:
+```julia-repl
+julia> (D,X)=get_deflated_eigpairs(S,V,size(nep,1));
+julia> for i=1:3; @show norm(compute_Mlincomb(nep,D[i],X[:,i])); end
+norm(compute_Mlincomb(nep, D[i], X[:, i])) = 8.459878994614521e-13
+norm(compute_Mlincomb(nep, D[i], X[:, i])) = 1.2102336671048442e-13
+norm(compute_Mlincomb(nep, D[i], X[:, i])) = 2.1012363973403225e-16
+```
 # References
 
 * Jarlebring, Broyden’s method for nonlinear eigenproblems, SIAM J. Sci. Comput., 41:A989–A1012, 2019, https://arxiv.org/pdf/1802.07322

--- a/src/method_broyden.jl
+++ b/src/method_broyden.jl
@@ -196,10 +196,8 @@ determines if `NaNs` should be added in the deflation.
 `:invpow`. The `:invpow` is an implementation of the power method, which
 is slow but works well e.g. for `BigFloat`.
 
-The method computes an invariant pair and can therefore find several
-eigenvalues. The
-retured value is (S,V) is an invariant pair and the eigenvalues are
-on the diagonal of S.
+The method computes an invariant pair and can therefore find several eigenvalues. The
+retured value is (S,V) is an invariant pair and the eigenvalues are on the diagonal of S.
 
 See [`augnewton`](@ref) for other parameters.
 
@@ -262,7 +260,7 @@ function broyden(::Type{TT},nep::NEP,approxnep::Union{NEP,Symbol,Matrix};σ::Num
     # Step 1. Compute M0 and T0
     if (isa(approxnep,Matrix))
         M1=approxnep;
-    if (approxnep == :eye)
+    elseif (approxnep == :eye)
         M1=Matrix{TT}(I,n,n)
     else
         M1=compute_Mder(approxnep,σ);

--- a/src/method_broyden.jl
+++ b/src/method_broyden.jl
@@ -177,14 +177,29 @@ end
 
 ##################
 """
-    S,V = broyden([eltype,]nep::NEP[,approxnep::NEP];kwargs)
+    S,V = broyden([eltype,]nep::NEP[,approxnep];kwargs)
 
-Runs Broydens method (with deflation) for the nonlinear eigenvalue problem defined by nep.
-An approximate nep can be provided which is used as an initialization of starting
-matrix/vectors.
+Runs Broydens method (with deflation) for the nonlinear eigenvalue
+problem defined by nep.
+An approximate nep can be provided which is used as an
+initialization of starting
+matrix/vectors. The optional argument `approxnep` determines how
+ to initiate the
+algorithm. It can be an `NEP`, the symbol `:eye`
+corresponding to starting
+with an identity matrix, and a `Matrix` (of size ``n\times n``).
+Beside most of the standard kwargs as described in [`augnewton`](@ref),
+it supports `pmax` which is subspace used in deflation, essentially
+the number of eigenvalues, `add_nans::Bool`  which
+determines if `NaNs` should be added in the deflation.
+`eigmethod` which can be `:eig`, `:eigs` or
+`:invpow`. The `:invpow` is an implementation of the power method, which
+is slow but works well e.g. for `BigFloat`.
 
-The method computes an invariant pair and can therefore find several eigenvalues. The
-retured value is (S,V) is an invariant pair and the eigenvalues are on the diagonal of S.
+The method computes an invariant pair and can therefore find several
+eigenvalues. The
+retured value is (S,V) is an invariant pair and the eigenvalues are
+on the diagonal of S.
 
 See [`augnewton`](@ref) for other parameters.
 
@@ -215,8 +230,8 @@ julia> broyden(nep,logger=2,check_error_every=1);  # Prints out a lot more conve
 
 """
 broyden(nep::NEP;params...)=broyden(ComplexF64,nep,:eye;params...)
-broyden(nep::NEP,approxnep::Union{NEP,Symbol};params...)=broyden(ComplexF64,nep,approxnep;params...)
-function broyden(::Type{TT},nep::NEP,approxnep::Union{NEP,Symbol};σ::Number=0,
+broyden(nep::NEP,approxnep;params...)=broyden(ComplexF64,nep,approxnep;params...)
+function broyden(::Type{TT},nep::NEP,approxnep::Union{NEP,Symbol,Matrix};σ::Number=0,
                  pmax::Integer=3,
                  c::Vector=ones(TT,size(nep,1)),
                  maxit::Integer=1000,addconj=false,
@@ -245,6 +260,8 @@ function broyden(::Type{TT},nep::NEP,approxnep::Union{NEP,Symbol};σ::Number=0,
 
 
     # Step 1. Compute M0 and T0
+    if (isa(approxnep,Matrix))
+        M1=approxnep;
     if (approxnep == :eye)
         M1=Matrix{TT}(I,n,n)
     else

--- a/src/nep_deflation.jl
+++ b/src/nep_deflation.jl
@@ -416,11 +416,12 @@ end
 
 
 """
+    (D,V)=get_deflated_eigpairs(S,V,n)
     (D,V)=get_deflated_eigpairs(dnep::DeflatedNEP [λ,v])
 
 Returns a vector of eigenvalues `D` and a matrix with corresponding
-eigenvectors `V`. The eigenpairs correspond to the
-original problem, underlying the `DeflatedNEP`.
+eigenvectors `V` of the invariant pair `S,V`.
+The eigenpairs correspond to the original problem, underlying the `DeflatedNEP`.
 The optional parameters `λ,v` allows the inclusion
 of an additional eigpair. Essentially, the optional parameters
 are the expanding the deflation and the running `get_deflated_eigpairs`
@@ -430,13 +431,13 @@ are the expanding the deflation and the running `get_deflated_eigpairs`
 ```
 See example in [`deflate_eigpair`](@ref).
 """
-function get_deflated_eigpairs(nep::DeflatedNEP)
-   V=nep.V0;
-   S=nep.S0;
-   (D,X)=eigen(S);
-   return D,V[1:size(nep.orgnep,1),:]*X;
+function get_deflated_eigpairs(S,V,n)
+    (D,X)=eigen(S);
+    return D,V[1:n,:]*X;
 end
-
+function get_deflated_eigpairs(nep::DeflatedNEP)
+    return get_deflated_eigpairs(nep.S0,nep.V0,size(nep.orgnep,1))
+end
 function get_deflated_eigpairs(nep::DeflatedNEP,λ,v)
    T=promote_type(typeof(λ),eltype(v),eltype(nep.V0),eltype(nep.S0));
    p0=size(nep.V0,2);


### PR DESCRIPTION
Should fix #233 

* [x] several variants are provided, although one of them is deemed better in the manuscript. Remove bad versions
* [x] several parts of the code are not tested and seems unnecessary, e.g.  `NEPBroydenDeflatedEll1` which were used in the paper  
* [x] comments of old commented-out code can be removed
* [x] adaption of our new redesign of errmeasure and deflation 
* [x] Feature request: Currently a call to  `compute_Mder` is done to initiate the algorithm. This could be seen as optional, which would make it the only algorithm which only needs a `compute_Mlincomb`.
* [x] documentation of features  