### PR TITLE
Feature: damping in Newton type methods

### DIFF
--- a/src/method_newton.jl
+++ b/src/method_newton.jl
@@ -436,7 +436,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
             end
 
             if (damping isa Function)
-                (Δλ,Δv)=damping(nep,errmeasure,err,λ,v,Δλ,Δv)
+                (Δλ,Δv)=damping(j,λ,v,Δλ,Δv,err)
             end
 
 

--- a/src/method_newton.jl
+++ b/src/method_newton.jl
@@ -436,7 +436,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
             end
 
             if (damping isa Function)
-                (Δλ,Δv)=damping(j,λ,v,Δλ,Δv,err)
+                (Δλ,Δv)=damping(k,λ,v,Δλ,Δv,err)
             end
 
 

--- a/src/method_newton.jl
+++ b/src/method_newton.jl
@@ -381,6 +381,7 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
                          ws::Vector=v,
                          logger=0,
                          linsolvercreator=DefaultLinSolverCreator(),
+                         damping=:none,
                          armijo_factor::Real=1,
                          armijo_max::Int=5) where T
 
@@ -433,6 +434,11 @@ julia> norm(compute_Mlincomb(nep,λ,v))/norm(v)
             else
                 push_info!(logger,"");
             end
+
+            if (damping isa Function)
+                (Δλ,Δv)=damping(nep,errmeasure,err,λ,v,Δλ,Δv)
+            end
+
 
             # Update eigenpair
             λ += Δλ


### PR DESCRIPTION
This PR adds the possibility to do damping in the newton-type methods. This is useful when you want further control of the convergence, e.g., if the eigenvalue jumps around too much in the beginning of the iteration, one can freeze it for a couple of iterations.

```julia
julia> dampfun(j,λ,v,Δλ,Δv,err) = if (j<5); return (0,Δv); else return ( Δλ,Δv); end
julia> nep=nep_gallery("dep0");
julia> quasinewton(nep,v=ones(size(nep,1)), damping=dampfun,logger=1)
Precomputing linsolver
iter 1 err:0.4375106183538867 λ=0.0 + 0.0im
iter 2 err:0.14086383438577224 λ=0.0 + 0.0im
iter 3 err:0.06025324283567077 λ=0.0 + 0.0im
iter 4 err:0.05571699911766034 λ=0.0 + 0.0im
iter 5 err:0.055655133041208324 λ=0.0 + 0.0im
iter 6 err:0.0030751367350047615 λ=-0.17063270853535875 + 0.0im
iter 7 err:0.0013264956740222653 λ=-0.16353325361016532 + 0.0im
iter 8 err:0.0002126793613430449 λ=-0.15893132338845364 + 0.0im
iter 9 err:5.3257050366316595e-5 λ=-0.15971790340779132 + 0.0im
iter 10 err:9.156555736375752e-6 λ=-0.1595250775062491 + 0.0im
iter 11 err:1.2799543397530632e-6 λ=-0.1595580559815855 + 0.0im
iter 12 err:1.3530594933298134e-7 λ=-0.15955346228126174 + 0.0im
iter 13 err:7.891207692630864e-9 λ=-0.15955394676086682 + 0.0im
iter 14 err:1.5407052452259348e-9 λ=-0.1595539210779778 + 0.0im
iter 15 err:5.47589872132068e-10 λ=-0.15955391677522587 + 0.0im
iter 16 err:1.188934262297173e-10 λ=-0.15955391857035742 + 0.0im
iter 17 err:2.0448347547063802e-11 λ=-0.15955391817347542 + 0.0im
iter 18 err:2.9475982087156356e-12 λ=-0.15955391824166087 + 0.0im
iter 19 err:3.5259868378990546e-13 λ=-0.15955391823196227 + 0.0im
iter 20 err:3.2228010665283885e-14 λ=-0.15955391823308038 + 0.0im
iter 21 err:2.187537380212693e-15 λ=-0.1595539182329915 + 0.0im
(-0.1595539182329915 + 0.0im, Complex{Float64}[2.5648893440094573 + 0.0im, 17.384418712127655 + 0.0im, -2.2377685530289693 + 0.0im, 0.5684397719035917 + 0.0im, 2.230412892858379 + 0.0im])

```


Not yet ready to be merged. At the moment only implemented for `quasinewton`.