### PR TITLE
Test fix for version 1.5.1

### DIFF
--- a/test/inner_solves.jl
+++ b/test/inner_solves.jl
@@ -17,8 +17,7 @@ Random.seed!(0);
     pnep=create_proj_NEP(dep);
 
     k = 5
-    Q,R=qr(randn(n,k));
-    Q = Matrix(Q)
+    temp_pep=nep_gallery("pep0",200); Q,R=qr(temp_pep.A[1][:,8:12]);  Q = Matrix(Q) # Ugly but gives stability over versions. Stable "random" projection space Q.
     set_projectmatrices!(pnep,Q,Q)
 
     logger=ErrorLogger(50,100,0);

--- a/test/jd.jl
+++ b/test/jd.jl
@@ -45,7 +45,7 @@ verify_lambdas(1, nep, λ, u, TOL)
 
 
 @info "Testing errors thrown"
-nep = nep_gallery("pep0",4)
+nep = nep_gallery("pep0",10)
 # Throw error if iterating more than the size of the NEP
 @test_throws ErrorException λ,u=jd_betcke(nep, tol=TOL, maxit=60, logger = displaylevel, v=ones(size(nep,1)))
 # SG requires Galerkin projection type to keep Hermitian
@@ -53,7 +53,7 @@ nep = nep_gallery("pep0",4)
 # An undefined projection type
 @test_throws ErrorException λ,u=jd_betcke(nep, tol=TOL, maxit=4, projtype = :MYNOTDEFINED, v=ones(size(nep,1)))
 # Too many required eigenvalues, will not converge and hence throw an exception
-@test_throws NEPCore.NoConvergenceException λ,u=jd_betcke(nep, tol=TOL, maxit=4, neigs=1000, v=ones(size(nep,1)))
+@test_throws NEPCore.NoConvergenceException λ,u=jd_betcke(nep, tol=TOL, maxit=4, λ=10.0, neigs=1000, v=ones(size(nep,1)))
 
 end
 
@@ -86,7 +86,7 @@ nep = nep_gallery("pep0",50)
 # SG not possible with Effenberger
 @test_throws ErrorException λ, u = jd_effenberger(nep, tol=TOL, maxit=40, inner_solver_method = SGIterInnerSolver(), v=ones(size(nep,1)))
 # Too many required eigenvalues, will not converge and hence throw an exception
-@test_throws NEPCore.NoConvergenceException λ, u = jd_effenberger(nep, neigs=1000, tol=TOL, maxit=20, v=ones(size(nep,1)))
+@test_throws NEPCore.NoConvergenceException λ, u = jd_effenberger(nep, neigs=1000, tol=TOL, maxit=4, v=ones(size(nep,1)), λ=10.0)
 
 end
 

--- a/test/nleigs/particle_test_utils.jl
+++ b/test/nleigs/particle_test_utils.jl
@@ -27,8 +27,7 @@ function particle_init(interval)
     Σ = [xmin + 0im, xmax + 0im]
 
     # options
-    Random.seed!(5)
-    v = randn(size(nep, 1)) .+ 0im
+    temp_pep=nep_gallery("pep0",size(nep,1)); v=complex(temp_pep.A[1][:,1]) # Ugly but gives stability over versions. Stable "random" vector v.
     nodes = range(xmin + 0im, stop = xmax + 0im, length = 11)
     nodes = collect(nodes[2:2:end])
 

--- a/test/nleigs/particle_test_utils.jl
+++ b/test/nleigs/particle_test_utils.jl
@@ -27,7 +27,7 @@ function particle_init(interval)
     Σ = [xmin + 0im, xmax + 0im]
 
     # options
-    temp_pep=nep_gallery("pep0",size(nep,1)); v=complex(temp_pep.A[1][:,1]) # Ugly but gives stability over versions. Stable "random" vector v.
+    temp_pep=nep_gallery("pep0",200); v=complex(vcat(vec(temp_pep.A[1][:,1:81]),temp_pep.A[1][1:81,82])) # Ugly but gives stability over versions. Stable "random" vector v.
     nodes = range(xmin + 0im, stop = xmax + 0im, length = 11)
     nodes = collect(nodes[2:2:end])
 

--- a/test/wep_small.jl
+++ b/test/wep_small.jl
@@ -12,6 +12,7 @@ import GalleryWaveguide.SchurMatVec
 @bench @testset "WEP" begin
 
     @bench @testset "SPMF - NEP, and Preconditioner" begin
+        @info "Compare SPFM and native format, and test Preconditioner"
         nx = 11
         nz = 7
         nep_spmf=nep_gallery(WEP, nx = nx, nz = nz, benchmark_problem = "TAUSCH", neptype = "SPMF")
@@ -62,6 +63,7 @@ import GalleryWaveguide.SchurMatVec
     end
 
     @bench @testset "NEP solvers" begin
+        @info "WEP NEP solvers"
         λ,v = quasinewton(ComplexF64,nep,logger=displaylevel,λ=λ0,v=v0,
                           errmeasure=myerrmeasure,tol=1e-12,
                           linsolvercreator=GalleryWaveguide.WEPLinSolverCreator(solver_type=:factorized)


### PR DESCRIPTION
The fixes for `Inner_solver` and `NLEIGS particle r2` are pretty uggly to say the least. However, it was the best I could come up with when "simple" deterministic vectors did not give passing tests.
One could start playing with new seed, but that felt pretty irritating since there is no guarantee that it will not change in future releases anyway. At least these initializations are stable.

I have to look further into the segfault of `wep_small ` before I am done.